### PR TITLE
fix: typo in lint CI name and unnecessary docker-compose dep

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Runt Lint
+    name: Run Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,8 +71,6 @@ services:
       - postgres
       - redis
       - timescale
-      # Make worker block on API so API can run migrations first
-      - api
 
   # Dummy service to run shared tests
   shared:


### PR DESCRIPTION
required checks are based on the name so before i make the lint check required i should fix the typo

also i originally made `worker` depend on `api` in `docker-compose.yml` so that the latter would run migrations first. turns out that didn't work and they still raced, so now there is `make devenv.migrate`. this PR removes that dependency which will slightly improve startup and teardown time