### PR TITLE
Improve cleanup progress reporting and scheduling

### DIFF
--- a/apps/worker/services/cleanup/cleanup.py
+++ b/apps/worker/services/cleanup/cleanup.py
@@ -1,71 +1,35 @@
-import contextlib
 import logging
 
 from django.db.models.query import QuerySet
 
 from services.cleanup.models import MANUAL_CLEANUP
 from services.cleanup.relations import build_relation_graph
-from services.cleanup.utils import (
-    CleanupContext,
-    CleanupResult,
-    CleanupSummary,
-    cleanup_context,
-)
+from services.cleanup.utils import CleanupContext
 
 log = logging.getLogger(__name__)
 
 
-def run_cleanup(
-    query: QuerySet,
-    context: CleanupContext | None = None,
-) -> CleanupSummary:
+def cleanup_queryset(query: QuerySet, context: CleanupContext):
     """
     Cleans up all the models and storage files reachable from the given `QuerySet`.
 
     This deletes all database models in topological sort order, and also removes
     all the files in storage for any of the models in the relationship graph.
-
-    Returns the number of models and files being cleaned up in total, and per-Model.
     """
     models_to_cleanup = build_relation_graph(query)
 
-    summary = {}
-    cleaned_models = 0
-    cleaned_files = 0
+    for relation in models_to_cleanup:
+        model = relation.model
+        context.set_current_model(model)
 
-    cm = contextlib.nullcontext(context) if context else cleanup_context()
-    with cm as context:
-        for relation in models_to_cleanup:
-            model = relation.model
-            result = CleanupResult(0)
+        for query in relation.querysets:
+            # This is needed so that the correct connection is chosen for the
+            # `_raw_delete` queries, as otherwise it might chose a readonly connection.
+            query._for_write = True
 
-            for query in relation.querysets:
-                # This is needed so that the correct connection is chosen for the
-                # `_raw_delete` queries, as otherwise it might chose a readonly connection.
-                query._for_write = True
-
-                manual_cleanup = MANUAL_CLEANUP.get(model)
-                if manual_cleanup is not None:
-                    query_result = manual_cleanup(context, query)
-                else:
-                    query_result = CleanupResult(query._raw_delete(query.db))
-
-                result.cleaned_models += query_result.cleaned_models
-                result.cleaned_files += query_result.cleaned_files
-
-            if result.cleaned_models > 0 or result.cleaned_files > 0:
-                summary[model] = result
-
-                log.info(
-                    f"Finished cleaning up `{model.__name__}`",
-                    extra={
-                        "cleaned_models": result.cleaned_models,
-                        "cleaned_files": result.cleaned_files,
-                    },
-                )
-
-            cleaned_models += result.cleaned_models
-            cleaned_files += result.cleaned_files
-
-    totals = CleanupResult(cleaned_models, cleaned_files)
-    return CleanupSummary(totals, summary)
+            manual_cleanup = MANUAL_CLEANUP.get(model)
+            if manual_cleanup is not None:
+                manual_cleanup(context, query)
+            else:
+                cleaned_models = query._raw_delete(query.db)
+                context.add_progress(cleaned_models)

--- a/apps/worker/services/cleanup/regular.py
+++ b/apps/worker/services/cleanup/regular.py
@@ -1,44 +1,48 @@
 import logging
 import random
+from collections.abc import Callable
+from functools import partial
 
-from django.db.models.query import QuerySet
-
-from services.cleanup.cleanup import run_cleanup
+from services.cleanup.cleanup import cleanup_queryset
 from services.cleanup.uploads import cleanup_old_uploads
-from services.cleanup.utils import CleanupResult, CleanupSummary, cleanup_context
+from services.cleanup.utils import CleanupContext, CleanupSummary, cleanup_context
 from shared.django_apps.reports.models import CommitReport
 from shared.django_apps.staticanalysis.models import StaticAnalysisSingleFileSnapshot
 
 log = logging.getLogger(__name__)
 
