### PR TITLE
chore: remove log that is extremely noisy in dev envs

### DIFF
--- a/libs/shared/shared/rollouts/__init__.py
+++ b/libs/shared/shared/rollouts/__init__.py
@@ -128,10 +128,6 @@ class Feature:
         self.refresh = get_config(
             "setup", "skip_feature_cache", default=False
         )  # to be used only during development
-        if self.refresh:
-            log.warning(
-                "skip_feature_cache for Feature should only be turned on in development environments, and should not be used in production"
-            )
 
     def check_value(self, identifier, default=False):
         """


### PR DESCRIPTION
this fires constantly and makes logs much less useful