### PR TITLE
Enhance queue parameter handling in `_get_queues_param_from_queue_input`

### DIFF
--- a/apps/worker/main.py
+++ b/apps/worker/main.py
@@ -136,7 +136,14 @@ def _get_queues_param_from_queue_input(queues: list[str]) -> str:
 
     # Support passing comma separated values, as those will be split again:
     joined_queues = ",".join(queues)
-    enterprise_queues = ["enterprise_" + q for q in joined_queues.split(",")]
+    enterprise_queues = (
+        [
+            "enterprise_" + q if not q.startswith("enterprise_") else q
+            for q in joined_queues.split(",")
+        ]
+        if get_config("setup", "enterprise_queues_enabled", default=True)
+        else []
+    )
     all_queues = [
         joined_queues,
         *enterprise_queues,

--- a/apps/worker/main.py
+++ b/apps/worker/main.py
@@ -11,14 +11,14 @@ django.setup()
 import logging  # noqa: E402
 import sys  # noqa: E402
 
-import app  # noqa: E402
 import click  # noqa: E402
-import shared.storage  # noqa: E402
 from celery.signals import worker_process_shutdown  # noqa: E402
+from prometheus_client import REGISTRY, CollectorRegistry, multiprocess  # noqa: E402
+
+import app  # noqa: E402
+import shared.storage  # noqa: E402
 from helpers.environment import get_external_dependencies_folder  # noqa: E402
 from helpers.version import get_current_version  # noqa: E402
-from prometheus_client import (REGISTRY, CollectorRegistry,  # noqa: E402
-                               multiprocess)
 from shared.celery_config import BaseCeleryConfig  # noqa: E402
 from shared.config import get_config  # noqa: E402
 from shared.license import startup_license_logging  # noqa: E402

--- a/apps/worker/main.py
+++ b/apps/worker/main.py
@@ -11,14 +11,14 @@ django.setup()
 import logging  # noqa: E402
 import sys  # noqa: E402
 
-import click  # noqa: E402
-from celery.signals import worker_process_shutdown  # noqa: E402
-from prometheus_client import REGISTRY, CollectorRegistry, multiprocess  # noqa: E402
-
 import app  # noqa: E402
+import click  # noqa: E402
 import shared.storage  # noqa: E402
+from celery.signals import worker_process_shutdown  # noqa: E402
 from helpers.environment import get_external_dependencies_folder  # noqa: E402
 from helpers.version import get_current_version  # noqa: E402
+from prometheus_client import (REGISTRY, CollectorRegistry,  # noqa: E402
+                               multiprocess)
 from shared.celery_config import BaseCeleryConfig  # noqa: E402
 from shared.config import get_config  # noqa: E402
 from shared.license import startup_license_logging  # noqa: E402
@@ -136,21 +136,19 @@ def _get_queues_param_from_queue_input(queues: list[str]) -> str:
 
     # Support passing comma separated values, as those will be split again:
     joined_queues = ",".join(queues)
-    enterprise_queues = (
-        [
-            "enterprise_" + q if not q.startswith("enterprise_") else q
+    enterprise_queues = []
+    if get_config("setup", "enterprise_queues_enabled", default=True):
+        enterprise_queues = [
+            "enterprise_" + q if not q.startswith("enterprise_") else ""
             for q in joined_queues.split(",")
         ]
-        if get_config("setup", "enterprise_queues_enabled", default=True)
-        else []
-    )
     all_queues = [
         joined_queues,
         *enterprise_queues,
         BaseCeleryConfig.health_check_default_queue,
     ]
 
-    return ",".join(all_queues)
+    return ",".join([q for q in all_queues if q])
 
 
 def main():

--- a/apps/worker/tests/unit/test_main.py
+++ b/apps/worker/tests/unit/test_main.py
@@ -19,7 +19,7 @@ def test_get_queues_param_from_queue_input():
     )
 
 def test_get_queues_param_from_queue_input_disabled_enterprise_queues(mocker):
-    mocker.patch.dict(os.environ, {"SETUP__ENTERPRISE_QUEUES_ENABLED": "False"})
+    mocker.patch('main.get_config', return_value=False)
     assert (
         _get_queues_param_from_queue_input(["worker,profiling,notify"])
         == f"worker,profiling,notify,{BaseCeleryConfig.health_check_default_queue}"

--- a/apps/worker/tests/unit/test_main.py
+++ b/apps/worker/tests/unit/test_main.py
@@ -18,8 +18,9 @@ def test_get_queues_param_from_queue_input():
         == f"worker,profiling,notify,enterprise_worker,enterprise_profiling,enterprise_notify,{BaseCeleryConfig.health_check_default_queue}"
     )
 
+
 def test_get_queues_param_from_queue_input_disabled_enterprise_queues(mocker):
-    mocker.patch('main.get_config', return_value=False)
+    mocker.patch("main.get_config", return_value=False)
     assert (
         _get_queues_param_from_queue_input(["worker,profiling,notify"])
         == f"worker,profiling,notify,{BaseCeleryConfig.health_check_default_queue}"
@@ -29,15 +30,21 @@ def test_get_queues_param_from_queue_input_disabled_enterprise_queues(mocker):
         == f"worker,profiling,notify,{BaseCeleryConfig.health_check_default_queue}"
     )
 
+
 def test_get_queues_param_from_queue_input_does_not_double_enterprise():
     assert (
-        _get_queues_param_from_queue_input(["enterprise_worker,enterprise_profiling,enterprise_notify"])
+        _get_queues_param_from_queue_input(
+            ["enterprise_worker,enterprise_profiling,enterprise_notify"]
+        )
         == f"enterprise_worker,enterprise_profiling,enterprise_notify,{BaseCeleryConfig.health_check_default_queue}"
     )
     assert (
-        _get_queues_param_from_queue_input(["enterprise_worker", "enterprise_profiling", "enterprise_notify"])
+        _get_queues_param_from_queue_input(
+            ["enterprise_worker", "enterprise_profiling", "enterprise_notify"]
+        )
         == f"enterprise_worker,enterprise_profiling,enterprise_notify,{BaseCeleryConfig.health_check_default_queue}"
     )
+
 
 @mock.patch("main.startup_license_logging")
 @mock.patch("main.start_prometheus")

--- a/apps/worker/tests/unit/test_main.py
+++ b/apps/worker/tests/unit/test_main.py
@@ -18,6 +18,26 @@ def test_get_queues_param_from_queue_input():
         == f"worker,profiling,notify,enterprise_worker,enterprise_profiling,enterprise_notify,{BaseCeleryConfig.health_check_default_queue}"
     )
 