+CleanupJob = Callable[[CleanupContext], None]
+
 
 def run_regular_cleanup() -> CleanupSummary:
     log.info("Starting regular cleanup job")
-    complete_summary = CleanupSummary(CleanupResult(0), summary={})
 
-    cleanups_to_run: list[QuerySet] = [
-        StaticAnalysisSingleFileSnapshot.objects.all(),
-        CommitReport.objects.filter(code__isnull=False),
+    cleanup_jobs: list[tuple[str, CleanupJob]] = [
+        (
+            "Static Analysis Files",
+            partial(cleanup_queryset, StaticAnalysisSingleFileSnapshot.objects.all()),
+        ),
+        (
+            '`CommitReport`s for "local uploads"',
+            partial(cleanup_queryset, CommitReport.objects.filter(code__isnull=False)),
+        ),
+        ("old `Upload`s", cleanup_old_uploads),
+        # TODO: add the `flare_cleanup` here as well
     ]
-
-    # as we expect this job to have frequent retries, and cleanup to take a long time,
-    # lets shuffle the various cleanups so that each one of those makes a little progress.
-    random.shuffle(cleanups_to_run)
-
-    with cleanup_context() as context:
-        for query in cleanups_to_run:
-            name = query.model.__name__
-            log.info(f"Cleaning up `{name}`")
-            summary = run_cleanup(query, context=context)
-            log.info(f"Cleaned up `{name}`", extra={"summary": summary})
-            complete_summary.add(summary)
-
-        summary = cleanup_old_uploads(context)
-        complete_summary.add(summary)
 
     # TODO:
     # - cleanup `Commit`s that are `deleted`
     # - figure out a way how we can first mark, and then fully delete `Branch`es
 
+    # as we expect this job to have frequent retries, and cleanup to take a long time,
+    # lets shuffle the various cleanups so that each one of those makes a little progress.
+    random.shuffle(cleanup_jobs)
+
+    with cleanup_context() as context:
+        for description, job in cleanup_jobs:
+            log.info(f"Starting cleanup for {description}…")
+            job(context)
+        summary = context.summary
+
     log.info("Regular cleanup finished")
-    return complete_summary
+    return summary

--- a/apps/worker/services/cleanup/tests/test_regular_cleanup.py
+++ b/apps/worker/services/cleanup/tests/test_regular_cleanup.py
@@ -5,12 +5,10 @@ from services.cleanup.utils import CleanupResult, CleanupSummary
 from shared.api_archive.archive import ArchiveService
 from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
 from shared.django_apps.reports.models import CommitReport
-from shared.django_apps.reports.models import ReportSession as Upload
 from shared.django_apps.reports.tests.factories import (
     CommitReportFactory,
     UploadFactory,
 )
-from shared.django_apps.staticanalysis.models import StaticAnalysisSingleFileSnapshot
 from shared.django_apps.staticanalysis.tests.factories import (
     StaticAnalysisSingleFileSnapshotFactory,
 )
@@ -55,9 +53,9 @@ def test_runs_regular_cleanup(mock_storage):
     assert summary == CleanupSummary(
         CleanupResult(3, 3),
         {
-            Upload: CleanupResult(1, 1),
-            StaticAnalysisSingleFileSnapshot: CleanupResult(1, 1),
-            CommitReport: CleanupResult(1, 1),
+            "ReportSession": CleanupResult(1, 1),
+            "StaticAnalysisSingleFileSnapshot": CleanupResult(1, 1),
+            "CommitReport": CleanupResult(1, 1),
         },
     )
     assert len(archive) == 2

--- a/apps/worker/services/cleanup/tests/test_upload_cleanup.py
+++ b/apps/worker/services/cleanup/tests/test_upload_cleanup.py
@@ -62,7 +62,7 @@ def test_regular_upload_cleanup(mock_storage):
     assert summary == CleanupSummary(
         CleanupResult(2, 2),
         {
-            Upload: CleanupResult(2, 2),
+            "ReportSession": CleanupResult(2, 2),
         },
     )
     assert len(archive) == 3

--- a/apps/worker/services/cleanup/utils.py
+++ b/apps/worker/services/cleanup/utils.py
@@ -1,4 +1,6 @@
 import dataclasses
+import logging
+import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 
@@ -8,31 +10,7 @@ import shared.storage
 from shared.config import get_config
 from shared.storage.base import BaseStorageService
 
-
-class CleanupContext:
-    threadpool: ThreadPoolExecutor
-    storage: BaseStorageService
-    default_bucket: str
-    bundleanalysis_bucket: str
-
-    def __init__(self):
-        self.threadpool = ThreadPoolExecutor()
-        self.storage = shared.storage.get_appropriate_storage_service()
-        self.default_bucket = get_config(
-            "services", "minio", "bucket", default="archive"
-        )
-        self.bundleanalysis_bucket = get_config(
-            "bundle_analysis", "bucket_name", default="bundle-analysis"
-        )
-
-
-@contextmanager
-def cleanup_context():
-    context = CleanupContext()
-    try:
-        yield context
-    finally:
-        context.threadpool.shutdown()
+log = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
@@ -44,16 +22,64 @@ class CleanupResult:
 @dataclasses.dataclass
 class CleanupSummary:
     totals: CleanupResult
-    summary: dict[type[Model], CleanupResult]
+    summary: dict[str, CleanupResult]
 
-    def add(self, other: "CleanupSummary"):
-        self.totals.cleaned_models += other.totals.cleaned_models
-        self.totals.cleaned_files += other.totals.cleaned_files
 
-        for model, other_result in other.summary.items():
-            if model not in self.summary:
-                self.summary[model] = CleanupResult(0)
-            result = self.summary[model]
+class CleanupContext:
+    threadpool: ThreadPoolExecutor
+    storage: BaseStorageService
+    default_bucket: str
+    bundleanalysis_bucket: str
+    summary: CleanupSummary
 
-            result.cleaned_models += other_result.cleaned_models
-            result.cleaned_files += other_result.cleaned_files
+    _current_model: str | None = None
+    _last_progress_report: float
+
+    def __init__(self):
+        self.threadpool = ThreadPoolExecutor()
+        self.storage = shared.storage.get_appropriate_storage_service()
+        self.default_bucket = get_config(
+            "services", "minio", "bucket", default="archive"
+        )
+        self.bundleanalysis_bucket = get_config(
+            "bundle_analysis", "bucket_name", default="bundle-analysis"
+        )
+        self.summary = CleanupSummary(CleanupResult(0), {})
+        self._last_progress_report = time.monotonic()
+
+    def set_current_model(self, model: type[Model] | None):
+        self._current_model = model.__name__ if model else None
+
+    def add_progress(
+        self,
+        cleaned_models: int = 0,
+        cleaned_files: int = 0,
+        model: type[Model] | None = None,
+    ):
+        self.summary.totals.cleaned_models += cleaned_models
+        self.summary.totals.cleaned_files += cleaned_files
+
+        model_name = model.__name__ if model else self._current_model
+        if model_name and (cleaned_models or cleaned_files):
+            result = self.summary.summary.setdefault(model_name, CleanupResult(0))
+            result.cleaned_models += cleaned_models
+            result.cleaned_files += cleaned_files
+
+        now = time.monotonic()
+        if (now - self._last_progress_report) > 120.0:
+            self._last_progress_report = now
+            log.info("Cleanup is making progress…", extra={"summary": self.summary})
+
+
+@contextmanager
+def cleanup_context():
+    context = CleanupContext()
+    try:
+        yield context
+        context.set_current_model(None)
+    finally:
+        msg = (
+            "Cleanup was interrupted" if context._current_model else "Cleanup completed"
+        )
+        log.info(msg, extra={"summary": context.summary})
+        context.threadpool.shutdown()

--- a/apps/worker/tasks/tests/unit/test_delete_owner.py
+++ b/apps/worker/tasks/tests/unit/test_delete_owner.py
@@ -8,10 +8,7 @@ from shared.django_apps.codecov_auth.tests.factories import OwnerFactory
 from shared.django_apps.compare.models import CommitComparison
 from shared.django_apps.compare.tests.factories import CommitComparisonFactory
 from shared.django_apps.core.models import Branch, Commit, Pull, Repository
-from shared.django_apps.core.tests.factories import (
-    CommitFactory,
-    RepositoryFactory,
-)
+from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
 from shared.django_apps.reports.models import (
     CommitReport,
     DailyTestRollup,
@@ -43,11 +40,11 @@ def test_delete_owner_deletes_owner_with_ownerid(mock_storage):
     assert res == CleanupSummary(
         CleanupResult(5),
         {
-            Branch: CleanupResult(1),
-            Commit: CleanupResult(1),
-            Owner: CleanupResult(1),
-            Pull: CleanupResult(1),
-            Repository: CleanupResult(1),
+            "Branch": CleanupResult(1),
+            "Commit": CleanupResult(1),
+            "Owner": CleanupResult(1),
+            "Pull": CleanupResult(1),
+            "Repository": CleanupResult(1),
         },
     )
 
@@ -85,17 +82,17 @@ def test_delete_owner_deletes_owner_with_commit_compares(mock_storage):
     assert res == CleanupSummary(
         CleanupResult(12),
         {
-            Branch: CleanupResult(1),
-            Commit: CleanupResult(2),
-            CommitComparison: CleanupResult(1),
-            Owner: CleanupResult(1),
-            Pull: CleanupResult(1),
-            Repository: CleanupResult(1),
-            CommitReport: CleanupResult(1),
-            Upload: CleanupResult(1),
-            Test: CleanupResult(1),
-            TestInstance: CleanupResult(1),
-            DailyTestRollup: CleanupResult(1),
+            "Branch": CleanupResult(1),
+            "Commit": CleanupResult(2),
+            "CommitComparison": CleanupResult(1),
+            "Owner": CleanupResult(1),
+            "Pull": CleanupResult(1),
+            "Repository": CleanupResult(1),
+            "CommitReport": CleanupResult(1),
+            "ReportSession": CleanupResult(1),
+            "Test": CleanupResult(1),
+            "TestInstance": CleanupResult(1),
+            "DailyTestRollup": CleanupResult(1),
         },
     )
 
@@ -124,7 +121,7 @@ def test_delete_owner_from_orgs_removes_ownerid_from_organizations_of_related_ow
 
     res = DeleteOwnerTask().run_impl({}, org.ownerid)
 
-    assert res.summary[Owner] == CleanupResult(1)
+    assert res.summary["Owner"] == CleanupResult(1)
 
     user_1 = Owner.objects.get(pk=user_1.ownerid)
     assert user_1.organizations == []

--- a/apps/worker/tasks/tests/unit/test_flare_cleanup.py
+++ b/apps/worker/tasks/tests/unit/test_flare_cleanup.py
@@ -1,8 +1,16 @@
 from unittest.mock import call
 
+from services.cleanup.utils import CleanupResult, CleanupSummary
 from shared.django_apps.core.models import Pull, PullStates
 from shared.django_apps.core.tests.factories import PullFactory, RepositoryFactory
 from tasks.flare_cleanup import FlareCleanupTask
+
+
+def mk_summary(cleaned_files: int) -> CleanupSummary:
+    summary = {}
+    if cleaned_files:
+        summary = {"Pull": CleanupResult(0, cleaned_files)}
+    return {"summary": CleanupSummary(CleanupResult(0, cleaned_files), summary)}
 
 
 class TestFlareCleanupTask(object):
@@ -67,6 +75,7 @@ class TestFlareCleanupTask(object):
             [
                 call("Starting FlareCleanupTask"),
                 call("FlareCleanupTask cleared 1 database flares"),
+                call("Cleanup completed", extra=mk_summary(1)),
                 call("FlareCleanupTask cleared 1 Archive flares"),
             ]
         )
@@ -108,6 +117,7 @@ class TestFlareCleanupTask(object):
             [
                 call("Starting FlareCleanupTask"),
                 call("FlareCleanupTask cleared 0 database flares"),
+                call("Cleanup completed", extra=mk_summary(0)),
                 call("FlareCleanupTask cleared 0 Archive flares"),
             ]
         )
