### PR TITLE
Fully remove and disallow non-default `report_code`

### DIFF
--- a/apps/codecov-api/services/task/task.py
+++ b/apps/codecov-api/services/task/task.py
@@ -106,7 +106,6 @@ class TaskService(object):
         repoid,
         commitid,
         report_type=None,
-        report_code=None,
         arguments=None,
         debug=False,
         rebuild=False,
@@ -118,7 +117,6 @@ class TaskService(object):
                 repoid=repoid,
                 commitid=commitid,
                 report_type=report_type,
-                report_code=report_code,
                 arguments=arguments,
                 debug=debug,
                 rebuild=rebuild,
@@ -131,7 +129,6 @@ class TaskService(object):
         repoid,
         commitid,
         report_type=None,
-        report_code=None,
         arguments=None,
         countdown=0,
         debug=False,
@@ -141,7 +138,6 @@ class TaskService(object):
             repoid,
             commitid,
             report_type=report_type,
-            report_code=report_code,
             arguments=arguments,
             debug=debug,
             rebuild=rebuild,
@@ -329,27 +325,16 @@ class TaskService(object):
             kwargs=dict(repoid=repository_id),
         ).apply_async()
 
-    def manual_upload_completion_trigger(
-        self, repoid, commitid, report_code=None, current_yaml=None
-    ):
+    def manual_upload_completion_trigger(self, repoid, commitid, current_yaml=None):
         self._create_signature(
             "app.tasks.upload.ManualUploadCompletionTrigger",
-            kwargs=dict(
-                commitid=commitid,
-                repoid=repoid,
-                report_code=report_code,
-                current_yaml=current_yaml,
-            ),
+            kwargs=dict(commitid=commitid, repoid=repoid, current_yaml=current_yaml),
         ).apply_async()
 
-    def preprocess_upload(self, repoid, commitid, report_code):
+    def preprocess_upload(self, repoid, commitid):
         self._create_signature(
             "app.tasks.upload.PreProcessUpload",
-            kwargs=dict(
-                repoid=repoid,
-                commitid=commitid,
-                report_code=report_code,
-            ),
+            kwargs=dict(repoid=repoid, commitid=commitid),
         ).apply_async()
 
     def send_email(

--- a/apps/codecov-api/upload/helpers.py
+++ b/apps/codecov-api/upload/helpers.py
@@ -745,7 +745,6 @@ def dispatch_upload_task(
         repoid=repoid,
         commitid=commitid,
         report_type=str(report_type),
-        report_code=task_arguments.get("report_code"),
         arguments=task_arguments,
         countdown=max(
             countdown, int(get_config("setup", "upload_processing_delay") or 0)

--- a/apps/codecov-api/upload/serializers.py
+++ b/apps/codecov-api/upload/serializers.py
@@ -163,6 +163,16 @@ class CommitReportSerializer(serializers.ModelSerializer):
         )
         fields = read_only_fields + ("code",)
 
+    def validate_code(self, value):
+        """
+        Check that the blog post is about Django.
+        """
+        if value not in (None, "default"):
+            raise serializers.ValidationError(
+                "Using a non-default `code` has been deprecated"
+            )
+        return None
+
     def create(self, validated_data: Dict[str, Any]) -> tuple[CommitReport, bool]:
         report = (
             CommitReport.objects.coverage_reports()

--- a/apps/codecov-api/upload/tests/test_upload.py
+++ b/apps/codecov-api/upload/tests/test_upload.py
@@ -832,11 +832,7 @@ class UploadHandlerHelpersTest(TestCase):
     @patch("services.task.TaskService.upload")
     def test_dispatch_upload_task(self, upload):
         repo = RepositoryFactory()
-        task_arguments = {
-            "commit": "commit123",
-            "version": "v4",
-            "report_code": "local_report",
-        }
+        task_arguments = {"commit": "commit123", "version": "v4"}
 
         redis = get_redis_connection()
         dispatch_upload_task(redis, repo.repoid, task_arguments)
@@ -845,7 +841,6 @@ class UploadHandlerHelpersTest(TestCase):
             repoid=repo.repoid,
             commitid=task_arguments.get("commit"),
             report_type="coverage",
-            report_code="local_report",
             arguments=task_arguments,
             countdown=4,
         )

--- a/apps/codecov-api/upload/tests/views/test_base.py
+++ b/apps/codecov-api/upload/tests/views/test_base.py
@@ -80,4 +80,4 @@ def test_get_report_error(db):
     )
     with pytest.raises(ValidationError) as exp:
         generic_class.get_report(commit)
-    assert exp.match("Report not found")
+    assert exp.match("Non-default `report_code` has been deprecated")

--- a/apps/codecov-api/upload/tests/views/test_bundle_analysis.py
+++ b/apps/codecov-api/upload/tests/views/test_bundle_analysis.py
@@ -79,7 +79,6 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
         "service": "test-service",
         "url": f"v1/uploads/{reportid}.json",
         "commit": commit_sha,
-        "report_code": None,
         "bundle_analysis_compare_sha": "6fd5b89357fc8cdf34d6197549ac7c6d7e5aaaaa",
     }
 
