### PR TITLE
fix: use getattr in RepositoryViewSet to handle attrs that may not be set

### DIFF
--- a/apps/codecov-api/api/internal/repo/views.py
+++ b/apps/codecov-api/api/internal/repo/views.py
@@ -50,8 +50,14 @@ class RepositoryViewSet(
 
     def get_serializer_context(self, *args, **kwargs):
         context = super().get_serializer_context(*args, **kwargs)
+
+        # These attributes only exist if RepositoryViewSetMixin.check_object_permissions() has run.
+        # This should be cleaned up but it's old code.
+        can_edit = getattr(self, "can_edit", False)
+        can_view = getattr(self, "can_view", False)
+
         if self.action != "list":
-            context.update({"can_edit": self.can_edit, "can_view": self.can_view})
+            context.update({"can_edit": can_edit, "can_view": can_view})
         return context
 
     def get_queryset(self):


### PR DESCRIPTION
if [`RepositoryViewSetMixin.check_object_permissions()`](https://github.com/codecov/umbrella/blob/595af92059db4c6e7dba591fee0a905e28d96f4a/apps/codecov-api/api/shared/repo/mixins.py#L44) has not been called, the `self.can_edit` and `self.can_view` attributes don't exist and this code blows up. this code uses `getattr` with a default value of `False`

this "mixins" pattern is strange to me. a mixin doesn't appear to have a way to initialize its instance state when an object is constructed, so if things outside the mixin try to use that state before calling a magic function it will blow up. i think the safe thing to do would be for the mixin to only expose state through getters which lazy-initialize?