### PR TITLE
Fix old upload cleanup

### DIFF
--- a/apps/worker/services/cleanup/uploads.py
+++ b/apps/worker/services/cleanup/uploads.py
@@ -23,8 +23,8 @@ def cleanup_old_uploads(context: CleanupContext) -> CleanupSummary:
             if len(upload_ids) == 0:
                 break
 
-            query = Upload.objects.filter(pk__in=upload_ids)
-            summary = run_cleanup(query, context=context)
+            uploads_query = Upload.objects.filter(pk__in=upload_ids)
+            summary = run_cleanup(uploads_query, context=context)
 
             complete_summary.add(summary)
 


### PR DESCRIPTION
Now that the cleanup has been changed to work on chunks, it seems to run fine.

Except that there was a bug and I was overwriting / shadowing the `query` variable. So the cleanup was only running a single iteration of the chunk cleanup loop.