### PR TITLE
use variable for self-hosted/backup image name

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -34,7 +34,7 @@ jobs:
     uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.31
     secrets: inherit
     with:
-      repo: ${{ vars.CODECOV_API_IMAGE_V2 || 'codecov/self-hosted-api' }}
+      repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
       working_directory: apps/codecov-api
 
   # Runs create-commit, create-report
@@ -55,7 +55,7 @@ jobs:
     secrets: inherit
     with:
       run_integration: false
-      repo: ${{ vars.CODECOV_API_IMAGE_V2 || 'codecov/self-hosted-api' }}
+      repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
       working_directory: apps/codecov-api
       flag_prefix: api
 
@@ -66,7 +66,7 @@ jobs:
     uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.31
     secrets: inherit
     with:
-      repo: ${{ vars.CODECOV_API_IMAGE_V2 || 'codecov/self-hosted-api' }}
+      repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
       working_directory: apps/codecov-api
 
   api-staging:
@@ -77,7 +77,7 @@ jobs:
     secrets: inherit
     with:
       environment: staging
-      repo: ${{ vars.CODECOV_API_IMAGE_V2 || 'codecov/self-hosted-api' }}
+      repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
       working_directory: apps/codecov-api
       sentry_project: api
 
@@ -89,7 +89,7 @@ jobs:
     secrets: inherit
     with:
       environment: production
-      repo: ${{ vars.CODECOV_API_IMAGE_V2 || 'codecov/self-hosted-api' }}
+      repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
       working_directory: apps/codecov-api
       sentry_project: api
 
@@ -101,7 +101,7 @@ jobs:
     uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.31
     with:
       push_rolling: true
-      repo: ${{ vars.CODECOV_API_IMAGE_V2 || 'codecov/self-hosted-api' }}
+      repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
       working_directory: apps/codecov-api
 
   # This job works around a strange interaction between reusable workflows and

--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -1,4 +1,4 @@
-iname: Create Self Hosted Release
+name: Create Self Hosted Release
 
 on:
   pull_request:
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       push_release: true
-      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || 'codecov/self-hosted-worker' }}
+      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
       working_directory: apps/worker
 
   push-api-image:
@@ -36,5 +36,5 @@ jobs:
     secrets: inherit
     with:
       push_release: true
-      repo: ${{ vars.CODECOV_API_IMAGE_V2 || 'codecov/self-hosted-api' }}
+      repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
       working_directory: apps/codecov-api

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -34,7 +34,7 @@ jobs:
     uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.31
     secrets: inherit
     with:
-      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || 'codecov/self-hosted-worker' }}
+      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
       working_directory: apps/worker
 
   # Runs create-commit, create-report
@@ -54,7 +54,7 @@ jobs:
     uses: codecov/gha-workflows/.github/workflows/run-tests.yml@pr45
     secrets: inherit
     with:
-      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || 'codecov/self-hosted-worker' }}
+      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
       working_directory: apps/worker
       flag_prefix: worker
 
@@ -65,7 +65,7 @@ jobs:
     uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.31
     secrets: inherit
     with:
-      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || 'codecov/self-hosted-worker' }}
+      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
       working_directory: apps/worker
 
   worker-staging:
@@ -76,7 +76,7 @@ jobs:
     secrets: inherit
     with:
       environment: staging
-      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || 'codecov/self-hosted-worker' }}
+      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
       working_directory: apps/worker
       sentry_project: worker
 
@@ -88,7 +88,7 @@ jobs:
     secrets: inherit
     with:
       environment: production
-      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || 'codecov/self-hosted-worker' }}
+      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
       working_directory: apps/worker
       sentry_project: worker
 
@@ -100,7 +100,7 @@ jobs:
     uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.31
     with:
       push_rolling: true
-      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || 'codecov/self-hosted-worker' }}
+      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
       working_directory: apps/worker
 
   # This job works around a strange interaction between reusable workflows and


### PR DESCRIPTION
we want to use unique names for prod/self-hosted images while testing out umbrella. use repo vars for both

currently they are set to `...worker-umbrella`, `...api-umbrella`, etc