### PR TITLE
chore: change which host ports are used by devenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ make devenv.upload.shared
 ```
 
 ### Extras
-- You can browse your local MinIO (archive service) at http://localhost:9000/ with the username `codecov-default-key` and password `codecov-default-secret`
-- You can browse your local Redis by pointing the [Redis CLI](https://redis.io/docs/latest/develop/tools/cli/) or [Redis Insight GUI](https://redis.io/insight/) at 127.0.0.1:6379
-- You can browse your local Postgres database with the connection string `postgres://postgres@localhost:5432/postgres` in your preferred database browser
+- You can browse your local MinIO (archive service) at http://localhost:9001/ with the username `codecov-default-key` and password `codecov-default-secret`
+- You can browse your local Redis by pointing the [Redis CLI](https://redis.io/docs/latest/develop/tools/cli/) or [Redis Insight GUI](https://redis.io/insight/) at 127.0.0.1:6380
+- You can browse your local Postgres database with the connection string `postgres://postgres@localhost:5434/postgres` in your preferred database browser
 - You can browse your local Timescale database with the connection string `postgres://postgres@localhost:5433/postgres` in your preferred database browser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
   redis:
     image: redis:6.2-alpine
     ports:
-      - "6379:6379"
+      - "6380:6379"
     volumes:
       - redis-volume:/data
     networks:
@@ -108,7 +108,7 @@ services:
     volumes:
       - postgres-volume:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "5434:5432"
     networks:
       - codecov
 
@@ -127,7 +127,7 @@ services:
     image: minio/minio:latest
     command: server /export
     ports:
-      - "${CODECOV_MINIO_PORT-9000}:9000"
+      - "${CODECOV_MINIO_PORT-9001}:9000"
     environment:
       - MINIO_ACCESS_KEY=codecov-default-key
       - MINIO_SECRET_KEY=codecov-default-secret


### PR DESCRIPTION
Sentry's devenv's postgres, redis, and clickhouse bind to host ports `5432`, `6379`, and `9000` respectively. these bindings conflict with umbrella's devenv's postgres, redis, and minio respectively. it's easier to change what we bind to, so this PR does that

ports inside the codecov docker network don't need to be changed, and thus neither do `codecov.yml` or any django settings. this is just necessary for the development environments not to fight if we run them simultaneously