### PR TITLE
add workflows that hooky will watch to trigger deployments

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -83,3 +83,15 @@ jobs:
     secrets: inherit
     with:
       skip: ${{ needs.change-detection.outputs.shared == 'false' }}
+
+  trigger-worker-deploy:
+    name: Trigger worker deployment
+    needs: [change-detection, worker-ci]
+    if: ${{ github.event_name == 'push' && needs.change-detection.outputs.worker == 'true' }}
+    uses: ./.github/workflows/trigger-worker-deploy.yml
+
+  trigger-api-deploy:
+    name: Trigger codecov-api deployment
+    needs: [change-detection, api-ci]
+    if: ${{ github.event_name == 'push' && needs.change-detection.outputs.codecov-api == 'true' }}
+    uses: ./.github/workflows/trigger-api-deploy.yml

--- a/.github/workflows/trigger-api-deploy.yml
+++ b/.github/workflows/trigger-api-deploy.yml
@@ -1,0 +1,15 @@
+name: Trigger API deployment
+
+# This is a dummy workflow that Hooky will watch for in order to trigger
+# codecov-api deployments.
+
+on:
+  workflow_call:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Succeed
+        run: exit 0
+

--- a/.github/workflows/trigger-worker-deploy.yml
+++ b/.github/workflows/trigger-worker-deploy.yml
@@ -1,0 +1,14 @@
+name: Trigger worker deployment
+
+# This is a dummy workflow that Hooky will watch for in order to trigger
+# worker deployments.
+
+on:
+  workflow_call:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Succeed
+        run: exit 0


### PR DESCRIPTION
we need a way for Hooky to deploy only worker for a change that affects only worker. apparently we use a dummy trigger workflow with Hooky to [trigger preview deployments of Gazebo](https://github.com/codecov/gazebo/blob/main/.github/workflows/trigger-gazebo-preview.yml). this PR uses the same approach

if the current event is a push, and the change detector said worker has changed (meaning, `apps/worker` or `libs/shared` have changed), it'll run the `trigger-worker-deployment.yml` workflow. same story with API