### PR TITLE
Switch some `transactional_db` fixtures to `db`

### DIFF
--- a/apps/codecov-api/codecov_auth/tests/test_admin.py
+++ b/apps/codecov-api/codecov_auth/tests/test_admin.py
@@ -515,7 +515,7 @@ def create_stale_users(
     return ([org_1, org_2], [user_1, user_2, user_3, user_4, user_5])
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_stale_user_cleanup():
     orgs, users = create_stale_users()
 

--- a/apps/codecov-api/upload/tests/test_serializers.py
+++ b/apps/codecov-api/upload/tests/test_serializers.py
@@ -42,7 +42,7 @@ def get_fake_upload_with_flags():
     return upload
 
 
-def test_serialize_upload(transactional_db, mocker):
+def test_serialize_upload(db, mocker):
     mocker.patch(
         "shared.storage.MinioStorageService.create_presigned_put",
         return_value="presigned put",
@@ -59,7 +59,7 @@ def test_serialize_upload(transactional_db, mocker):
     assert fake_upload.name == "upload name...?"
 
 
-def test_upload_serializer_contains_expected_fields_no_flags(transactional_db, mocker):
+def test_upload_serializer_contains_expected_fields_no_flags(db, mocker):
     mocker.patch(
         "shared.storage.MinioStorageService.create_presigned_put",
         return_value="presigned put",
@@ -84,9 +84,7 @@ def test_upload_serializer_contains_expected_fields_no_flags(transactional_db, m
     assert serializer.data == expected_data
 
 
-def test_upload_serializer_contains_expected_fields_with_flags(
-    transactional_db, mocker
-):
+def test_upload_serializer_contains_expected_fields_with_flags(db, mocker):
     mocker.patch(
         "shared.storage.MinioStorageService.create_presigned_put",
         return_value="presigned put",
@@ -111,7 +109,7 @@ def test_upload_serializer_contains_expected_fields_with_flags(
     assert serializer.data == expected_data
 
 
-def test_upload_serializer_null_build_url_empty_flags(transactional_db, mocker):
+def test_upload_serializer_null_build_url_empty_flags(db, mocker):
     mocker.patch(
         "shared.storage.MinioStorageService.create_presigned_put",
         return_value="presigned put",
@@ -128,7 +126,7 @@ def test_upload_serializer_null_build_url_empty_flags(transactional_db, mocker):
     assert serializer.is_valid()
 
 
-def test__create_existing_flags_map(transactional_db, mocker):
+def test__create_existing_flags_map(db, mocker):
     mocker.patch(
         "shared.storage.MinioStorageService.create_presigned_put",
         return_value="presigned put",
@@ -147,7 +145,7 @@ def test__create_existing_flags_map(transactional_db, mocker):
     }
 
 
-def test_commit_serializer_contains_expected_fields(transactional_db, mocker):
+def test_commit_serializer_contains_expected_fields(db):
     commit = CommitFactory.create()
     serializer = CommitSerializer(commit)
     expected_data = {
@@ -177,7 +175,7 @@ def test_commit_serializer_contains_expected_fields(transactional_db, mocker):
     assert serializer.data == expected_data
 
 
-def test_commit_serializer_does_not_duplicate(transactional_db, mocker):
+def test_commit_serializer_does_not_duplicate(db):
     mock_all_plans_and_tiers()
     repository = RepositoryFactory()
     serializer = CommitSerializer()
@@ -205,7 +203,7 @@ def test_commit_serializer_does_not_duplicate(transactional_db, mocker):
     assert saved_commit1 == saved_commit2
 
 
-def test_invalid_update_data(transactional_db, mocker):
+def test_invalid_update_data(db):
     commit = CommitFactory.create()
     new_data = {"pullid": "1"}
     serializer = CommitSerializer(commit, new_data)
@@ -215,7 +213,7 @@ def test_invalid_update_data(transactional_db, mocker):
     }
 
 
-def test_valid_update_data(transactional_db, mocker):
+def test_valid_update_data(db):
     commit = CommitFactory.create(pullid=1)
     new_data = {"pullid": "20", "commitid": "abc"}
     serializer = CommitSerializer(commit)
@@ -225,7 +223,7 @@ def test_valid_update_data(transactional_db, mocker):
     assert commit == res
 
 
-def test_commit_report_serializer(transactional_db, mocker):
+def test_commit_report_serializer(db):
     report = CommitReportFactory.create()
     serializer = CommitReportSerializer(report)
     expected_data = {

--- a/apps/worker/services/report/tests/unit/test_transplant.py
+++ b/apps/worker/services/report/tests/unit/test_transplant.py
@@ -10,7 +10,7 @@ from shared.django_apps.reports.models import ReportLevelTotals
 from services.report.transplant import transplant_commit_report
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_transplanting_commit(mock_storage):
     repo = RepositoryFactory()
     commit_from = CommitWithReportFactory(repository=repo)

--- a/apps/worker/services/test_analytics/ta_process_flakes.py
+++ b/apps/worker/services/test_analytics/ta_process_flakes.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime
 
-from django.db import transaction
 from django.db.models import Q, QuerySet
 from redis.exceptions import LockError
 from shared.django_apps.reports.models import CommitReport, ReportSession
@@ -103,8 +102,6 @@ def process_flakes_for_commit(repo_id: int, commit_id: str):
         unique_fields=["id"],
         update_fields=["end_date", "count", "recent_passes_count", "fail_count"],
     )
-
-    transaction.commit()
 
 
 def process_flakes_for_repo(repo_id: int):

--- a/apps/worker/services/test_analytics/tests/test_ta_process_flakes.py
+++ b/apps/worker/services/test_analytics/tests/test_ta_process_flakes.py
@@ -38,9 +38,7 @@ class SetupResult(TypedDict):
     commitid: str
 
 
-pytestmark = pytest.mark.django_db(
-    databases=["default", "ta_timeseries"], transaction=True
-)
+pytestmark = pytest.mark.django_db(databases=["default", "ta_timeseries"])
 
 
 @pytest.fixture

--- a/apps/worker/services/test_analytics/tests/test_ta_processor.py
+++ b/apps/worker/services/test_analytics/tests/test_ta_processor.py
@@ -61,7 +61,7 @@ def test_ta_processor_impl_already_processed(update_state):
     assert result is False
 
 
-@pytest.mark.django_db(databases=["default", "timeseries"])
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
 def test_ta_processor_impl_no_storage_path(storage):
     repository = RepositoryFactory.create()
     commit = CommitFactory.create(repository=repository, branch="main")

--- a/apps/worker/services/tests/test_report.py
+++ b/apps/worker/services/tests/test_report.py
@@ -3362,9 +3362,9 @@ class TestReportService(BaseTestCase):
         assert r is not None
         assert len(mock_storage.storage["archive"]) == 0
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_initialize_and_save_report_carryforward_needed(
-        self, dbsession, sample_commit_with_report_big, mocker, mock_storage
+        self, dbsession, sample_commit_with_report_big, mock_storage
     ):
         parent_commit = sample_commit_with_report_big
         commit = CommitFactory.create(
@@ -3423,7 +3423,7 @@ class TestReportService(BaseTestCase):
         }
         assert second_upload.upload_type == "carriedforward"
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_initialize_and_save_report_report_but_no_details_carryforward_needed(
         self, dbsession, sample_commit_with_report_big, mock_storage
     ):

--- a/apps/worker/tasks/tests/integration/test_upload_e2e.py
+++ b/apps/worker/tasks/tests/integration/test_upload_e2e.py
@@ -164,7 +164,7 @@ def setup_mocks(
 
 
 @pytest.mark.integration
-@pytest.mark.django_db(databases={"default"}, transaction=True)
+@pytest.mark.django_db
 def test_full_upload(
     dbsession: DbSession,
     mocker,
@@ -371,7 +371,7 @@ end_of_record
 
 
 @pytest.mark.integration
-@pytest.mark.django_db(databases={"default"}, transaction=True)
+@pytest.mark.django_db
 def test_full_carryforward(
     dbsession: DbSession,
     mocker,

--- a/apps/worker/tasks/tests/unit/test_base.py
+++ b/apps/worker/tasks/tests/unit/test_base.py
@@ -554,7 +554,7 @@ class TestBaseCodecovTaskApplyAsyncOverride(object):
         )
 
     @pytest.mark.freeze_time("2023-06-13T10:01:01.000123")
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_real_example_no_override(
         self, mocker, dbsession, mock_configuration, fake_repos
     ):
@@ -601,7 +601,7 @@ class TestBaseCodecovTaskApplyAsyncOverride(object):
         )
 
     @pytest.mark.freeze_time("2023-06-13T10:01:01.000123")
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_real_example_override_from_celery(
         self, mocker, dbsession, mock_configuration, fake_repos
     ):
@@ -648,7 +648,7 @@ class TestBaseCodecovTaskApplyAsyncOverride(object):
         )
 
     @pytest.mark.freeze_time("2023-06-13T10:01:01.000123")
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_real_example_override_from_upload(
         self, mocker, dbsession, mock_configuration, fake_repos
     ):

--- a/apps/worker/tasks/tests/unit/test_cache_rollup_cron_task.py
+++ b/apps/worker/tasks/tests/unit/test_cache_rollup_cron_task.py
@@ -7,7 +7,7 @@ from tasks.cache_rollup_cron_task import CacheRollupTask
 from tasks.cache_test_rollups import cache_test_rollups_task_name
 
 
-def test_cache_rollup_cron_task(mock_storage, transactional_db, mocker):
+def test_cache_rollup_cron_task(mock_storage, db, mocker):
     mocked_app = mocker.patch.object(
         CacheRollupTask,
         "app",
@@ -31,7 +31,7 @@ def test_cache_rollup_cron_task(mock_storage, transactional_db, mocker):
     )
 
 
-def test_cache_rollup_cron_task_delete(mock_storage, transactional_db, mocker):
+def test_cache_rollup_cron_task_delete(mock_storage, db, mocker):
     mocked_app = mocker.patch.object(
         CacheRollupTask,
         "app",

--- a/apps/worker/tasks/tests/unit/test_cache_test_rollups.py
+++ b/apps/worker/tasks/tests/unit/test_cache_test_rollups.py
@@ -21,7 +21,7 @@ def read_table(mock_storage, storage_path: str):
 
 
 @freeze_time()
-def test_cache_test_rollups(mock_storage, transactional_db):
+def test_cache_test_rollups(mock_storage, db):
     repo = RepositoryFactory()
     flag = RepositoryFlagFactory(
         repository=repo,
@@ -178,7 +178,7 @@ def test_cache_test_rollups(mock_storage, transactional_db):
 
 
 @freeze_time()
-def test_cache_test_rollups_no_update_date(mock_storage, transactional_db):
+def test_cache_test_rollups_no_update_date(mock_storage, db):
     repo = RepositoryFactory()
     rollup_date = LastCacheRollupDateFactory(
         repository=repo,
@@ -200,7 +200,7 @@ def test_cache_test_rollups_no_update_date(mock_storage, transactional_db):
 
 
 @freeze_time()
-def test_cache_test_rollups_update_date(mock_storage, transactional_db):
+def test_cache_test_rollups_update_date(mock_storage, db):
     repo = RepositoryFactory()
 
     rollup_date = LastCacheRollupDateFactory(
@@ -240,7 +240,7 @@ def test_cache_test_rollups_update_date_does_not_exist(mock_storage, db):
 
 
 @freeze_time()
-def test_cache_test_rollups_both(mock_storage, transactional_db, mocker):
+def test_cache_test_rollups_both(mock_storage, db, mocker):
     mock_cache_rollups = mocker.patch("tasks.cache_test_rollups.cache_rollups")
     task = CacheTestRollupsTask()
     mocker.patch.object(task, "run_impl_within_lock")

--- a/apps/worker/tasks/tests/unit/test_cache_test_rollups_redis.py
+++ b/apps/worker/tasks/tests/unit/test_cache_test_rollups_redis.py
@@ -1,4 +1,3 @@
-import polars as pl
 import shared.storage
 from shared.django_apps.core.tests.factories import RepositoryFactory
 from shared.helpers.redis import get_redis_connection
@@ -7,28 +6,23 @@ from shared.storage.exceptions import BucketAlreadyExistsError
 from tasks.cache_test_rollups_redis import CacheTestRollupsRedisTask
 
 
-class TestCacheTestRollupsTask:
-    def read_table(self, mock_storage, storage_path: str):
-        decompressed_table: bytes = mock_storage.read_file("archive", storage_path)
-        return pl.read_ipc(decompressed_table)
+def test_cache_test_rollups(mock_storage, db):
+    repo = RepositoryFactory()
 
-    def test_cache_test_rollups(self, mock_storage, transactional_db):
-        repo = RepositoryFactory()
+    redis = get_redis_connection()
+    storage_service = shared.storage.get_appropriate_storage_service(repo.repoid)
+    storage_key = f"test_results/rollups/{repo.repoid}/main/1"
+    try:
+        storage_service.create_root_storage("archive")
+    except BucketAlreadyExistsError:
+        pass
 
-        redis = get_redis_connection()
-        storage_service = shared.storage.get_appropriate_storage_service(repo.repoid)
-        storage_key = f"test_results/rollups/{repo.repoid}/main/1"
-        try:
-            storage_service.create_root_storage("archive")
-        except BucketAlreadyExistsError:
-            pass
+    storage_service.write_file("archive", storage_key, b"hello world")
 
-        storage_service.write_file("archive", storage_key, b"hello world")
+    task = CacheTestRollupsRedisTask()
+    result = task.run_impl(_db_session=None, repoid=repo.repoid, branch="main")
+    assert result == {"success": True}
 
-        task = CacheTestRollupsRedisTask()
-        result = task.run_impl(_db_session=None, repoid=repo.repoid, branch="main")
-        assert result == {"success": True}
+    redis_key = f"ta_roll:{repo.repoid}:main:1"
 
-        redis_key = f"ta_roll:{repo.repoid}:main:1"
-
-        assert redis.get(redis_key) == storage_service.read_file("archive", storage_key)
+    assert redis.get(redis_key) == storage_service.read_file("archive", storage_key)

--- a/apps/worker/tasks/tests/unit/test_delete_owner.py
+++ b/apps/worker/tasks/tests/unit/test_delete_owner.py
@@ -31,7 +31,7 @@ from tasks.delete_owner import DeleteOwnerTask
 here = Path(__file__)
 
 
-@pytest.mark.django_db(databases=["timeseries", "default"], transaction=True)
+@pytest.mark.django_db(databases=["timeseries", "default"])
 def test_delete_owner_deletes_owner_with_ownerid(mock_storage):
     user = OwnerFactory()
     repo = RepositoryFactory(author=user)
@@ -58,7 +58,7 @@ def test_delete_owner_deletes_owner_with_ownerid(mock_storage):
     assert Repository.objects.count() == 0
 
 
-@pytest.mark.django_db(databases=["timeseries", "default"], transaction=True)
+@pytest.mark.django_db(databases=["timeseries", "default"])
 def test_delete_owner_deletes_owner_with_commit_compares(mock_storage):
     user = OwnerFactory()
     repo = RepositoryFactory(author=user)
@@ -113,7 +113,7 @@ def test_delete_owner_deletes_owner_with_commit_compares(mock_storage):
     assert DailyTestRollup.objects.count() == 0
 
 
-@pytest.mark.django_db(databases=["timeseries", "default"], transaction=True)
+@pytest.mark.django_db(databases=["timeseries", "default"])
 def test_delete_owner_from_orgs_removes_ownerid_from_organizations_of_related_owners(
     mock_storage,
 ):

--- a/apps/worker/tasks/tests/unit/test_flare_cleanup.py
+++ b/apps/worker/tasks/tests/unit/test_flare_cleanup.py
@@ -14,7 +14,7 @@ class TestFlareCleanupTask(object):
         )
         assert FlareCleanupTask.get_min_seconds_interval_between_executions() > 17000
 
-    def test_successful_run(self, transactional_db, mocker, mock_archive_storage):
+    def test_successful_run(self, db, mocker, mock_archive_storage):
         mock_logs = mocker.patch("logging.Logger.info")
         archive_value_for_flare = {"some": "data"}
         local_value_for_flare = {"test": "test"}
@@ -113,7 +113,7 @@ class TestFlareCleanupTask(object):
             ]
         )
 
-    def test_limits_on_manual_run(self, transactional_db, mocker, mock_archive_storage):
+    def test_limits_on_manual_run(self, db, mocker, mock_archive_storage):
         mock_logs = mocker.patch("logging.Logger.info")
         local_value_for_flare = {"test": "test"}
         archive_value_for_flare = {"some": "data"}

--- a/apps/worker/tasks/tests/unit/test_notify_task.py
+++ b/apps/worker/tasks/tests/unit/test_notify_task.py
@@ -214,7 +214,7 @@ class TestNotifyTaskHelpers(object):
         )
         assert not mock_schedule_new_user_activated_task.called
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_determine_decoration_type_from_pull_attempt_activation(
         self, dbsession, mocker, enriched_pull, with_sql_functions
     ):

--- a/apps/worker/tasks/tests/unit/test_preprocess_upload.py
+++ b/apps/worker/tasks/tests/unit/test_preprocess_upload.py
@@ -13,7 +13,7 @@ from tasks.preprocess_upload import PreProcessUpload
 
 
 class TestPreProcessUpload(object):
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_preprocess_task(
         self,
         mocker,

--- a/apps/worker/tasks/tests/unit/test_process_flakes.py
+++ b/apps/worker/tasks/tests/unit/test_process_flakes.py
@@ -132,7 +132,7 @@ class RepoSimulator:
         self.test_count = 0
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_generate_flake_dict():
     repo = RepositoryFactory()
 
@@ -149,7 +149,7 @@ def test_generate_flake_dict():
     assert "id" in flake_dict
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_get_test_instances_when_test_is_flaky():
     repo = RepositoryFactory()
     commit = CommitFactory()
@@ -169,7 +169,7 @@ def test_get_test_instances_when_test_is_flaky():
     assert tis[0].commitid
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_get_test_instances_when_instance_is_failure():
     repo = RepositoryFactory()
     commit = CommitFactory()
@@ -189,7 +189,7 @@ def test_get_test_instances_when_instance_is_failure():
     assert tis[0].commitid
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_get_test_instances_when_test_is_flaky_and_instance_is_skip():
     repo = RepositoryFactory()
     commit = CommitFactory()
@@ -208,7 +208,7 @@ def test_get_test_instances_when_test_is_flaky_and_instance_is_skip():
     assert len(tis) == 0
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_get_test_instances_when_instance_is_pass():
     repo = RepositoryFactory()
     commit = CommitFactory()
@@ -227,7 +227,7 @@ def test_get_test_instances_when_instance_is_pass():
     assert len(tis) == 0
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_update_flake_pass():
     rs = RepoSimulator()
     c = rs.create_commit()
@@ -244,7 +244,7 @@ def test_update_flake_pass():
     assert f.recent_passes_count == 1
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_update_flake_fail():
     rs = RepoSimulator()
     c = rs.create_commit()
@@ -262,7 +262,7 @@ def test_update_flake_fail():
     assert f.fail_count == 1
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_upsert_failed_flakes():
     repo = RepositoryFactory()
     repo.save()
@@ -292,7 +292,7 @@ def test_upsert_failed_flakes():
     assert r.flaky_fail_count == 1
 
 
-@pytest.mark.django_db(transaction=False)
+@pytest.mark.django_db
 def test_upsert_failed_flakes_rollup_is_none():
     repo = RepositoryFactory()
     repo.save()
@@ -312,7 +312,7 @@ def test_upsert_failed_flakes_rollup_is_none():
     assert r is None
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_it_handles_only_passes():
     rs = RepoSimulator()
     c1 = rs.create_commit()
@@ -324,7 +324,7 @@ def test_it_handles_only_passes():
     assert len(Flake.objects.all()) == 0
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @freeze_time()
 def test_it_creates_flakes_from_processed_uploads():
     rs = RepoSimulator()
@@ -345,7 +345,7 @@ def test_it_creates_flakes_from_processed_uploads():
     assert flake.start_date == dt.datetime.now(tz=dt.UTC)
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @freeze_time()
 def test_it_does_not_create_flakes_from_flake_processed_uploads():
     rs = RepoSimulator()
@@ -360,7 +360,7 @@ def test_it_does_not_create_flakes_from_flake_processed_uploads():
     assert len(Flake.objects.all()) == 0
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @freeze_time()
 def test_it_processes_two_commits_separately():
     rs = RepoSimulator()
@@ -384,7 +384,7 @@ def test_it_processes_two_commits_separately():
     assert flake.start_date == dt.datetime.now(dt.UTC)
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_it_creates_flakes_expires():
     with freeze_time() as traveller:
         rs = RepoSimulator()
@@ -431,7 +431,7 @@ def test_it_creates_flakes_expires():
         assert flake.end_date == new_time
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_it_creates_rollups():
     with freeze_time("1970-01-01"):
         rs = RepoSimulator()
@@ -469,7 +469,7 @@ def test_it_creates_rollups():
         assert rollups[3].date == dt.date.today()
 
 
-@pytest.mark.django_db(transaction=False)
+@pytest.mark.django_db
 def test_it_locks(mocker):
     mock_all_plans_and_tiers()
     result2 = None

--- a/apps/worker/tasks/tests/unit/test_sync_repos_task.py
+++ b/apps/worker/tasks/tests/unit/test_sync_repos_task.py
@@ -386,7 +386,7 @@ class TestSyncReposTaskUnit(object):
         assert new_repo.branch == repo_data.get("branch")
         assert new_repo.private is True
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_only_public_repos_already_in_db(self, dbsession):
         token = "ecd73a086eadc85db68747a66bdbd662a785a072"
         user = OwnerFactory.create(
@@ -457,7 +457,7 @@ class TestSyncReposTaskUnit(object):
         "tasks/tests/unit/cassetes/test_sync_repos_task/TestSyncReposTaskUnit/test_only_public_repos_not_in_db.yaml"
     )
     @respx.mock
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_only_public_repos_not_in_db(self, dbsession):
         mock_all_plans_and_tiers()
         token = "ecd73a086eadc85db68747a66bdbd662a785a072"
@@ -491,7 +491,7 @@ class TestSyncReposTaskUnit(object):
     @reuse_cassette(
         "tasks/tests/unit/cassetes/test_sync_repos_task/TestSyncReposTaskUnit/test_sync_repos_using_integration.yaml"
     )
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_sync_repos_using_integration(
         self,
         mocker,
@@ -600,7 +600,7 @@ class TestSyncReposTaskUnit(object):
     @reuse_cassette(
         "tasks/tests/unit/cassetes/test_sync_repos_task/TestSyncReposTaskUnit/test_sync_repos_using_integration_no_repos.yaml"
     )
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_sync_repos_using_integration_no_repos(
         self,
         dbsession,
@@ -665,7 +665,7 @@ class TestSyncReposTaskUnit(object):
             SoftTimeLimitExceeded(),
         ],
     )
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_sync_repos_list_repos_error(
         self,
         dbsession,
@@ -727,7 +727,7 @@ class TestSyncReposTaskUnit(object):
         "tasks/tests/unit/cassetes/test_sync_repos_task/TestSyncReposTaskUnit/test_only_public_repos_not_in_db.yaml"
     )
     @respx.mock
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_insert_repo_and_call_repo_sync_languages(self, dbsession):
         mock_all_plans_and_tiers()
         token = "ecd73a086eadc85db68747a66bdbd662a785a072"
@@ -935,7 +935,7 @@ class TestSyncReposTaskUnit(object):
 
         mocked_app.tasks[sync_repo_languages_task_name].apply_async.assert_not_called()
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_sync_repos_using_integration_affected_repos_known(
         self,
         mocker,

--- a/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
@@ -123,7 +123,7 @@ def test_not_joined_flag(flag, joined):
 
 
 class TestUploadFinisherTask(object):
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_upload_finisher_task_call(
         self,
         mocker,
@@ -201,7 +201,7 @@ class TestUploadFinisherTask(object):
             },
         )
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_upload_finisher_task_call_no_author(
         self, mocker, mock_configuration, dbsession, mock_storage, mock_repo_provider
     ):
@@ -675,7 +675,7 @@ class TestUploadFinisherTask(object):
             }
         )
 
-    @pytest.mark.django_db()
+    @pytest.mark.django_db
     def test_retry_on_report_lock(self, dbsession, mock_redis):
         commit = CommitFactory.create()
         dbsession.add(commit)

--- a/apps/worker/tasks/tests/unit/test_upload_processing_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_processing_task.py
@@ -34,7 +34,7 @@ def test_default_acks_late() -> None:
 
 class TestUploadProcessorTask(object):
     @pytest.mark.integration
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_upload_processor_task_call(
         self,
         mocker,
@@ -187,7 +187,7 @@ class TestUploadProcessorTask(object):
         parsed = LegacyReportParser().parse_raw_report_from_bytes(content)
         assert data == parsed.content().getvalue()
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_upload_task_call_exception_within_individual_upload(
         self,
         mocker,
@@ -260,7 +260,7 @@ class TestUploadProcessorTask(object):
             ),
         )
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_upload_task_call_with_expired_report(
         self,
         mocker,
@@ -424,7 +424,7 @@ class TestUploadProcessorTask(object):
                 {"upload_id": upload.id_},
             )
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_upload_task_call_with_empty_report(
         self,
         mocker,
@@ -506,7 +506,7 @@ class TestUploadProcessorTask(object):
 
         assert commit.state == "complete"
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_upload_task_call_no_successful_report(
         self,
         mocker,
@@ -583,7 +583,7 @@ class TestUploadProcessorTask(object):
             "error": {"code": "report_expired", "params": {}},
         }
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_upload_task_call_softtimelimit(
         self,
         mocker,
@@ -621,7 +621,7 @@ class TestUploadProcessorTask(object):
             )
         assert commit.state == "error"
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_upload_task_call_celeryerror(
         self,
         mocker,

--- a/apps/worker/tasks/tests/unit/test_upload_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_task.py
@@ -123,7 +123,7 @@ def clear_log_context(mocker):
 
 @pytest.mark.integration
 class TestUploadTaskIntegration(object):
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_call(
         self,
         mocker,
@@ -224,7 +224,7 @@ class TestUploadTaskIntegration(object):
         ]
         mock_checkpoint_submit.assert_has_calls(calls)
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_call_bundle_analysis(
         self,
         mocker,
@@ -294,7 +294,7 @@ class TestUploadTaskIntegration(object):
         )
         chain.assert_called_with([processor_sig, notify_sig])
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_call_bundle_analysis_no_upload(
         self,
         mocker,
@@ -361,7 +361,7 @@ class TestUploadTaskIntegration(object):
         )
         assert call([processor_sig]) in chain.mock_calls
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_call_test_results(
         self,
         mocker,
@@ -437,7 +437,7 @@ class TestUploadTaskIntegration(object):
         notify_sig = test_results_finisher_task.signature(kwargs=kwargs)
         chain.assert_called_with(*[processor_sig, notify_sig])
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_call_new_ta_tasks(
         self,
         mocker,
@@ -582,7 +582,7 @@ class TestUploadTaskIntegration(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_upload_processing_delay_not_enough_delay(
         self,
         mocker,
@@ -633,7 +633,7 @@ class TestUploadTaskIntegration(object):
         assert redis.exists(f"uploads/{commit.repoid}/{commit.commitid}")
         assert not mock_possibly_update_commit_from_provider_info.called
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_upload_processing_delay_enough_delay(
         self,
         mocker,
@@ -685,7 +685,7 @@ class TestUploadTaskIntegration(object):
         assert not redis.exists(f"uploads/{commit.repoid}/{commit.commitid}")
         mocked_chord.assert_called_with([mocker.ANY, mocker.ANY], mocker.ANY)
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     @pytest.mark.skip(reason="Bitbucket down is breaking this test")
     def test_upload_task_upload_processing_delay_upload_is_none(
         self,
@@ -733,7 +733,7 @@ class TestUploadTaskIntegration(object):
         assert not redis.exists(f"uploads/{commit.repoid}/{commit.commitid}")
         mocked_chord.assert_called_with([mocker.ANY, mocker.ANY], mocker.ANY)
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_call_multiple_processors(
         self,
         mocker,
@@ -872,7 +872,7 @@ class TestUploadTaskIntegration(object):
             timeout=300,
         )
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_no_bot(
         self,
         mocker,
@@ -939,7 +939,7 @@ class TestUploadTaskIntegration(object):
         )
         assert not mocked_fetch_yaml.called
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_bot_no_permissions(
         self,
         mocker,
@@ -1007,7 +1007,7 @@ class TestUploadTaskIntegration(object):
         )
         assert not mocked_fetch_yaml.called
 
-    @pytest.mark.django_db(databases={"default"}, transaction=True)
+    @pytest.mark.django_db
     def test_upload_task_bot_unauthorized(
         self,
         mocker,

--- a/apps/worker/tasks/upload.py
+++ b/apps/worker/tasks/upload.py
@@ -10,7 +10,6 @@ import sentry_sdk
 from asgiref.sync import async_to_sync
 from celery import chain, chord
 from django.conf import settings
-from django.db import transaction as django_transaction
 from django.utils import timezone
 from redis import Redis
 from redis.exceptions import LockError
@@ -541,7 +540,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
 
         # Bulk insert coverage measurements
         if measurements := create_upload_res["measurements_list"]:
-            self._bulk_insert_coverage_measurements(measurements=measurements)
+            bulk_insert_coverage_measurements(measurements=measurements)
 
         return create_upload_res["argument_list"]
 
@@ -655,10 +654,6 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         """
         flags = db_session.query(RepositoryFlag).filter_by(repository_id=repoid).all()
         return {flag.flag_name: flag for flag in flags} if flags else {}
-
-    def _bulk_insert_coverage_measurements(self, measurements: list[UserMeasurement]):
-        bulk_insert_coverage_measurements(measurements=measurements)
-        django_transaction.commit()
 
     def schedule_task(
         self,

--- a/libs/shared/tests/integration/test_bots.py
+++ b/libs/shared/tests/integration/test_bots.py
@@ -28,7 +28,7 @@ C/tY+lZIEO1Gg/FxSMB+hwwhwfSuE3WohZfEcSy+R48=
 
 
 class TestRepositoryServiceIntegration(object):
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_get_token_type_mapping_non_existing_integration(
         self, codecov_vcr, mock_configuration, mocker
     ):
@@ -48,7 +48,7 @@ class TestRepositoryServiceIntegration(object):
         with pytest.raises(RepositoryWithoutValidBotError):
             get_repo_appropriate_bot_token(repo)
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_get_token_type_mapping_bad_data(
         self, codecov_vcr, mock_configuration, mocker
     ):

--- a/libs/shared/tests/integration/test_github.py
+++ b/libs/shared/tests/integration/test_github.py
@@ -1128,7 +1128,7 @@ class TestGithubTestCase(object):
         assert mock_api.call_count == 2
 
     @pytest.mark.asyncio
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     async def test_list_repos(self, valid_handler, codecov_vcr):
         res = await valid_handler.list_repos()
         assert len(res) == 115
@@ -1147,7 +1147,7 @@ class TestGithubTestCase(object):
         assert one_expected_result in res
 
     @pytest.mark.asyncio
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     async def test_list_repos_generator(self, valid_handler, codecov_vcr):
         repos = []
         page_count = 0
@@ -1200,7 +1200,7 @@ class TestGithubTestCase(object):
         assert all(x in repos for x in some_expected_results)
 
     @pytest.mark.asyncio
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     async def test_list_repos_using_installation(self, valid_handler, codecov_vcr):
         res = await valid_handler.list_repos_using_installation()
         assert res == [
@@ -1217,7 +1217,7 @@ class TestGithubTestCase(object):
         ]
 
     @pytest.mark.asyncio
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     async def test_list_repos_using_installation_generator(
         self, valid_handler, codecov_vcr
     ):
@@ -1925,7 +1925,7 @@ class TestGithubTestCase(object):
         assert res is True
 
     @pytest.mark.asyncio
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     async def test_get_repos_from_nodeids_generator(self, valid_handler, codecov_vcr):
         repo_node_ids = ["R_kgDOHrbKcg", "R_kgDOLEJx2g"]
         expected = [

--- a/libs/shared/tests/unit/bots/test_bots.py
+++ b/libs/shared/tests/unit/bots/test_bots.py
@@ -61,7 +61,7 @@ class TestGettingAdapterAuthInformation(object):
 
             return owner
 
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_owner_info(self):
             owner = self._generate_test_owner(with_bot=False)
             expected = AdapterAuthInformation(
@@ -78,7 +78,7 @@ class TestGettingAdapterAuthInformation(object):
             )
             assert get_adapter_auth_information(owner) == expected
 
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_owner_bot_info(self):
             owner = self._generate_test_owner(with_bot=True)
             expected = AdapterAuthInformation(
@@ -99,7 +99,7 @@ class TestGettingAdapterAuthInformation(object):
             "shared.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_owner_single_installation(
             self, mock_get_github_integration_token
         ):
@@ -138,7 +138,7 @@ class TestGettingAdapterAuthInformation(object):
             "shared.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_owner_single_installation_ignoring_installations(
             self, mock_get_github_integration_token
         ):
@@ -176,7 +176,7 @@ class TestGettingAdapterAuthInformation(object):
             "shared.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_owner_deprecated_using_integration(
             self, mock_get_github_integration_token
         ):
@@ -201,7 +201,7 @@ class TestGettingAdapterAuthInformation(object):
             "shared.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_owner_multiple_installations_default_name(
             self, mock_get_github_integration_token
         ):
@@ -249,7 +249,7 @@ class TestGettingAdapterAuthInformation(object):
             "shared.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_owner_multiple_installations_custom_name(
             self, mock_get_github_integration_token
         ):
@@ -354,7 +354,7 @@ class TestGettingAdapterAuthInformation(object):
 
             return repo
 
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_repo_info_fallback_to_owner(self):
             repo = self._generate_test_repo(with_bot=False, with_owner_bot=False)
             expected = AdapterAuthInformation(
@@ -372,7 +372,7 @@ class TestGettingAdapterAuthInformation(object):
             )
             assert get_adapter_auth_information(repo.author, repo) == expected
 
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_owner_bot_info(self):
             repo = self._generate_test_repo(with_owner_bot=True, with_bot=False)
             expected = AdapterAuthInformation(
@@ -390,7 +390,7 @@ class TestGettingAdapterAuthInformation(object):
             )
             assert get_adapter_auth_information(repo.author, repo) == expected
 
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_repo_bot_info(self):
             repo = self._generate_test_repo(with_owner_bot=True, with_bot=True)
             expected = AdapterAuthInformation(
@@ -408,7 +408,7 @@ class TestGettingAdapterAuthInformation(object):
             )
             assert get_adapter_auth_information(repo.author, repo) == expected
 
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_repo_bot_info_public_repo(self, mock_configuration):
             repo = self._generate_test_repo(
                 with_owner_bot=True, with_bot=True, private=False
@@ -454,7 +454,7 @@ class TestGettingAdapterAuthInformation(object):
             "shared.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_repo_single_installation(
             self, mock_get_github_integration_token
         ):
@@ -495,7 +495,7 @@ class TestGettingAdapterAuthInformation(object):
             "shared.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_repo_deprecated_using_integration(
             self, mock_get_github_integration_token
         ):
@@ -524,7 +524,7 @@ class TestGettingAdapterAuthInformation(object):
             "shared.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_repo_multiple_installations_default_name(
             self, mock_get_github_integration_token
         ):
@@ -574,7 +574,7 @@ class TestGettingAdapterAuthInformation(object):
             "shared.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        @pytest.mark.django_db(databases={"default"})
+        @pytest.mark.django_db
         def test_select_repo_multiple_installations_custom_name(
             self, mock_get_github_integration_token
         ):
@@ -633,7 +633,7 @@ class TestGettingAdapterAuthInformation(object):
             )
 
     @pytest.mark.parametrize("service", ["github", "gitlab"])
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_select_repo_public_with_no_token_no_admin_token_configured(
         self, service, mocker
     ):

--- a/libs/shared/tests/unit/bots/test_github_apps.py
+++ b/libs/shared/tests/unit/bots/test_github_apps.py
@@ -51,7 +51,7 @@ def _to_installation_info(
 
 
 class TestGetSpecificGithubAppDetails(object):
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_get_specific_github_app_details(self):
         owner = _get_owner_with_apps()
         assert get_specific_github_app_details(
@@ -71,7 +71,7 @@ class TestGetSpecificGithubAppDetails(object):
             pem_path="some_path",
         )
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_get_specific_github_app_not_found(self):
         owner = _get_owner_with_apps()
         with pytest.raises(RequestedGithubAppNotFound):
@@ -108,7 +108,7 @@ class TestGetSpecificGithubAppDetails(object):
             ),
         ],
     )
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_raise_NoAppsConfiguredAvailable_if_suspended_or_rate_limited(
         self, app, is_rate_limited, mocker
     ):
@@ -135,7 +135,7 @@ class TestGetSpecificGithubAppDetails(object):
 
 
 class TestGettingGitHubAppTokenSideEffect(object):
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_mark_installation_suspended_side_effect(self, mocker):
         owner = _get_owner_with_apps()
         installations: list[GithubAppInstallation] = (
@@ -160,7 +160,7 @@ class TestGettingGitHubAppTokenSideEffect(object):
         assert installations[1].is_suspended is False
         assert not Owner.objects.filter(integration_id=None).exists()
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_mark_installation_not_found_side_effect(self, mocker):
         owner = _get_owner_with_apps()
         installations: list[GithubAppInstallation] = (
@@ -185,7 +185,7 @@ class TestGettingGitHubAppTokenSideEffect(object):
         owner.refresh_from_db()
         assert list(owner.github_app_installations.all()) == [installations[1]]
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_mark_installation_suspended_legacy_path_side_effect(self, mocker):
         owner = _get_owner_with_apps()
         installations: list[GithubAppInstallation] = (
@@ -210,7 +210,7 @@ class TestGettingGitHubAppTokenSideEffect(object):
         owner.refresh_from_db()
         assert list(Owner.objects.filter(integration_id=None).all()) == [owner]
 
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_mark_installation_suspended_side_effect_not_called(self, mocker):
         owner = _get_owner_with_apps()
         installations: list[GithubAppInstallation] = (

--- a/libs/shared/tests/unit/django_apps/test_model_utils.py
+++ b/libs/shared/tests/unit/django_apps/test_model_utils.py
@@ -5,7 +5,7 @@ from shared.django_apps.utils.model_utils import get_ownerid_if_member
 
 
 class TestMigrationUtils:
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     def test_get_ownerid_if_member(self):
         test_owner_id = 123
         valid_owner_id = 456

--- a/libs/shared/tests/unit/rate_limits/test_rate_limit.py
+++ b/libs/shared/tests/unit/rate_limits/test_rate_limit.py
@@ -55,7 +55,7 @@ def test_determine_entity_redis_key_github_bot():
     "shared.bots.github_apps.get_github_integration_token",
     side_effect=get_github_integration_token_side_effect,
 )
-@pytest.mark.django_db(databases={"default"})
+@pytest.mark.django_db
 def test_determine_entity_redis_key_installed_gh_app_via_repository(
     mock_get_github_integration_token,
 ):
@@ -87,7 +87,7 @@ def test_determine_entity_redis_key_installed_gh_app_via_repository(
     "shared.bots.github_apps.get_github_integration_token",
     side_effect=get_github_integration_token_side_effect,
 )
-@pytest.mark.django_db(databases={"default"})
+@pytest.mark.django_db
 def test_determine_entity_redis_key_installed_gh_app_via_owner(
     mock_get_github_integration_token,
 ):
@@ -114,7 +114,7 @@ def test_determine_entity_redis_key_installed_gh_app_via_owner(
     )
 
 
-@pytest.mark.django_db(databases={"default"})
+@pytest.mark.django_db
 def test_determine_entity_redis_key_owner_token_via_repository():
     owner = OwnerFactory(
         ownerid=1428,
@@ -130,7 +130,7 @@ def test_determine_entity_redis_key_owner_token_via_repository():
     )
 
 
-@pytest.mark.django_db(databases={"default"})
+@pytest.mark.django_db
 def test_determine_entity_redis_key_owner_token_via_owner():
     owner = OwnerFactory(
         ownerid=1428,

--- a/libs/shared/tests/unit/torngit/test_github.py
+++ b/libs/shared/tests/unit/torngit/test_github.py
@@ -1887,7 +1887,7 @@ class TestUnitGithub(object):
             assert after - before == 1
 
     @pytest.mark.asyncio
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db
     async def test_get_repos_from_nodeids(self, ghapp_handler):
         before = REGISTRY.get_sample_value(
             "git_provider_api_calls_github_total",


### PR DESCRIPTION
Similar to the case with `TransactionTestCase`, the `transactional_db` might be a bit slower, as is has to do more heavy lifting to setup/teardown the test. So lets switch to regular testcases, hopefully speeding up the tests slightly.