### PR TITLE
add devenv.migrate make target to perform db migrations safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ From the repository root:
 # Build `umbrella` containers, pull other containers, start docker compose
 $ make devenv
 
+# Run migrations
+$ make devenv.migrate
+
 # Rebuild and restart `umbrella` containers. Necessary if dependencies change.
 # Run this after pulling if you haven't pulled in a while.
 $ make devenv.refresh

--- a/tools/devenv/Makefile.devenv
+++ b/tools/devenv/Makefile.devenv
@@ -29,12 +29,20 @@ devenv.start: devenv.start.deps devenv.start.backend
 .PHONY: devenv
 devenv:
 	$(MAKE) devenv.build
+	$(MAKE) devenv.migrate
 	$(MAKE) devenv.start
 
 .PHONY: devenv.refresh
 devenv.refresh:
 	$(MAKE) devenv.build
+	$(MAKE) devenv.migrate
 	$(MAKE) devenv.start.backend
+
+.PHONY: devenv.migrate
+devenv.migrate:
+	$(MAKE) devenv.start.deps
+	docker compose run --entrypoint python api manage.py migrate
+	docker compose run --entrypoint python worker manage.py migrate
 
 .PHONY: devenv.stop
 devenv.stop:


### PR DESCRIPTION
if the `worker` and `api` docker compose services are started at the same time, they will both stumble over each other when trying to run migrations and that can lead to a broken database state. this PR adds a safe `devenv.migrate` target which will migrate API and then migrate worker, and it calls this inside `make devenv` and `make devenv.refresh` before attempting to start the services