### PR TITLE
Switch to timezone-aware datetimes, using AI

### DIFF
--- a/apps/worker/database/models/core.py
+++ b/apps/worker/database/models/core.py
@@ -340,7 +340,7 @@ class Commit(CodecovBaseModel):
     pullid = Column(types.Integer)
     repoid = Column(types.Integer, ForeignKey("repos.repoid"))
     state = Column(types.String(256))
-    timestamp = Column(types.DateTime, nullable=False)
+    timestamp = Column(types.DateTime(timezone=True), nullable=False)
     updatestamp = Column(types.DateTime, nullable=True)
     totals = Column(postgresql.JSON)
 

--- a/apps/worker/services/tests/test_repository_service.py
+++ b/apps/worker/services/tests/test_repository_service.py
@@ -1,5 +1,5 @@
 import inspect
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -868,7 +868,7 @@ async def test_update_commit_from_provider_info_no_author_id(
     assert commit.report_json == {}
     assert commit.branch == "newbranchyeah"
     assert commit.merged is False
-    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20)
+    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20, tzinfo=UTC)
     assert commit.parent_commit_id == possible_parent_commit.commitid
     assert commit.state == "complete"
 
@@ -923,7 +923,7 @@ async def test_update_commit_from_provider_info_no_pullid_on_defaultbranch(
     assert commit.report_json == {}
     assert commit.branch == "superbranch"
     assert commit.merged is True
-    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20)
+    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20, tzinfo=UTC)
     assert commit.parent_commit_id == possible_parent_commit.commitid
     assert commit.state == "complete"
 
@@ -974,7 +974,7 @@ async def test_update_commit_from_provider_info_no_pullid_not_on_defaultbranch(
     assert commit.report_json == {}
     assert commit.branch == "papapa"
     assert commit.merged is False
-    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20)
+    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20, tzinfo=UTC)
     assert commit.parent_commit_id == possible_parent_commit.commitid
     assert commit.state == "complete"
 
@@ -1028,7 +1028,7 @@ async def test_update_commit_from_provider_info_with_author_id(
     assert commit.parent_commit_id == possible_parent_commit.commitid
     assert commit.state == "complete"
     assert commit.author is not None
-    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20)
+    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20, tzinfo=UTC)
     assert commit.author.username == "author_username"
 
 
@@ -1084,7 +1084,7 @@ async def test_update_commit_from_provider_info_pull_from_fork(
     assert commit.parent_commit_id == possible_parent_commit.commitid
     assert commit.state == "complete"
     assert commit.author is not None
-    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20)
+    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20, tzinfo=UTC)
     assert commit.author.username == "author_username"
 
 
@@ -1142,7 +1142,7 @@ async def test_update_commit_from_provider_info_bitbucket_merge(
     assert commit.parent_commit_id == possible_parent_commit.commitid
     assert commit.state == "complete"
     assert commit.author is not None
-    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20)
+    assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20, tzinfo=UTC)
     assert commit.author.username == "author_username"
 
 
@@ -1299,7 +1299,7 @@ class TestGetRepoProviderServiceForSpecificCommit:
     async def test_fetch_and_update_pull_request_information_from_commit_new_pull_commits_in_place(
         self, dbsession, mocker
     ):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         commit = CommitFactory.create(message="", totals=None, _report_json=None)
         base_commit = CommitFactory.create(repository=commit.repository)
         dbsession.add(commit)
