### PR TITLE
disable noisy mypy ci workflows

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -21,12 +21,13 @@ jobs:
     with:
       make_target_prefix: api.
 
-  api-mypy:
-    name: Patch typing (API)
-    if: ${{ inputs.skip == false }}
-    uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.31
-    with:
-      working_directory: apps/codecov-api
+  # TODO: Enable after we actually get this passing. It's just noise until then.
+  # api-mypy:
+  #   name: Patch typing (API)
+  #   if: ${{ inputs.skip == false }}
+  #   uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.31
+  #   with:
+  #     working_directory: apps/codecov-api
 
   # Once we cut over to umbrella, we can just replace the default cache key in build-app.yml
   # and self-hosted.yml and get rid of this step.

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -8,7 +8,7 @@ on:
         default: false
 
 jobs:
-  # TODO: get mypy running
+  # TODO: Get mypy passing and running. Don't enable if not passing
   shared-lint:
     name: Run Lint (Shared)
     if: ${{ inputs.skip == false }}

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -21,12 +21,13 @@ jobs:
     with:
       make_target_prefix: worker.
 
-  worker-mypy:
-    name: Patch typing (Worker)
-    if: ${{ inputs.skip == false }}
-    uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.31
-    with:
-      working_directory: apps/worker
+  # TODO: Enable after we actually get this passing. It's just noise until then.
+  # worker-mypy:
+  #   name: Patch typing (Worker)
+  #   if: ${{ inputs.skip == false }}
+  #   uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.31
+  #   with:
+  #     working_directory: apps/worker
 
   # Once we cut over to umbrella, we can just replace the default cache key in build-app.yml
   # and self-hosted.yml and get rid of this step.


### PR DESCRIPTION
apparently this workflow erroring causes problems for hooky. disabling it because we have not invested at all in mypy types since enabling and they are just noisy