### PR TITLE
fix: update self-hosted-release workflow

### DIFF
--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -19,22 +19,44 @@ jobs:
       tag_to_prepend: self-hosted-
     secrets: inherit
 
+  # Once we cut over to umbrella, we can just replace the default cache key in build-app.yml
+  # and self-hosted.yml and get rid of this step.
+  compute-reqs-cache-keys:
+    name: Compute cache keys for requirements images
+    runs-on: ubuntu-latest
+    outputs:
+      api-reqs-cache-key: ${{ steps.compute.outputs.api-cache-key }}
+      worker-reqs-cache-key: ${{ steps.compute.outputs.worker-cache-key }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - id: compute
+        run: |
+          echo api-cache-key=${{ hashFiles('apps/codecov-api/uv.lock') }}-${{ hashFiles('docker/Dockerfile.requirements') }}-${{ hashFiles('libs/shared/**') }} >> "$GITHUB_OUTPUT"
+          echo worker-cache-key=${{ hashFiles('apps/worker/uv.lock') }}-${{ hashFiles('docker/Dockerfile.requirements') }}-${{ hashFiles('libs/shared/**') }} >> "$GITHUB_OUTPUT"
+
   push-worker-image:
     needs: [create-release]
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.31
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.36
     secrets: inherit
     with:
       push_release: true
       repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
-      working_directory: apps/worker
+      output_directory: apps/worker
+      make_target_prefix: worker.
+      reqs_cache_key: ${{ needs.worker-compute-reqs-cache-key.outputs.worker-reqs-cache-key }}
 
   push-api-image:
     needs: [create-release]
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.31
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.36
     secrets: inherit
     with:
       push_release: true
       repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
-      working_directory: apps/codecov-api
+      output_directory: apps/codecov-api
+      make_target_prefix: api.
+      reqs_cache_key: ${{ needs.api-compute-reqs-cache-key.outputs.api-reqs-cache-key }}


### PR DESCRIPTION
https://github.com/codecov/umbrella/actions/runs/14450746409/job/40526301074

the self-hosted workflow was not updated in https://github.com/codecov/umbrella/pull/30 like it should have been