@@ -157,6 +167,7 @@ class TestFlareCleanupTask(object):
             [
                 call("Starting FlareCleanupTask"),
                 call("FlareCleanupTask cleared 3 database flares"),
+                call("Cleanup completed", extra=mk_summary(3)),
                 call("FlareCleanupTask cleared 3 Archive flares"),
             ]
         )

--- a/apps/worker/tasks/tests/unit/test_flush_repo.py
+++ b/apps/worker/tasks/tests/unit/test_flush_repo.py
@@ -3,20 +3,16 @@ import pytest
 from services.cleanup.utils import CleanupResult, CleanupSummary
 from shared.api_archive.archive import ArchiveService
 from shared.bundle_analysis import StoragePaths
-from shared.django_apps.compare.models import CommitComparison, FlagComparison
 from shared.django_apps.compare.tests.factories import (
     CommitComparisonFactory,
     FlagComparisonFactory,
 )
-from shared.django_apps.core.models import Branch, Commit, Pull, Repository
 from shared.django_apps.core.tests.factories import (
     BranchFactory,
     CommitFactory,
     PullFactory,
     RepositoryFactory,
 )
-from shared.django_apps.reports.models import CommitReport, RepositoryFlag
-from shared.django_apps.reports.models import ReportSession as Upload
 from shared.django_apps.reports.tests.factories import (
     CommitReportFactory,
     RepositoryFlagFactory,
@@ -35,7 +31,7 @@ def test_flush_repo_nothing(mock_storage):
     assert res == CleanupSummary(
         CleanupResult(1),
         {
-            Repository: CleanupResult(1),
+            "Repository": CleanupResult(1),
         },
     )
 
@@ -73,13 +69,13 @@ def test_flush_repo_few_of_each_only_db_objects(mock_storage):
     assert res == CleanupSummary(
         CleanupResult(24 + 16 + 4 + 4 + 18 + 1 + 1),
         {
-            Branch: CleanupResult(24),
-            Commit: CleanupResult(16),
-            CommitComparison: CleanupResult(4),
-            FlagComparison: CleanupResult(4),
-            Pull: CleanupResult(18),
-            Repository: CleanupResult(1),
-            RepositoryFlag: CleanupResult(1),
+            "Branch": CleanupResult(24),
+            "Commit": CleanupResult(16),
+            "CommitComparison": CleanupResult(4),
+            "FlagComparison": CleanupResult(4),
+            "Pull": CleanupResult(18),
+            "Repository": CleanupResult(1),
+            "RepositoryFlag": CleanupResult(1),
         },
     )
 
@@ -128,12 +124,12 @@ def test_flush_repo_little_bit_of_everything(mocker, mock_storage):
     assert res == CleanupSummary(
         CleanupResult(24 + 8 + 16 + 18 + 1 + 16, 16 + 16),
         {
-            Branch: CleanupResult(24),
-            Commit: CleanupResult(8),
-            CommitReport: CleanupResult(16, 16),
-            Pull: CleanupResult(18),
-            Repository: CleanupResult(1),
-            Upload: CleanupResult(16, 16),
+            "Branch": CleanupResult(24),
+            "Commit": CleanupResult(8),
+            "CommitReport": CleanupResult(16, 16),
+            "Pull": CleanupResult(18),
+            "Repository": CleanupResult(1),
+            "ReportSession": CleanupResult(16, 16),
         },
     )
     assert len(archive) == 0


### PR DESCRIPTION
This improves regular cleanup scheduling by integrating queryset-based cleanups with fn-based ones.

The progress reporting is changed in such a way that progress is logged regularly in a debounced fashion, as well as logging a summary once the contextmanager either finished regularly, or is being aborted due to a timeout.