### PR TITLE
ci: make each project's ci's path filters track its ci workflow

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -48,14 +48,17 @@ jobs:
               - 'apps/worker/**'
               - 'libs/shared'
               - 'libs/shared/**'
+              - '.github/workflows/worker-ci.yml'
             codecov-api:
               - 'apps/codecov-api'
               - 'apps/codecov-api/**'
               - 'libs/shared'
               - 'libs/shared/**'
+              - '.github/workflows/api-ci.yml'
             shared:
               - 'libs/shared'
               - 'libs/shared/**'
+              - '.github/workflows/shared-ci.yml'
 
   api-ci:
     name: API CI


### PR DESCRIPTION
if you change worker ci it should probably run worker ci, etc