### PR TITLE
docker: build with host network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ export DOCKER_REQS_SHA := $(shell sha1sum docker/Dockerfile.requirements | head 
 # `worker.build.requirements` or `api.build.requirements`.
 _build.requirements:
 	docker pull ${AR_REPO}:${REQUIREMENTS_TAG} || docker build \
+			   --network host \
                -f docker/Dockerfile.requirements . \
                --build-arg APP_DIR=${APP_DIR} \
                -t ${AR_REPO}:${REQUIREMENTS_TAG} \


### PR DESCRIPTION
I've been having problems building the requirements images since fetching the debian or cargo reqs will randomly fail, building with the host network fixes that