### PR TITLE
fix: use root org for activated user

### DIFF
--- a/apps/codecov-api/graphql_api/types/owner/owner.py
+++ b/apps/codecov-api/graphql_api/types/owner/owner.py
@@ -326,6 +326,12 @@ def resolve_is_current_user_activated(owner: Owner, info: GraphQLResolveInfo) ->
     if not current_owner:
         return False
 
+    # handle gitlab subgroups
+    if owner.service == "gitlab":
+        root_owner = owner.root_organization
+        if root_owner:
+            owner = root_owner
+
     if owner.ownerid == current_owner.ownerid:
         return True
     if owner.plan_activated_users is None:


### PR DESCRIPTION
when resolving the activated user in GQL, if the current owner is a Gitlab owner we should check if the user is in the plan activated users of the root org since the subgroup doesn't seem to contain that information

the other option here is to actually add the relevant users to the subgroup owner in the db, but this seems like the shorter fix to unblock customers even though it may be the less correct one