### PR TITLE
fix: Fix failure rate in public API

### DIFF
--- a/apps/codecov-api/README.md
+++ b/apps/codecov-api/README.md
@@ -1,3 +1,7 @@
+# PHASED OUT
+
+This project has been moved to [the `apps/codecov-api` folder in our `umbrella` repository](https://github.com/codecov/umbrella/tree/main/apps/codecov-api). Please contribute there instead.
+
 ## Codecov API
 
 > We believe that everyone should have access to quality software (like Sentry), that’s why we have always offered Codecov for free to open source maintainers.

--- a/apps/codecov-api/api/public/v2/test_results/serializers.py
+++ b/apps/codecov-api/api/public/v2/test_results/serializers.py
@@ -1,3 +1,4 @@
+from django.db.models import Count, Q
 from rest_framework import serializers
 
 from reports.models import TestInstance
@@ -13,14 +14,32 @@ class TestInstanceSerializer(serializers.ModelSerializer):
     outcome = serializers.CharField(label="outcome")
     branch = serializers.CharField(label="branch name")
     repoid = serializers.IntegerField(label="repo id")
-    failure_rate = serializers.FloatField(
-        source="test.failure_rate", read_only=True, label="failure rate"
-    )
+    failure_rate = serializers.SerializerMethodField(label="failure rate")
     commits_where_fail = serializers.ListField(
         source="test.commits_where_fail",
         read_only=True,
         label="commits where test failed",
     )
+
+    def get_failure_rate(self, obj):
+        """Calculate the failure rate for a test.
+        The failure rate is calculated as:
+        number of failed test runs / total number of test runs
+        Returns:
+            float: A value between 0.0 and 1.0 representing the failure rate
+                  0.0 means no failures
+                  1.0 means all runs failed
+        """
+        stats = TestInstance.objects.filter(test=obj.test).aggregate(
+            total=Count("id"),
+            failures=Count("id", filter=Q(outcome=TestInstance.Outcome.FAILURE.value)),
+        )
+
+        total_runs = stats["total"]
+        if total_runs == 0:
+            return 0.0
+
+        return stats["failures"] / total_runs
 
     class Meta:
         model = TestInstance

--- a/apps/codecov-api/api/public/v2/tests/test_test_results_view.py
+++ b/apps/codecov-api/api/public/v2/tests/test_test_results_view.py
@@ -53,6 +53,7 @@ class TestResultsViewsetTests(InternalAPITest):
                     "outcome": self.test_instances[0].outcome,
                     "branch": self.test_instances[0].branch,
                     "repoid": self.test_instances[0].repoid,
+                    "failure_rate": 1.0,
                 },
                 {
                     "id": self.test_instances[1].id,
@@ -64,6 +65,7 @@ class TestResultsViewsetTests(InternalAPITest):
                     "outcome": self.test_instances[1].outcome,
                     "branch": self.test_instances[1].branch,
                     "repoid": self.test_instances[1].repoid,
+                    "failure_rate": 1.0,
                 },
             ],
             "total_pages": 1,
@@ -95,6 +97,7 @@ class TestResultsViewsetTests(InternalAPITest):
                     "outcome": self.test_instances[0].outcome,
                     "branch": self.test_instances[0].branch,
                     "repoid": self.test_instances[0].repoid,
+                    "failure_rate": 1.0,
                 },
             ],
             "total_pages": 1,
@@ -125,6 +128,7 @@ class TestResultsViewsetTests(InternalAPITest):
             "outcome": self.test_instances[0].outcome,
             "branch": self.test_instances[0].branch,
             "repoid": self.test_instances[0].repoid,
+            "failure_rate": 1.0,
         }
 
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
@@ -226,4 +230,5 @@ class TestResultsViewsetTests(InternalAPITest):
             "outcome": self.test_instances[0].outcome,
             "branch": self.test_instances[0].branch,
             "repoid": self.test_instances[0].repoid,
+            "failure_rate": 1.0,
         }


### PR DESCRIPTION
(migrated from https://github.com/codecov/codecov-api/pull/1302)

### Purpose/Motivation
What is the feature? Why is this being done?
Apparently, failure_rate was removed in a recent migration. This PR fetches the correct failure rate for users by dividing the number of failed runs by the total number of test runs.

### Links to relevant tickets
https://github.com/codecov/codecov-api/issues/1274

<!--

 Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.