### PR TITLE
Clean up some `report_code` usage

### DIFF
--- a/apps/codecov-api/services/bundle_analysis.py
+++ b/apps/codecov-api/services/bundle_analysis.py
@@ -35,14 +35,11 @@ from timeseries.models import Interval, MeasurementName
 
 
 @sentry_sdk.trace
-def load_report(
-    commit: Commit, report_code: Optional[str] = None
-) -> Optional[SharedBundleAnalysisReport]:
+def load_report(commit: Commit) -> SharedBundleAnalysisReport | None:
     storage = get_appropriate_storage_service(commit.repository.repoid)
 
     commit_report = commit.reports.filter(
-        report_type=CommitReport.ReportType.BUNDLE_ANALYSIS,
-        code=report_code,
+        report_type=CommitReport.ReportType.BUNDLE_ANALYSIS, code=None
     ).first()
     if commit_report is None:
         return None

--- a/apps/codecov-api/upload/views/bundle_analysis.py
+++ b/apps/codecov-api/upload/views/bundle_analysis.py
@@ -184,9 +184,9 @@ class BundleAnalysisView(APIView, ShelterMixin):
         )
 
         dispatch_upload_task(
-            task_arguments,
-            repo,
             get_redis_connection(),
+            repo.repoid,
+            task_arguments,
             report_type=CommitReport.ReportType.BUNDLE_ANALYSIS,
         )
 

--- a/apps/codecov-api/upload/views/legacy.py
+++ b/apps/codecov-api/upload/views/legacy.py
@@ -341,7 +341,7 @@ class UploadHandler(APIView, ShelterMixin):
         )
 
         # Send task to worker
-        dispatch_upload_task(task_arguments, repository, redis)
+        dispatch_upload_task(redis, repository.repoid, task_arguments)
 
         # Analytics Tracking
         analytics_upload_data = upload_params.copy()

--- a/apps/codecov-api/upload/views/test_results.py
+++ b/apps/codecov-api/upload/views/test_results.py
@@ -196,9 +196,9 @@ class TestResultsView(
         )
 
         dispatch_upload_task(
-            task_arguments,
-            repo,
             get_redis_connection(),
+            repo.repoid,
+            task_arguments,
             report_type=CommitReport.ReportType.TEST_RESULTS,
         )
 

--- a/apps/codecov-api/upload/views/uploads.py
+++ b/apps/codecov-api/upload/views/uploads.py
@@ -130,7 +130,7 @@ def trigger_upload_task(
         "report_code": report.code,
         "reportid": str(report.external_id),
     }
-    dispatch_upload_task(task_arguments, repository, redis)
+    dispatch_upload_task(redis, repository.repoid, task_arguments)
 
 
 def activate_repo(repository: Repository) -> None:

--- a/apps/worker/tasks/tests/integration/test_upload_e2e.py
+++ b/apps/worker/tasks/tests/integration/test_upload_e2e.py
@@ -292,7 +292,7 @@ end_of_record
     assert len(archive) == 2 + 4 + 3
 
     report_service = ReportService(UserYaml({}))
-    report = report_service.get_existing_report_for_commit(commit, report_code=None)
+    report = report_service.get_existing_report_for_commit(commit)
 
     assert report
     assert set(report.files) == {"a.rs", "b.rs"}
@@ -333,7 +333,7 @@ end_of_record
             }
         )
 
-    report = report_service.get_existing_report_for_commit(commit, report_code=None)
+    report = report_service.get_existing_report_for_commit(commit)
 
     assert report
     assert set(report.files) == {"a.rs", "b.rs", "c.rs"}
@@ -460,9 +460,7 @@ end_of_record
         )
 
     report_service = ReportService(UserYaml({}))
-    report = report_service.get_existing_report_for_commit(
-        base_commit, report_code=None
-    )
+    report = report_service.get_existing_report_for_commit(base_commit)
     assert report
 
     base_sessions = report.sessions
@@ -535,7 +533,7 @@ end_of_record
         )
 
     # with only one upload being processed so far, we still expect all "b" sessions to still exist
-    report = report_service.get_existing_report_for_commit(commit, report_code=None)
+    report = report_service.get_existing_report_for_commit(commit)
 
     assert report
     assert set(report.files) == {"a.rs", "b.rs"}
@@ -589,7 +587,7 @@ end_of_record
                 "commitid": commitid,
             }
         )
-    report = report_service.get_existing_report_for_commit(commit, report_code=None)
+    report = report_service.get_existing_report_for_commit(commit)
 
     assert report
     assert set(report.files) == {"a.rs", "b.rs"}

--- a/apps/worker/tasks/tests/unit/test_preprocess_upload.py
+++ b/apps/worker/tasks/tests/unit/test_preprocess_upload.py
@@ -106,7 +106,6 @@ class TestPreProcessUpload(object):
             dbsession,
             repoid=commit.repository.repoid,
             commitid=commit.commitid,
-            report_code=None,
         )
         assert result == {"preprocessed_upload": False, "reason": "already_running"}
 
@@ -120,7 +119,6 @@ class TestPreProcessUpload(object):
             dbsession,
             repoid=commit.repository.repoid,
             commitid=commit.commitid,
-            report_code=None,
         )
         assert result == {
             "preprocessed_upload": False,

--- a/apps/worker/tasks/tests/unit/test_upload_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_task.py
@@ -423,7 +423,6 @@ class TestUploadTaskIntegration(object):
                     "upload_pk": upload.id,
                 }
             ],
-            report_code=None,
             impl_type="old",
         )
         kwargs = dict(
@@ -534,7 +533,6 @@ class TestUploadTaskIntegration(object):
                     "upload_pk": upload.id,
                 }
             ],
-            report_code=None,
             impl_type="both",
         )
         kwargs = dict(

--- a/apps/worker/tasks/upload.py
+++ b/apps/worker/tasks/upload.py
@@ -782,7 +782,6 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 commitid=commit.commitid,
                 commit_yaml=commit_yaml,
                 arguments_list=list(chunk),
-                report_code=commit_report.code,
                 impl_type=new_ta_tasks,
             )
             for chunk in itertools.batched(argument_list, CHUNK_SIZE)


### PR DESCRIPTION
This removes some `report_code` usage where it is not being used.

It also simplifies the `disptach_upload_task` fn a bit, which I just couldn’t resist :-D