### PR TITLE
chore: pre-commit hook for running uv sync automatically

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,33 @@ repos:
     - id: ruff
       args: [ --fix ]
     - id: ruff-format
+- repo: local
+  hooks:
+    - id: uv-sync-shared
+      name: uv sync for shared
+      entry: tools/devenv/scripts/uv-sync.sh
+      files: ^libs/shared/pyproject.toml$
+      args: [ shared ]
+      language: script
+      types: [file]
+    - id: uv-sync-worker
+      name: uv sync for worker
+      entry: tools/devenv/scripts/uv-sync.sh
+      files: ^(apps/worker|libs/shared)/pyproject.toml$
+      args: [ worker ]
+      language: script
+      types: [file]
+    - id: uv-sync-codecov-api
+      name: uv sync for api
+      entry: tools/devenv/scripts/uv-sync.sh
+      files: ^(apps/codecov-api|libs/shared)/pyproject.toml$
+      args: [ codecov-api ]
+      language: script
+      types: [file]
+    - id: uv-sync-umbrella
+      name: uv sync for umbrella
+      entry: tools/devenv/scripts/uv-sync.sh
+      files: ^pyproject.toml$
+      args: [ umbrella ]
+      language: script
+      types: [file]

--- a/tools/devenv/scripts/uv-sync.sh
+++ b/tools/devenv/scripts/uv-sync.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+proj=$1
+
+case $proj in
+    "shared")
+        cd $(git rev-parse --show-toplevel)/libs/shared
+        ;;
+    "worker")
+        cd $(git rev-parse --show-toplevel)/apps/worker
+        ;;
+    "codecov-api")
+        cd $(git rev-parse --show-toplevel)/apps/codecov-api
+        ;;
+    "umbrella")
+        cd $(git rev-parse --show-toplevel)
+        ;;
+    *)
+        echo "Unknown uv project"
+        exit 1
+        ;;
+esac
+
+uv sync --frozen
+
+if [ "$(git diff --name-only uv.lock)" != '' ]; then
+    echo "\`uv sync\` made new changes for $proj. Please review and then commit again."
+    exit 1
+fi
+
+echo "All good"
+exit 0


### PR DESCRIPTION
we are in the habit of running `uv sync` for a project when we change its `pyproject.toml`, but it seems like it will be easy to forget that when you modify `libs/shared/pyproject.toml` you have to run `uv sync --frozen` in _three_ places: `libs/shared`, `apps/worker`, and `apps/codecov-api`. this PR adds a pre-commit hook that will make sure `uv sync --frozen` is run properly.

when shared is no longer its own package, we can get rid of the shared-related bits. and when umbrella has a unified pyproject.toml, we can simplify even further