### PR TITLE
move deploy trigger jobs into their respective .yml workflows

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -6,6 +6,9 @@ on:
       skip:
         type: boolean
         default: false
+      event_name:
+        type: string
+        required: false
 
 permissions:
   contents: "read"
@@ -32,6 +35,7 @@ jobs:
   # and self-hosted.yml and get rid of this step.
   api-compute-reqs-cache-key:
     name: Compute cache key for requirements image
+    if: ${{ inputs.skip == false }}
     runs-on: ubuntu-latest
     outputs:
       reqs-cache-key: ${{ steps.compute.outputs.cache-key }}
@@ -145,3 +149,9 @@ jobs:
       - name: Fail tests
         if: ${{ needs.api-test.outputs.tests_passed == 'failure' }}
         run: exit 1
+
+  trigger-api-deploy:
+    name: Trigger codecov-api deployment
+    needs: [api-required-checks, api-production]
+    if: ${{ !cancelled() && inputs.event_name == 'push' && inputs.skip == false }}
+    uses: ./.github/workflows/trigger-api-deploy.yml

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -67,6 +67,7 @@ jobs:
     secrets: inherit
     with:
       skip: ${{ needs.change-detection.outputs.codecov-api == 'false' }}
+      event_name: ${{ github.event_name }}
 
   worker-ci:
     name: Worker CI
@@ -75,6 +76,7 @@ jobs:
     secrets: inherit
     with:
       skip: ${{ needs.change-detection.outputs.worker == 'false' }}
+      event_name: ${{ github.event_name }}
 
   shared-ci:
     name: Shared CI
@@ -83,15 +85,4 @@ jobs:
     secrets: inherit
     with:
       skip: ${{ needs.change-detection.outputs.shared == 'false' }}
-
-  trigger-worker-deploy:
-    name: Trigger worker deployment
-    needs: [change-detection, worker-ci]
-    if: ${{ github.event_name == 'push' && needs.change-detection.outputs.worker == 'true' }}
-    uses: ./.github/workflows/trigger-worker-deploy.yml
-
-  trigger-api-deploy:
-    name: Trigger codecov-api deployment
-    needs: [change-detection, api-ci]
-    if: ${{ github.event_name == 'push' && needs.change-detection.outputs.codecov-api == 'true' }}
-    uses: ./.github/workflows/trigger-api-deploy.yml
+      event_name: ${{ github.event_name }}

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -6,6 +6,9 @@ on:
       skip:
         type: boolean
         default: false
+      event_name:
+        type: string
+        required: false
 
 jobs:
   # TODO: get mypy running

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -6,6 +6,9 @@ on:
       skip:
         type: boolean
         default: false
+      event_name:
+        type: string
+        required: false
 
 permissions:
   contents: "read"
@@ -32,6 +35,7 @@ jobs:
   # and self-hosted.yml and get rid of this step.
   worker-compute-reqs-cache-key:
     name: Compute cache key for requirements image
+    if: ${{ inputs.skip == false }}
     runs-on: ubuntu-latest
     outputs:
       reqs-cache-key: ${{ steps.compute.outputs.cache-key }}
@@ -144,3 +148,9 @@ jobs:
       - name: Fail tests
         if: ${{ needs.worker-test.outputs.tests_passed == 'failure' }}
         run: exit 1
+
+  trigger-worker-deploy:
+    name: Trigger worker deployment
+    needs: [worker-required-checks, worker-production]
+    if: ${{ !cancelled() && inputs.event_name == 'push' && inputs.skip == false }}
+    uses: ./.github/workflows/trigger-worker-deploy.yml


### PR DESCRIPTION
this may allow us to work around the issue hooky has with the perma-failing mypy checks that i disabled in https://github.com/codecov/umbrella/pull/46

i am still disabling mypy because it's noisy