### PR TITLE
Add `mock_storage` to a bunch more places

### DIFF
--- a/apps/worker/services/bundle_analysis/notify/contexts/tests/test_comment_context.py
+++ b/apps/worker/services/bundle_analysis/notify/contexts/tests/test_comment_context.py
@@ -58,7 +58,7 @@ class TestBundleAnalysisPRCommentNotificationContext:
     )
     @pytest.mark.asyncio
     async def test_load_bundle_comparison_missing_some_info(
-        self, expected_missing_detail, dbsession, mocker
+        self, expected_missing_detail, dbsession, mocker, mock_storage
     ):
         head_commit, base_commit = get_commit_pair(dbsession)
         sink_commit = CommitFactory(repository=head_commit.repository)

--- a/apps/worker/services/bundle_analysis/notify/contexts/tests/test_commit_status_context.py
+++ b/apps/worker/services/bundle_analysis/notify/contexts/tests/test_commit_status_context.py
@@ -60,7 +60,7 @@ class TestBundleAnalysisPRCommentNotificationContext:
     )
     @pytest.mark.asyncio
     async def test_load_bundle_comparison_missing_some_info(
-        self, expected_missing_detail, dbsession, mocker
+        self, expected_missing_detail, dbsession, mocker, mock_storage
     ):
         head_commit, base_commit = get_commit_pair(dbsession)
         sink_commit = CommitFactory(repository=head_commit.repository)

--- a/apps/worker/services/tests/test_repository_service.py
+++ b/apps/worker/services/tests/test_repository_service.py
@@ -821,7 +821,9 @@ def test_upsert_author_needs_update(dbsession):
 
 
 @pytest.mark.asyncio
-async def test_update_commit_from_provider_info_no_author_id(dbsession, mocker):
+async def test_update_commit_from_provider_info_no_author_id(
+    dbsession, mocker, mock_storage
+):
     possible_parent_commit = CommitFactory.create(
         message="possible_parent_commit", pullid=None
     )
@@ -873,7 +875,7 @@ async def test_update_commit_from_provider_info_no_author_id(dbsession, mocker):
 
 @pytest.mark.asyncio
 async def test_update_commit_from_provider_info_no_pullid_on_defaultbranch(
-    dbsession, mocker, mock_repo_provider
+    dbsession, mocker, mock_repo_provider, mock_storage
 ):
     repository = RepositoryFactory.create(branch="superbranch")
     dbsession.add(repository)
@@ -928,7 +930,7 @@ async def test_update_commit_from_provider_info_no_pullid_on_defaultbranch(
 
 @pytest.mark.asyncio
 async def test_update_commit_from_provider_info_no_pullid_not_on_defaultbranch(
-    dbsession, mocker, mock_repo_provider
+    dbsession, mocker, mock_repo_provider, mock_storage
 ):
     repository = RepositoryFactory.create(branch="superbranch")
     dbsession.add(repository)
@@ -978,7 +980,9 @@ async def test_update_commit_from_provider_info_no_pullid_not_on_defaultbranch(
 
 
 @pytest.mark.asyncio
-async def test_update_commit_from_provider_info_with_author_id(dbsession, mocker):
+async def test_update_commit_from_provider_info_with_author_id(
+    dbsession, mocker, mock_storage
+):
     possible_parent_commit = CommitFactory.create(
         message="possible_parent_commit", pullid=None
     )
@@ -1029,7 +1033,9 @@ async def test_update_commit_from_provider_info_with_author_id(dbsession, mocker
 
 
 @pytest.mark.asyncio
-async def test_update_commit_from_provider_info_pull_from_fork(dbsession, mocker):
+async def test_update_commit_from_provider_info_pull_from_fork(
+    dbsession, mocker, mock_storage
+):
     possible_parent_commit = CommitFactory.create(
         message="possible_parent_commit", pullid=None
     )
@@ -1083,7 +1089,9 @@ async def test_update_commit_from_provider_info_pull_from_fork(dbsession, mocker
 
 
 @pytest.mark.asyncio
-async def test_update_commit_from_provider_info_bitbucket_merge(dbsession, mocker):
+async def test_update_commit_from_provider_info_bitbucket_merge(
+    dbsession, mocker, mock_storage
+):
     possible_parent_commit = CommitFactory.create(
         message="possible_parent_commit",
         pullid=None,

--- a/apps/worker/services/tests/unit/test_archive_service.py
+++ b/apps/worker/services/tests/unit/test_archive_service.py
@@ -2,13 +2,13 @@ import json
 
 from database.tests.factories import RepositoryFactory
 from shared.api_archive.archive import ArchiveService
-from shared.storage import MinioStorageService
+from shared.storage.memory import MemoryStorageService
 from test_utils.base import BaseTestCase
 
 
 class TestArchiveService(BaseTestCase):
-    def test_read_file_hard_to_decode(self, mocker):
-        mock_read_file = mocker.patch.object(MinioStorageService, "read_file")
+    def test_read_file_hard_to_decode(self, mocker, mock_storage):
+        mock_read_file = mocker.patch.object(MemoryStorageService, "read_file")
         mock_read_file.return_value = b"\x80abc"
         repo = RepositoryFactory.create()
         service = ArchiveService(repo)
@@ -19,11 +19,11 @@ class TestArchiveService(BaseTestCase):
 
 
 class TestWriteJsonData(BaseTestCase):
-    def test_write_report_details_to_storage(self, mocker, dbsession):
+    def test_write_report_details_to_storage(self, mocker, dbsession, mock_storage):
         repo = RepositoryFactory()
         dbsession.add(repo)
         dbsession.flush()
-        mock_write_file = mocker.patch.object(MinioStorageService, "write_file")
+        mock_write_file = mocker.patch.object(MemoryStorageService, "write_file")
 
         data = [
             {
@@ -61,11 +61,13 @@ class TestWriteJsonData(BaseTestCase):
             reduced_redundancy=False,
         )
 
-    def test_write_report_details_to_storage_no_commitid(self, mocker, dbsession):
+    def test_write_report_details_to_storage_no_commitid(
+        self, mocker, dbsession, mock_storage
+    ):
         repo = RepositoryFactory()
         dbsession.add(repo)
         dbsession.flush()
-        mock_write_file = mocker.patch.object(MinioStorageService, "write_file")
+        mock_write_file = mocker.patch.object(MemoryStorageService, "write_file")
 
         data = [
             {

--- a/apps/worker/tasks/tests/unit/test_upload_processing_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_processing_task.py
@@ -395,7 +395,7 @@ class TestUploadProcessorTask:
         assert commit.state == "complete"
 
     def test_upload_task_process_individual_report_with_notfound_report_no_retries_yet(
-        self, dbsession, mocker
+        self, dbsession, mocker, mock_storage
     ):
         commit = CommitFactory.create()
         dbsession.add(commit)


### PR DESCRIPTION
Running tests with a different (invalid) `config/codecov.yaml` revealed a bunch of tests that are initializing (but not necessarily using) the `ArchiveService`.

I have added the `mock_storage` fixture to those tests, to make sure any test that touches storage (except tests for storage itself) are going through the mock.