### PR TITLE
chore: suppress Sentry error from token refresh failure

### DIFF
--- a/libs/shared/shared/torngit/github.py
+++ b/libs/shared/shared/torngit/github.py
@@ -1028,8 +1028,12 @@ class Github(TorngitBaseAdapter):
                 }
             )
             return self.token
-        # https://docs.github.com/apps/managing-oauth-apps/troubleshooting-oauth-app-access-token-request-errors
-        log.error(
+
+        # See https://github.com/codecov/internal-issues/issues/1234
+        # TL;DR this can be the result of a race condition when a refresh
+        # should be succeeding. We've decided to not prioritize a fix for now.
+        # Changed from log.error to log.warning to supress Sentry spam.
+        log.warning(
             dict(
                 error="No access_token in response",
                 gh_error=session.get("error"),


### PR DESCRIPTION
Prevent the error log that occurs when token refresh fails from bubbling up to Sentry.

Resolves https://codecov.sentry.io/issues/4530397997/events/ab8faf32f54247a9a3c9fac416a7a757/