### PR TITLE
remove branch filter for PRs in enforce-license-compliance.yml

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -2,7 +2,6 @@ name: Enforce License Compliance
 
 on:
   pull_request:
-    branches: [main, master]
   merge_group:
     branches:
       - main


### PR DESCRIPTION
i am trying a tool that stacks PRs and i need this workflow to run for everything in the stack

- https://github.com/codecov/umbrella/pull/87 was based on main
- https://github.com/codecov/umbrella/pull/88 was based on the above
- https://github.com/codecov/umbrella/pull/89 was based on the above
- https://github.com/codecov/umbrella/pull/90 was based on the above

each one needs this job to trigger