### PR TITLE
fix: use correct invocation of migrate_timeseries.py in devenv startup

### DIFF
--- a/tools/devenv/scripts/start-worker.sh
+++ b/tools/devenv/scripts/start-worker.sh
@@ -21,7 +21,7 @@ fi
 
 python manage.py migrate
 python manage.py migrate --database "timeseries"
-python manage.py migrate_timeseries.py
+python migrate_timeseries.py
 
 # Auto-restart worker when Python files change.
 watchmedo auto-restart \


### PR DESCRIPTION
https://github.com/codecov/umbrella/pull/72 invokes this script in two different ways. this way is apparently wrong so i changed it to the other way