+def test_get_queues_param_from_queue_input_disabled_enterprise_queues(mocker):
+    mocker.patch.dict(os.environ, {"SETUP__ENTERPRISE_QUEUES_ENABLED": "False"})
+    assert (
+        _get_queues_param_from_queue_input(["worker,profiling,notify"])
+        == f"worker,profiling,notify,{BaseCeleryConfig.health_check_default_queue}"
+    )
+    assert (
+        _get_queues_param_from_queue_input(["worker", "profiling", "notify"])
+        == f"worker,profiling,notify,{BaseCeleryConfig.health_check_default_queue}"
+    )
+
+def test_get_queues_param_from_queue_input_does_not_double_enterprise():
+    assert (
+        _get_queues_param_from_queue_input(["enterprise_worker,enterprise_profiling,enterprise_notify"])
+        == f"enterprise_worker,enterprise_profiling,enterprise_notify,{BaseCeleryConfig.health_check_default_queue}"
+    )
+    assert (
+        _get_queues_param_from_queue_input(["enterprise_worker", "enterprise_profiling", "enterprise_notify"])
+        == f"enterprise_worker,enterprise_profiling,enterprise_notify,{BaseCeleryConfig.health_check_default_queue}"
+    )
 
 @mock.patch("main.startup_license_logging")
 @mock.patch("main.start_prometheus")


### PR DESCRIPTION
- Update the logic to conditionally prepend "enterprise_" to queue names only if they do not already start with it, based on the `enterprise_queues_enabled` configuration.
- Add tests to verify behavior when enterprise queues are disabled and ensure no duplication of enterprise prefixes in the input.