### PR TITLE
fix: add missing "needs" declaration to self-hosted actions in ci

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -78,7 +78,7 @@ jobs:
   api-build-self-hosted:
     name: Build Self Hosted (API)
     if: ${{ inputs.skip == false }}
-    needs: [api-build, api-test]
+    needs: [api-compute-reqs-cache-key, api-build, api-test]
     uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.36
     secrets: inherit
     with:
@@ -115,7 +115,7 @@ jobs:
 
   api-self-hosted:
     name: Push Self Hosted Image (API)
-    needs: [api-build-self-hosted, api-test]
+    needs: [api-compute-reqs-cache-key, api-build-self-hosted, api-test]
     secrets: inherit
     if: ${{ inputs.skip == false && github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
     uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.36

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -77,7 +77,7 @@ jobs:
   worker-build-self-hosted:
     name: Build Self Hosted (Worker)
     if: ${{ inputs.skip == false }}
-    needs: [worker-build, worker-test]
+    needs: [worker-compute-reqs-cache-key, worker-build, worker-test]
     uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.36
     secrets: inherit
     with:


### PR DESCRIPTION
there is just no way to test this stuff. irritating

because the job wasn't in the `needs` list, trying to get its output silently returns ""

this should fix failing "Build Self-hosted App" steps in umbrella CI