### PR TITLE
fix: add shared test junit/coverage artifacts to gitignore

### DIFF
--- a/libs/shared/.gitignore
+++ b/libs/shared/.gitignore
@@ -52,8 +52,8 @@ coverage.xml
 .pytest_cache/
 cover/
 .codspeed
-*.junit.xml
-*.coverage.xml
+*junit.xml
+*coverage.xml
 
 # Translations
 *.mo


### PR DESCRIPTION
it would make sense to merge all three projects' `.gitignore` into a top-level `umbrella` one but that's a different commit