@@ -1358,7 +1358,7 @@ class TestGetRepoProviderServiceForSpecificCommit:
     async def test_fetch_and_update_pull_request_information_from_commit_existing_pull_commits_in_place(
         self, dbsession, mocker, repo, pull
     ):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         commit = CommitFactory.create(
             message="",
             pullid=pull.pullid,
@@ -1433,7 +1433,7 @@ class TestGetRepoProviderServiceForSpecificCommit:
     async def test_fetch_and_update_pull_request_multiple_pulls_same_repo(
         self, dbsession, mocker, repo, pull
     ):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         pull.title = "purposelly bad title"
         second_pull = PullFactory.create(repository=repo)
         commit = CommitFactory.create(
@@ -1517,7 +1517,7 @@ class TestGetRepoProviderServiceForSpecificCommit:
         repo,
         pull,
     ):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         commit = CommitFactory.create(
             message="",
             pullid=pull.pullid,
@@ -1603,7 +1603,7 @@ class TestGetRepoProviderServiceForSpecificCommit:
     async def test_fetch_and_update_pull_request_information_no_compared_to(
         self, dbsession, mocker, repo, pull
     ):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         compared_to_commit = CommitFactory.create(
             repository=repo, branch="master", merged=True
         )

--- a/apps/worker/tasks/commit_update.py
+++ b/apps/worker/tasks/commit_update.py
@@ -45,9 +45,7 @@ class CommitUpdateTask(BaseCodecovTask, name=commit_update_task_name):
             )
 
             if isinstance(commit.timestamp, str):
-                commit.timestamp = dt.datetime.fromisoformat(commit.timestamp).replace(
-                    tzinfo=None
-                )
+                commit.timestamp = dt.datetime.fromisoformat(commit.timestamp)
 
             if commit.pullid is not None:
                 # upsert pull

--- a/apps/worker/tasks/tests/unit/test_sync_repos_task.py
+++ b/apps/worker/tasks/tests/unit/test_sync_repos_task.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import call
 
@@ -79,7 +79,7 @@ class TestSyncReposTaskUnit:
         service_id = "123456"
         old_username = "codecov_org"
         new_username = "Codecov"
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         existing_owner = OwnerFactory.create(
             ownerid=ownerid,
             organizations=[],

--- a/libs/shared/tests/unit/plan/test_plan.py
+++ b/libs/shared/tests/unit/plan/test_plan.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
@@ -37,7 +37,7 @@ class PlanServiceTests(TestCase):
         assert plan_service.trial_status == TrialStatus.NOT_STARTED.value
 
     def test_plan_service_trial_status_expired(self):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date_expired = trial_start_date - timedelta(days=1)
         current_org = OwnerFactory(
             plan=DEFAULT_FREE_PLAN,
@@ -50,7 +50,7 @@ class PlanServiceTests(TestCase):
         assert plan_service.trial_status == TrialStatus.EXPIRED.value
 
     def test_plan_service_trial_status_ongoing(self):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date_ongoing = trial_start_date + timedelta(days=5)
         current_org = OwnerFactory(
             plan=PlanName.TRIAL_PLAN_NAME.value,
@@ -77,12 +77,12 @@ class PlanServiceTests(TestCase):
         assert current_org_with_ongoing_trial.trial_status == TrialStatus.EXPIRED.value
         assert current_org_with_ongoing_trial.plan_activated_users is None
         assert current_org_with_ongoing_trial.plan_user_count == 1
-        assert current_org_with_ongoing_trial.trial_end_date == datetime.utcnow()
+        assert current_org_with_ongoing_trial.trial_end_date == datetime.now(UTC)
 
     def test_plan_service_expire_trial_when_upgrading_successful_if_trial_is_ongoing(
         self,
     ):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date_ongoing = trial_start_date + timedelta(days=5)
         current_org_with_ongoing_trial = OwnerFactory(
             plan=DEFAULT_FREE_PLAN,
@@ -95,12 +95,12 @@ class PlanServiceTests(TestCase):
         assert current_org_with_ongoing_trial.trial_status == TrialStatus.EXPIRED.value
         assert current_org_with_ongoing_trial.plan_activated_users is None
         assert current_org_with_ongoing_trial.plan_user_count == 1
-        assert current_org_with_ongoing_trial.trial_end_date == datetime.utcnow()
+        assert current_org_with_ongoing_trial.trial_end_date == datetime.now(UTC)
 
     def test_plan_service_expire_trial_users_pretrial_users_count_if_existing(
         self,
     ):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date_ongoing = trial_start_date + timedelta(days=5)
         pretrial_users_count = 5
         current_org_with_ongoing_trial = OwnerFactory(
@@ -115,10 +115,10 @@ class PlanServiceTests(TestCase):
         assert current_org_with_ongoing_trial.trial_status == TrialStatus.EXPIRED.value
         assert current_org_with_ongoing_trial.plan_activated_users is None
         assert current_org_with_ongoing_trial.plan_user_count == pretrial_users_count
-        assert current_org_with_ongoing_trial.trial_end_date == datetime.utcnow()
+        assert current_org_with_ongoing_trial.trial_end_date == datetime.now(UTC)
 
     def test_plan_service_start_trial_errors_if_status_is_ongoing(self):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date = trial_start_date + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value
         )
@@ -135,7 +135,7 @@ class PlanServiceTests(TestCase):
             plan_service.start_trial(current_owner=current_owner)
 
     def test_plan_service_start_trial_errors_if_status_is_expired(self):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date = trial_start_date + timedelta(days=-1)
         current_org = OwnerFactory(
             plan=DEFAULT_FREE_PLAN,
@@ -190,8 +190,8 @@ class PlanServiceTests(TestCase):
         current_owner = OwnerFactory()
 
         plan_service.start_trial(current_owner=current_owner)
-        assert current_org.trial_start_date == datetime.utcnow()
-        assert current_org.trial_end_date == datetime.utcnow() + timedelta(
+        assert current_org.trial_start_date == datetime.now(UTC)
+        assert current_org.trial_end_date == datetime.now(UTC) + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value
         )
         assert current_org.trial_status == TrialStatus.ONGOING.value
@@ -218,7 +218,7 @@ class PlanServiceTests(TestCase):
         plan_service.start_trial_manually(
             current_owner=current_owner, end_date="2024-01-01 00:00:00"
         )
-        assert current_org.trial_start_date == datetime.utcnow()
+        assert current_org.trial_start_date == datetime.now(UTC)
         assert current_org.trial_end_date == "2024-01-01 00:00:00"
         assert current_org.trial_status == TrialStatus.ONGOING.value
         assert current_org.plan == PlanName.TRIAL_PLAN_NAME.value
@@ -266,8 +266,8 @@ class PlanServiceTests(TestCase):
         assert plan_service.monthly_uploads_limit == 250
 
     def test_plan_service_returns_plan_data_for_trialing_user_trial_plan(self):
-        trial_start_date = datetime.utcnow()
-        trial_end_date = datetime.utcnow() + timedelta(
+        trial_start_date = datetime.now(UTC)
+        trial_end_date = datetime.now(UTC) + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value
         )
         current_org = OwnerFactory(
@@ -309,8 +309,8 @@ class PlanServiceTests(TestCase):
     def test_plan_service_returns_if_owner_has_trial_dates(self):
         current_org = OwnerFactory(
             plan=PlanName.CODECOV_PRO_MONTHLY.value,
-            trial_start_date=datetime.utcnow(),
-            trial_end_date=datetime.utcnow() + timedelta(days=14),
+            trial_start_date=datetime.now(UTC),
+            trial_end_date=datetime.now(UTC) + timedelta(days=14),
         )
         current_org.save()
 
@@ -597,8 +597,8 @@ class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):
 
     def setUp(self):
         self.current_org = OwnerFactory(
-            trial_start_date=datetime.utcnow() + timedelta(days=-10),
-            trial_end_date=datetime.utcnow() + timedelta(days=-3),
+            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC) + timedelta(days=-3),
             trial_status=TrialStatus.EXPIRED.value,
             plan_user_count=3,
         )
@@ -747,8 +747,8 @@ class AvailablePlansExpiredTrialMoreThanTenActivatedUsers(TestCase):
 
     def setUp(self):
         self.current_org = OwnerFactory(
-            trial_start_date=datetime.utcnow() + timedelta(days=-10),
-            trial_end_date=datetime.utcnow() + timedelta(days=-3),
+            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC) + timedelta(days=-3),
             trial_status=TrialStatus.EXPIRED.value,
             plan_user_count=1,
             plan_activated_users=list(range(13)),
@@ -853,8 +853,8 @@ class AvailablePlansExpiredTrialMoreThanTenSeatsLessThanTenActivatedUsers(TestCa
             plan_user_count=100,
             plan_activated_users=list(range(10)),
             trial_status=TrialStatus.EXPIRED.value,
-            trial_start_date=datetime.utcnow() + timedelta(days=-10),
-            trial_end_date=datetime.utcnow() + timedelta(days=-3),
+            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC) + timedelta(days=-3),
         )
         self.owner = OwnerFactory()
         self.plan_service = PlanService(current_org=self.current_org)
@@ -868,8 +868,8 @@ class AvailablePlansExpiredTrialMoreThanTenSeatsLessThanTenActivatedUsers(TestCa
             plan_user_count=100,
             plan_activated_users=list(range(10)),
             trial_status=TrialStatus.ONGOING.value,
-            trial_start_date=datetime.utcnow() + timedelta(days=-10),
-            trial_end_date=datetime.utcnow() + timedelta(days=3),
+            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC) + timedelta(days=3),
         )
         self.owner = OwnerFactory()
         self.plan_service = PlanService(current_org=self.current_org)
@@ -919,8 +919,8 @@ class AvailablePlansOngoingTrial(TestCase):
     def setUp(self):
         self.current_org = OwnerFactory(
             plan=DEFAULT_FREE_PLAN,
-            trial_start_date=datetime.utcnow(),
-            trial_end_date=datetime.utcnow() + timedelta(days=14),
+            trial_start_date=datetime.now(UTC),
+            trial_end_date=datetime.now(UTC) + timedelta(days=14),
             trial_status=TrialStatus.ONGOING.value,
             plan_user_count=1000,
             plan_activated_users=None,
@@ -1025,8 +1025,8 @@ class PlanServiceIs___PlanTests(TestCase):
         )
         self.current_org = OwnerFactory(
             plan=plan.name,
-            trial_start_date=datetime.utcnow(),
-            trial_end_date=datetime.utcnow() + timedelta(days=14),
+            trial_start_date=datetime.now(UTC),
+            trial_end_date=datetime.now(UTC) + timedelta(days=14),
             trial_status=TrialStatus.ONGOING.value,
             plan_user_count=1000,
             plan_activated_users=None,

--- a/libs/shared/tests/unit/upload/test_utils.py
+++ b/libs/shared/tests/unit/upload/test_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import PropertyMock, patch
 
 from django.test import TestCase
@@ -112,8 +112,8 @@ class CoverageMeasurement(TestCase):
         freezer.start()
         owner = OwnerFactory(
             trial_status="expired",
-            trial_start_date=datetime.utcnow(),
-            trial_end_date=datetime.utcnow() + timedelta(days=14),
+            trial_start_date=datetime.now(UTC),
+            trial_end_date=datetime.now(UTC) + timedelta(days=14),
         )
         freezer.stop()
 


### PR DESCRIPTION
Actually my first use of AI. I asked it to replace usage of the deprecated `datetime.utcnow()` function, as well as replace naive datetimes with timezone aware ones.