@@ -91,7 +90,6 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
     upload.assert_called_with(
         commitid=commit_sha,
         repoid=repository.repoid,
-        report_code=None,
         report_type="bundle_analysis",
         arguments=ANY,
         countdown=4,
@@ -183,7 +181,6 @@ def test_upload_bundle_analysis_success_shelter(db, client, mocker, mock_redis):
         "service": "test-service",
         "url": f"v1/uploads/{reportid}.json",
         "commit": commit_sha,
-        "report_code": None,
         "bundle_analysis_compare_sha": "6fd5b89357fc8cdf34d6197549ac7c6d7e5aaaaa",
     }
 
@@ -195,7 +192,6 @@ def test_upload_bundle_analysis_success_shelter(db, client, mocker, mock_redis):
     upload.assert_called_with(
         commitid=commit_sha,
         repoid=repository.repoid,
-        report_code=None,
         report_type="bundle_analysis",
         arguments=ANY,
         countdown=4,
@@ -282,7 +278,6 @@ def test_upload_bundle_analysis_existing_commit(db, client, mocker, mock_redis):
     upload.assert_called_with(
         commitid=commit.commitid,
         repoid=repository.repoid,
-        report_code=None,
         report_type="bundle_analysis",
         arguments=ANY,
         countdown=4,

--- a/apps/codecov-api/upload/tests/views/test_test_results.py
+++ b/apps/codecov-api/upload/tests/views/test_test_results.py
@@ -89,7 +89,6 @@ def test_upload_test_results(db, client, mocker, mock_redis):
         "service": "github-actions",
         "url": f"test_results/v1/raw/{date}/{repo_hash}/{commit_sha}/{reportid}.txt",
         "commit": commit_sha,
-        "report_code": None,
         "flags": None,
     }
 
@@ -101,7 +100,6 @@ def test_upload_test_results(db, client, mocker, mock_redis):
     upload.assert_called_with(
         commitid=commit_sha,
         repoid=repository.repoid,
-        report_code=None,
         report_type="test_results",
         arguments=args,
         countdown=4,
@@ -447,7 +445,6 @@ def test_upload_test_results_file_not_found(db, client, mocker, mock_redis):
         "service": "github-actions",
         "url": None,
         "commit": commit_sha,
-        "report_code": None,
         "flags": None,
     }
 
@@ -459,7 +456,6 @@ def test_upload_test_results_file_not_found(db, client, mocker, mock_redis):
     upload.assert_called_with(
         commitid=commit_sha,
         repoid=repository.repoid,
-        report_code=None,
         report_type="test_results",
         arguments=args,
         countdown=4,
@@ -505,7 +501,6 @@ def test_upload_test_results_tokenless_authentication(db, client, mocker, mock_r
     upload.assert_called_with(
         commitid=commit_sha,
         repoid=repository.repoid,
-        report_code=None,
         report_type="test_results",
         arguments=mocker.ANY,
         countdown=4,

--- a/apps/codecov-api/upload/tests/views/test_upload_coverage.py
+++ b/apps/codecov-api/upload/tests/views/test_upload_coverage.py
@@ -129,7 +129,7 @@ def test_upload_coverage_post(db, mocker):
             "branch": "branch",
             "ci_service": "ci_service",
             "ci_url": "ci_url",
-            "code": "code",
+            "code": "default",
             "commitid": commit.commitid,
             "flags": ["flag1", "flag2"],
             "job_code": "job_code",
@@ -140,7 +140,7 @@ def test_upload_coverage_post(db, mocker):
     response_json = response.json()
     upload = ReportSession.objects.filter(
         report__commit=commit,
-        report__code="code",
+        report__code=None,
         upload_extras={"format_version": "v1"},
     ).first()
     assert response.status_code == 201
@@ -168,7 +168,7 @@ def test_upload_coverage_post(db, mocker):
 
     assert ReportSession.objects.filter(
         report__commit=commit,
-        report__code="code",
+        report__code=None,
         upload_extras={"format_version": "v1"},
     ).exists()
     assert RepositoryFlag.objects.filter(
@@ -239,7 +239,7 @@ def test_upload_coverage_post_shelter(db, mocker):
             "branch": "branch",
             "ci_service": "ci_service",
             "ci_url": "ci_url",
-            "code": "code",
+            "code": "default",
             "commitid": commit.commitid,
             "flags": ["flag1", "flag2"],
             "job_code": "job_code",
@@ -255,7 +255,7 @@ def test_upload_coverage_post_shelter(db, mocker):
     response_json = response.json()
     upload = ReportSession.objects.filter(
         report__commit=commit,
-        report__code="code",
+        report__code=None,
         upload_extras={"format_version": "v1"},
     ).first()
     assert response.status_code == 201
@@ -272,7 +272,7 @@ def test_upload_coverage_post_shelter(db, mocker):
 
     assert ReportSession.objects.filter(
         report__commit=commit,
-        report__code="code",
+        report__code=None,
         upload_extras={"format_version": "v1"},
     ).exists()
     assert RepositoryFlag.objects.filter(

--- a/apps/codecov-api/upload/tests/views/test_uploads.py
+++ b/apps/codecov-api/upload/tests/views/test_uploads.py
@@ -221,7 +221,7 @@ def test_uploads_post(db, mocker, mock_redis):
         name="the_repo", author__username="codecov", author__service="github"
     )
     commit = CommitFactory(repository=repository)
-    commit_report = CommitReport.objects.create(commit=commit, code="code")
+    commit_report = CommitReport.objects.create(commit=commit)
     repository.save()
     commit_report.save()
 
@@ -230,12 +230,7 @@ def test_uploads_post(db, mocker, mock_redis):
     client.force_authenticate(user=owner)
     url = reverse(
         "new_upload.uploads",
-        args=[
-            "github",
-            "codecov::::the_repo",
-            commit.commitid,
-            commit_report.code,
-        ],
+        args=["github", "codecov::::the_repo", commit.commitid, "default"],
     )
     response = client.post(
         url,
@@ -338,7 +333,7 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
     )
     commit = CommitFactory(repository=repository)
     commit.branch = branch
-    commit_report = CommitReport.objects.create(commit=commit, code="code")
+    commit_report = CommitReport.objects.create(commit=commit)
     repository.save()
     commit_report.save()
     commit.save()
@@ -346,12 +341,7 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
     client = APIClient()
     url = reverse(
         "new_upload.uploads",
-        args=[
-            "github",
-            "codecov::::the_repo",
-            commit.commitid,
-            commit_report.code,
-        ],
+        args=["github", "codecov::::the_repo", commit.commitid, "default"],
     )
     if branch_sent is not None:
         data = {
@@ -483,7 +473,7 @@ def test_uploads_post_token_required_auth_check(
     )
     commit = CommitFactory(repository=repository)
     commit.branch = branch
-    commit_report = CommitReport.objects.create(commit=commit, code="code")
+    commit_report = CommitReport.objects.create(commit=commit)
     repository.save()
     commit_report.save()
     commit.save()
@@ -491,12 +481,7 @@ def test_uploads_post_token_required_auth_check(
     client = APIClient()
     url = reverse(
         "new_upload.uploads",
-        args=[
-            "github",
-            "codecov::::the_repo",
-            commit.commitid,
-            commit_report.code,
-        ],
+        args=["github", "codecov::::the_repo", commit.commitid, "default"],
     )
     if branch_sent is not None:
         data = {
@@ -637,17 +622,12 @@ def test_uploads_post_github_oidc_auth(
     token = "ThisValueDoesNotMatterBecauseOf_mock_jwt_decode"
 
     commit = CommitFactory(repository=repository)
-    commit_report = CommitReport.objects.create(commit=commit, code="code")
+    commit_report = CommitReport.objects.create(commit=commit)
 
     client = APIClient()
     url = reverse(
         "new_upload.uploads",
-        args=[
-            "github",
-            "codecov::::the_repo",
-            commit.commitid,
-            commit_report.code,
-        ],
+        args=["github", "codecov::::the_repo", commit.commitid, "default"],
     )
     response = client.post(
         url,
@@ -750,7 +730,7 @@ def test_uploads_post_shelter(db, mocker, mock_redis):
         name="the_repo", author__username="codecov", author__service="github"
     )
     commit = CommitFactory(repository=repository)
-    commit_report = CommitReport.objects.create(commit=commit, code="code")
+    commit_report = CommitReport.objects.create(commit=commit)
     repository.save()
     commit_report.save()
 
@@ -759,12 +739,7 @@ def test_uploads_post_shelter(db, mocker, mock_redis):
     client.force_authenticate(user=owner)
     url = reverse(
         "new_upload.uploads",
-        args=[
-            "github",
-            "codecov::::the_repo",
-            commit.commitid,
-            commit_report.code,
-        ],
+        args=["github", "codecov::::the_repo", commit.commitid, "default"],
     )
     response = client.post(
         url,
@@ -817,7 +792,7 @@ def test_deactivated_repo(db, mocker, mock_redis):
         activated=False,
     )
     commit = CommitFactory(repository=repository)
-    commit_report = CommitReport.objects.create(commit=commit, code="code")
+    commit_report = CommitReport.objects.create(commit=commit)
     repository.save()
     commit_report.save()
 
@@ -826,12 +801,7 @@ def test_deactivated_repo(db, mocker, mock_redis):
     client.force_authenticate(user=owner)
     url = reverse(
         "new_upload.uploads",
-        args=[
-            "github",
-            "codecov::::the_repo",
-            commit.commitid,
-            commit_report.code,
-        ],
+        args=["github", "codecov::::the_repo", commit.commitid, "default"],
     )
     response = client.post(
         url,
@@ -918,7 +888,7 @@ class TestGitlabEnterpriseOIDC(APITestCase):
         token = "ThisValueDoesNotMatterBecauseOf_mock_jwt_decode"
 
         commit = CommitFactory(repository=repository)
-        commit_report = CommitReport.objects.create(commit=commit, code="code")
+        CommitReport.objects.create(commit=commit)
 
         client = APIClient()
         url = reverse(
@@ -927,7 +897,7 @@ class TestGitlabEnterpriseOIDC(APITestCase):
                 "github_enterprise",
                 "codecov::::the_repo",
                 commit.commitid,
-                commit_report.code,
+                "default",
             ],
         )
         response = client.post(
@@ -976,7 +946,7 @@ class TestGitlabEnterpriseOIDC(APITestCase):
         token = "ThisValueDoesNotMatterBecauseOf_mock_jwt_decode"
 
         commit = CommitFactory(repository=repository)
-        commit_report = CommitReport.objects.create(commit=commit, code="code")
+        CommitReport.objects.create(commit=commit)
 
         client = APIClient()
         url = reverse(
@@ -985,7 +955,7 @@ class TestGitlabEnterpriseOIDC(APITestCase):
                 "github_enterprise",
                 "codecov::::the_repo",
                 commit.commitid,
-                commit_report.code,
+                "default",
             ],
         )
         response = client.post(

--- a/apps/codecov-api/upload/tests/views/test_uploads.py
+++ b/apps/codecov-api/upload/tests/views/test_uploads.py
@@ -197,7 +197,7 @@ def test_get_report_error(db):
     )
     with pytest.raises(ValidationError) as exp:
         upload_views.get_report(commit)
-    assert exp.match("Report not found")
+    assert exp.match("Non-default `report_code` has been deprecated")
 
 
 def test_uploads_post(db, mocker, mock_redis):

--- a/apps/codecov-api/upload/views/base.py
+++ b/apps/codecov-api/upload/views/base.py
@@ -68,9 +68,10 @@ class GetterMixin(ShelterMixin):
         ] = CommitReport.ReportType.COVERAGE,
     ) -> CommitReport:
         report_code = self.kwargs.get("report_code")
-        if report_code == "default":
-            report_code = None
-        queryset = CommitReport.objects.filter(code=report_code, commit=commit)
+        if report_code not in (None, "default"):
+            raise ValidationError("Report not found")
+
+        queryset = CommitReport.objects.filter(code=None, commit=commit)
         if report_type == CommitReport.ReportType.COVERAGE:
             queryset = queryset.coverage_reports()
         else:
@@ -79,7 +80,7 @@ class GetterMixin(ShelterMixin):
         if report is None:
             log.warning(
                 "Report not found",
-                extra=dict(commit_sha=commit.commitid, report_code=report_code),
+                extra=dict(commit_sha=commit.commitid),
             )
             raise ValidationError("Report not found")
         if report.report_type is None:

--- a/apps/codecov-api/upload/views/base.py
+++ b/apps/codecov-api/upload/views/base.py
@@ -69,7 +69,7 @@ class GetterMixin(ShelterMixin):
     ) -> CommitReport:
         report_code = self.kwargs.get("report_code")
         if report_code not in (None, "default"):
-            raise ValidationError("Report not found")
+            raise ValidationError("Non-default `report_code` has been deprecated")
 
         queryset = CommitReport.objects.filter(code=None, commit=commit)
         if report_type == CommitReport.ReportType.COVERAGE:

--- a/apps/codecov-api/upload/views/bundle_analysis.py
+++ b/apps/codecov-api/upload/views/bundle_analysis.py
@@ -169,7 +169,6 @@ class BundleAnalysisView(APIView, ShelterMixin):
             "url": storage_path,  # storage_path
             # these are used for dispatching the task below
             "commit": commit.commitid,
-            "report_code": None,
             # custom comparison sha for the current uploaded commit sha
             "bundle_analysis_compare_sha": data.get("compareSha"),
         }

--- a/apps/codecov-api/upload/views/reports.py
+++ b/apps/codecov-api/upload/views/reports.py
@@ -43,9 +43,7 @@ def create_report(
         report_type=CommitReport.ReportType.COVERAGE,
     )
     if was_created:
-        TaskService().preprocess_upload(
-            repository.repoid, commit.commitid, instance.code
-        )
+        TaskService().preprocess_upload(repository.repoid, commit.commitid)
     return instance
 
 

--- a/apps/codecov-api/upload/views/test_results.py
+++ b/apps/codecov-api/upload/views/test_results.py
@@ -183,7 +183,6 @@ class TestResultsView(
             "url": storage_path,  # storage_path
             # these are used for dispatching the task below
             "commit": commit.commitid,
-            "report_code": None,
         }
 
         log.info(

--- a/apps/codecov-api/upload/views/uploads.py
+++ b/apps/codecov-api/upload/views/uploads.py
@@ -115,19 +115,13 @@ def trigger_upload_task(
 ) -> None:
     log.info(
         "Triggering upload task",
-        extra=dict(
-            repo=repository.name,
-            commit=commit_sha,
-            upload_id=upload.id,
-            report_code=report.code,
-        ),
+        extra=dict(repo=repository.name, commit=commit_sha, upload_id=upload.id),
     )
     redis = get_redis_connection()
     task_arguments = {
         "commit": commit_sha,
         "upload_id": upload.id,
         "version": "v4",
-        "report_code": report.code,
         "reportid": str(report.external_id),
     }
     dispatch_upload_task(redis, repository.repoid, task_arguments)

--- a/apps/worker/services/bundle_analysis/report.py
+++ b/apps/worker/services/bundle_analysis/report.py
@@ -108,16 +108,14 @@ class ProcessingResult:
 
 
 class BundleAnalysisReportService(BaseReportService):
-    def initialize_and_save_report(
-        self, commit: Commit, report_code: str | None = None
-    ) -> CommitReport:
+    def initialize_and_save_report(self, commit: Commit) -> CommitReport:
         db_session = commit.get_db_session()
 
         commit_report = (
             db_session.query(CommitReport)
             .filter_by(
                 commit_id=commit.id_,
-                code=report_code,
+                code=None,
                 report_type=ReportType.BUNDLE_ANALYSIS.value,
             )
             .first()
@@ -125,7 +123,7 @@ class BundleAnalysisReportService(BaseReportService):
         if not commit_report:
             commit_report = CommitReport(
                 commit_id=commit.id_,
-                code=report_code,
+                code=None,
                 report_type=ReportType.BUNDLE_ANALYSIS.value,
             )
             db_session.add(commit_report)

--- a/apps/worker/services/test_results.py
+++ b/apps/worker/services/test_results.py
@@ -42,15 +42,13 @@ class TestResultsReportService(BaseReportService):
         super().__init__(current_yaml)
         self.flag_dict = None
 
-    def initialize_and_save_report(
-        self, commit: Commit, report_code: str | None = None
-    ) -> CommitReport:
+    def initialize_and_save_report(self, commit: Commit) -> CommitReport:
         db_session = commit.get_db_session()
         current_report_row = (
             db_session.query(CommitReport)
             .filter_by(
                 commit_id=commit.id_,
-                code=report_code,
+                code=None,
                 report_type=ReportType.TEST_RESULTS.value,
             )
             .first()
@@ -60,7 +58,7 @@ class TestResultsReportService(BaseReportService):
             # or backfilled
             current_report_row = CommitReport(
                 commit_id=commit.id_,
-                code=report_code,
+                code=None,
                 report_type=ReportType.TEST_RESULTS.value,
             )
             db_session.add(current_report_row)

--- a/apps/worker/tasks/manual_trigger.py
+++ b/apps/worker/tasks/manual_trigger.py
@@ -30,13 +30,12 @@ class ManualTriggerTask(
         *,
         repoid: int,
         commitid: str,
-        report_code: str,
         current_yaml=None,
         **kwargs,
     ):
         log.info(
             "Received manual trigger task",
-            extra=dict(repoid=repoid, commit=commitid, report_code=report_code),
+            extra=dict(repoid=repoid, commit=commitid),
         )
         repoid = int(repoid)
         lock_name = f"manual_trigger_lock_{repoid}_{commitid}"
@@ -52,7 +51,6 @@ class ManualTriggerTask(
                     repoid=repoid,
                     commitid=commitid,
                     commit_yaml=current_yaml,
-                    report_code=report_code,
                     **kwargs,
                 )
         except LockError:
@@ -74,7 +72,6 @@ class ManualTriggerTask(
         repoid,
         commitid,
         commit_yaml,
-        report_code,
         **kwargs,
     ):
         commit = (
@@ -89,7 +86,7 @@ class ManualTriggerTask(
             db_session.query(Upload)
             .join(CommitReport)
             .filter(
-                CommitReport.code == report_code,
+                CommitReport.code == None,  # noqa: E711
                 CommitReport.commit == commit,
                 (CommitReport.report_type == None)  # noqa: E711
                 | (CommitReport.report_type == ReportType.COVERAGE.value),

--- a/apps/worker/tasks/tests/unit/test_manual_trigger.py
+++ b/apps/worker/tasks/tests/unit/test_manual_trigger.py
@@ -43,11 +43,7 @@ class TestUploadCompletionTask(object):
         dbsession.add(pull)
         dbsession.flush()
         result = ManualTriggerTask().run_impl(
-            dbsession,
-            repoid=commit.repoid,
-            commitid=commit.commitid,
-            report_code=None,
-            current_yaml={},
+            dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml={}
         )
         assert {
             "notifications_called": True,
@@ -101,7 +97,6 @@ class TestUploadCompletionTask(object):
                 dbsession,
                 repoid=commit.repoid,
                 commitid=commit.commitid,
-                report_code=None,
                 current_yaml={},
             )
             assert {

--- a/apps/worker/tasks/tests/unit/test_preprocess_upload.py
+++ b/apps/worker/tasks/tests/unit/test_preprocess_upload.py
@@ -59,10 +59,7 @@ class TestPreProcessUpload(object):
         commit, report = self.create_commit_and_report(dbsession)
 
         result = PreProcessUpload().process_impl_within_lock(
-            dbsession,
-            repoid=commit.repository.repoid,
-            commitid=commit.commitid,
-            report_code=None,
+            dbsession, repoid=commit.repository.repoid, commitid=commit.commitid
         )
         for sess_id in sample_report.sessions.keys():
             upload = (
@@ -164,10 +161,7 @@ class TestPreProcessUpload(object):
         dbsession.add(commit)
         dbsession.flush()
         res = PreProcessUpload().process_impl_within_lock(
-            db_session=dbsession,
-            repoid=commit.repoid,
-            commitid=commit.commitid,
-            report_code=None,
+            db_session=dbsession, repoid=commit.repoid, commitid=commit.commitid
         )
         assert res == {
             "preprocessed_upload": False,

--- a/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
@@ -305,28 +305,8 @@ class TestUploadFinisherTask(object):
                 commit,
                 commit_yaml,
                 [{"arguments": {"url": "url"}, "successful": True}],
-                None,
             )
             == ShouldCallNotifyResult.NOTIFY
-        )
-
-    def test_should_call_notifications_local_upload(self, dbsession):
-        commit_yaml = {"codecov": {"max_report_age": "1y ago"}}
-        commit = CommitFactory.create(
-            message="dsidsahdsahdsa",
-            commitid="abf6d4df662c47e32460020ab14abf9303581429",
-            repository__owner__unencrypted_oauth_token="testulk3d54rlhxkjyzomq2wh8b7np47xabcrkx8",
-            repository__owner__username="ThiagoCodecov",
-            repository__yaml=commit_yaml,
-        )
-        dbsession.add(commit)
-        dbsession.flush()
-
-        assert (
-            UploadFinisherTask().should_call_notifications(
-                commit, commit_yaml, [], "local_report1"
-            )
-            == ShouldCallNotifyResult.DO_NOT_NOTIFY
         )
 
     def test_should_call_notifications_manual_trigger(self, dbsession):
@@ -342,9 +322,7 @@ class TestUploadFinisherTask(object):
         dbsession.flush()
 
         assert (
-            UploadFinisherTask().should_call_notifications(
-                commit, commit_yaml, [], None
-            )
+            UploadFinisherTask().should_call_notifications(commit, commit_yaml, [])
             == ShouldCallNotifyResult.DO_NOT_NOTIFY
         )
 
@@ -367,7 +345,6 @@ class TestUploadFinisherTask(object):
                 commit,
                 commit_yaml,
                 [{"arguments": {"url": "url"}, "successful": True}],
-                None,
             )
             == ShouldCallNotifyResult.NOTIFY
         )
@@ -403,7 +380,6 @@ class TestUploadFinisherTask(object):
                 commit,
                 commit_yaml,
                 12 * [{"arguments": {"url": "url"}, "successful": False}],
-                None,
             )
             == result
         )
@@ -431,7 +407,6 @@ class TestUploadFinisherTask(object):
                 commit,
                 commit_yaml,
                 9 * [{"arguments": {"url": "url"}, "successful": True}],
-                None,
             )
             == ShouldCallNotifyResult.DO_NOT_NOTIFY
         )
@@ -459,7 +434,6 @@ class TestUploadFinisherTask(object):
                 commit,
                 commit_yaml,
                 2 * [{"arguments": {"url": "url"}, "successful": True}],
-                None,
             )
             == ShouldCallNotifyResult.NOTIFY
         )
@@ -479,11 +453,7 @@ class TestUploadFinisherTask(object):
 
         _start_upload_flow(mocker)
         res = UploadFinisherTask().finish_reports_processing(
-            dbsession,
-            commit,
-            UserYaml(commit_yaml),
-            [{"successful": True}],
-            None,
+            dbsession, commit, UserYaml(commit_yaml), [{"successful": True}]
         )
         assert res == {"notifications_called": True}
         mocked_app.tasks["app.tasks.notify.Notify"].apply_async.assert_called_with(
@@ -533,11 +503,7 @@ class TestUploadFinisherTask(object):
 
         _start_upload_flow(mocker)
         res = UploadFinisherTask().finish_reports_processing(
-            dbsession,
-            commit,
-            UserYaml(commit_yaml),
-            [{"successful": True}],
-            None,
+            dbsession, commit, UserYaml(commit_yaml), [{"successful": True}]
         )
         assert res == {"notifications_called": True}
         mocked_app.tasks["app.tasks.notify.Notify"].apply_async.assert_called_with(
@@ -592,11 +558,7 @@ class TestUploadFinisherTask(object):
 
         _start_upload_flow(mocker)
         res = UploadFinisherTask().finish_reports_processing(
-            dbsession,
-            commit,
-            UserYaml(commit_yaml),
-            [{"successful": False}],
-            None,
+            dbsession, commit, UserYaml(commit_yaml), [{"successful": False}]
         )
         assert res == {"notifications_called": False}
         if notify_error:

--- a/apps/worker/tasks/tests/unit/test_upload_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_task.py
@@ -195,7 +195,6 @@ class TestUploadTaskIntegration(object):
             repoid=commit.repoid,
             commitid="abf6d4df662c47e32460020ab14abf9303581429",
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},
-            report_code=None,
         )
         kwargs[_kwargs_key(UploadFlow)] = mocker.ANY
         finisher = upload_finisher_task.signature(kwargs=kwargs)
@@ -802,7 +801,6 @@ class TestUploadTaskIntegration(object):
             repoid=commit.repoid,
             commitid="abf6d4df662c47e32460020ab14abf9303581429",
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},
-            report_code=None,
         )
         kwargs[_kwargs_key(UploadFlow)] = mocker.ANY
         t_final = upload_finisher_task.signature(kwargs=kwargs)
@@ -1237,7 +1235,6 @@ class TestUploadTaskUnit(object):
                 "repoid": commit.repoid,
                 "commitid": commit.commitid,
                 "commit_yaml": commit_yaml,
-                "report_code": None,
                 _kwargs_key(UploadFlow): mocker.ANY,
             }
         )


### PR DESCRIPTION
This removes all the places where a non-default `report_code` is being passed around and used. It also changes the view serializer to reject any non-"default" `code` as well.