### PR TITLE
build: run TA timeseries migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - timescale-volume:/var/lib/postgresql/data
+      - ./docker/init_db.sql:/docker-entrypoint-initdb.d/init_db.sql
     ports:
       - "5433:5432"
     networks:

--- a/docker/init_db.sql
+++ b/docker/init_db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE test_analytics;

--- a/tools/devenv/Makefile.devenv
+++ b/tools/devenv/Makefile.devenv
@@ -43,6 +43,7 @@ devenv.migrate:
 	$(MAKE) devenv.start.deps
 	docker compose run --entrypoint python api manage.py migrate
 	docker compose run --entrypoint python worker manage.py migrate
+	docker compose run --entrypoint python worker migrate_timeseries.py
 
 .PHONY: devenv.stop
 devenv.stop:

--- a/tools/devenv/scripts/start-worker.sh
+++ b/tools/devenv/scripts/start-worker.sh
@@ -21,6 +21,7 @@ fi
 
 python manage.py migrate
 python manage.py migrate --database "timeseries"
+python manage.py migrate_timeseries.py
 
 # Auto-restart worker when Python files change.
 watchmedo auto-restart \


### PR DESCRIPTION
we need to:
- create the TA db in timescale
- run the migrate_timeseries.py script to apply migrations