### PR TITLE
Cleanup `staticanalysis` and `local-upload` related entities

### DIFF
--- a/apps/worker/services/cleanup/regular.py
+++ b/apps/worker/services/cleanup/regular.py
@@ -6,6 +6,8 @@ from django.db.models.query import QuerySet
 from services.cleanup.cleanup import run_cleanup
 from services.cleanup.uploads import cleanup_old_uploads
 from services.cleanup.utils import CleanupResult, CleanupSummary, cleanup_context
+from shared.django_apps.reports.models import CommitReport
+from shared.django_apps.staticanalysis.models import StaticAnalysisSingleFileSnapshot
 
 log = logging.getLogger(__name__)
 
@@ -14,7 +16,10 @@ def run_regular_cleanup() -> CleanupSummary:
     log.info("Starting regular cleanup job")
     complete_summary = CleanupSummary(CleanupResult(0), summary={})
 
-    cleanups_to_run: list[QuerySet] = []
+    cleanups_to_run: list[QuerySet] = [
+        StaticAnalysisSingleFileSnapshot.objects.all(),
+        CommitReport.objects.filter(code__isnull=False),
+    ]
 
     # as we expect this job to have frequent retries, and cleanup to take a long time,
     # lets shuffle the various cleanups so that each one of those makes a little progress.

--- a/apps/worker/services/cleanup/tests/test_regular_cleanup.py
+++ b/apps/worker/services/cleanup/tests/test_regular_cleanup.py
@@ -2,10 +2,62 @@ import pytest
 
 from services.cleanup.regular import run_regular_cleanup
 from services.cleanup.utils import CleanupResult, CleanupSummary
+from shared.api_archive.archive import ArchiveService
+from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
+from shared.django_apps.reports.models import CommitReport
+from shared.django_apps.reports.models import ReportSession as Upload
+from shared.django_apps.reports.tests.factories import (
+    CommitReportFactory,
+    UploadFactory,
+)
+from shared.django_apps.staticanalysis.models import StaticAnalysisSingleFileSnapshot
+from shared.django_apps.staticanalysis.tests.factories import (
+    StaticAnalysisSingleFileSnapshotFactory,
+)
 
 
 @pytest.mark.django_db
 def test_runs_regular_cleanup(mock_storage):
+    repo = RepositoryFactory()
+    archive_service = ArchiveService(repo)
+
+    filesnapshot = StaticAnalysisSingleFileSnapshotFactory()
+    archive_service.write_file(filesnapshot.content_location, "some content")
+
+    commit = CommitFactory(repository=repo)
+
+    commit_report = CommitReportFactory(
+        commit=commit, report_type=CommitReport.ReportType.COVERAGE.value
+    )
+    upload = UploadFactory(report=commit_report, storage_path="regular-upload")
+
+    archive_service.write_chunks(commit.commitid, "regular-upload-chunks_data")
+    archive_service.write_file(upload.storage_path, "regular-upload_data")
+
+    commit_report = CommitReportFactory(
+        commit=commit,
+        report_type=CommitReport.ReportType.COVERAGE.value,
+        code="local-upload",
+    )
+    upload = UploadFactory(report=commit_report, storage_path="upload")
+
+    archive_service.write_chunks(
+        commit.commitid, "local-upload-chunks_data", report_code="local-upload"
+    )
+    archive_service.write_file(upload.storage_path, "local-upload_data")
+
+    archive = mock_storage.storage["archive"]
+
+    assert len(archive) == 5
+
     summary = run_regular_cleanup()
 
-    assert summary == CleanupSummary(CleanupResult(0, 0), {})
+    assert summary == CleanupSummary(
+        CleanupResult(3, 3),
+        {
+            Upload: CleanupResult(1, 1),
+            StaticAnalysisSingleFileSnapshot: CleanupResult(1, 1),
+            CommitReport: CleanupResult(1, 1),
+        },
+    )
+    assert len(archive) == 2


### PR DESCRIPTION
As we are deprecating the "staticanalysis" (aka ATS [automated test selection]) and the "local-upload" (aka `report_code`) features, this adds the related models (`StaticAnalysisSingleFileSnapshot` and `CommitReport` with a `code`) to the cleanup task.

Thus, all related files in storage, and database entities will be cleaned up.