### PR TITLE
move lint commands to root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,33 @@ shared.%:
 # Development environment targets
 ######
 include tools/devenv/Makefile.devenv
+
+lint:
+	make lint.install
+	make lint.run
+
+# used for CI
+lint.install:
+	echo "Installing..."
+	pip install -Iv ruff
+
+lint.local:
+	make lint.install.local
+	make lint.run
+
+lint.install.local:
+	echo "Installing..."
+	uv add --dev ruff
+
+# The preferred method (for now) w.r.t. fixable rules is to manually update the makefile
+# with --fix and re-run 'make lint.' Since ruff is constantly adding rules this is a slight
+# amount of "needed" friction imo.
+lint.run:
+	ruff check
+	ruff format
+
+lint.check:
+	echo "Linting..."
+	ruff check
+	echo "Formatting..."
+	ruff format --check

--- a/apps/codecov-api/Makefile
+++ b/apps/codecov-api/Makefile
@@ -46,32 +46,6 @@ test.unit:
 test.integration:
 	COVERAGE_CORE=sysmon pytest --cov=./ -m "integration" --cov-report=xml:integration.coverage.xml --junitxml=integration.junit.xml -o junit_family=legacy -c pytest.ini --rootdir=${PYTEST_ROOTDIR}
 
-lint:
-	make lint.install
-	make lint.run
-
-lint.install:
-	echo "Installing..."
-	pip install -Iv ruff
-
-lint.local:
-	make lint.install.local
-	make lint.run
-
-lint.install.local:
-	echo "Installing..."
-	uv add --dev ruff
-
-lint.run:
-	ruff check
-	ruff format
-
-lint.check:
-	echo "Linting..."
-	ruff check
-	echo "Formatting..."
-	ruff format --check
-
 build.requirements:
 	# If make was given a different requirements tag, we assume a suitable image
 	# was already built (e.g. by umbrella) and don't want to build this one.

--- a/apps/worker/Makefile
+++ b/apps/worker/Makefile
@@ -60,36 +60,6 @@ test.unit:
 test.integration:
 	COVERAGE_CORE=sysmon pytest --cov=./ -m "integration" --cov-report=xml:integration.coverage.xml --junitxml=integration.junit.xml -o junit_family=legacy -c pytest.ini --rootdir=${PYTEST_ROOTDIR}
 
-lint:
-	make lint.install
-	make lint.run
-
-# used for CI
-lint.install:
-	echo "Installing..."
-	pip install -Iv ruff
-
-lint.local:
-	make lint.install.local
-	make lint.run
-
-lint.install.local:
-	echo "Installing..."
-	uv add --dev ruff
-
-# The preferred method (for now) w.r.t. fixable rules is to manually update the makefile
-# with --fix and re-run 'make lint.' Since ruff is constantly adding rules this is a slight
-# amount of "needed" friction imo.
-lint.run:
-	ruff check
-	ruff format
-
-lint.check:
-	echo "Linting..."
-	ruff check
-	echo "Formatting..."
-	ruff format --check
-
 build.requirements:
 	# If make was given a different requirements tag, we assume a suitable image
 	# was already built (e.g. by umbrella) and don't want to build this one.

--- a/libs/shared/Makefile
+++ b/libs/shared/Makefile
@@ -18,24 +18,6 @@ test:
 test.path:
 	docker compose exec shared uv run pytest $(TEST_PATH)
 
-lint:
-	make lint.install
-	make lint.run
-
-lint.install:
-	echo "Installing..."
-	pip install -Iv ruff
-
-lint.run:
-	ruff check
-	ruff format
-
-lint.check:
-	echo "Linting..."
-	ruff check --fix
-	echo "Formatting..."
-	ruff format --check
-
 requirements.install:
 	uv sync
 	. .venv/bin/activate


### PR DESCRIPTION
I like running the lint commands from the root of the project I'm working on.

We had the lint commands duplicated across the 3 projects, this pr adds them to umbrella's Makefile and removes the duplicated code from the other Makefiles