### PR TITLE
Add JWT Middleware authentication with endpoint

### DIFF
--- a/apps/codecov-api/codecov/settings_test.py
+++ b/apps/codecov-api/codecov/settings_test.py
@@ -13,3 +13,4 @@ SHELTER_PUBSUB_SYNC_REPO_TOPIC_ID = "test-topic-id"
 os.environ["PUBSUB_EMULATOR_HOST"] = "localhost"
 
 GRAPHQL_INTROSPECTION_ENABLED = True
+SENTRY_JWT_SECRET_KEY = "test-secret-key"

--- a/apps/codecov-api/codecov/settings_test.py
+++ b/apps/codecov-api/codecov/settings_test.py
@@ -13,4 +13,4 @@ SHELTER_PUBSUB_SYNC_REPO_TOPIC_ID = "test-topic-id"
 os.environ["PUBSUB_EMULATOR_HOST"] = "localhost"
 
 GRAPHQL_INTROSPECTION_ENABLED = True
-SENTRY_JWT_SECRET_KEY = "test-secret-key"
+SENTRY_JWT_SHARED_SECRET = "test-shared-secret"

--- a/apps/codecov-api/codecov_auth/middleware.py
+++ b/apps/codecov-api/codecov_auth/middleware.py
@@ -219,9 +219,6 @@ def jwt_middleware(get_response):
         except jwt.ExpiredSignatureError:
             log.warning(
                 "JWT token has expired",
-                extra={
-                    "token": token,
-                },
             )
             return HttpResponseForbidden("JWT token has expired")
         except Exception as e:

--- a/apps/codecov-api/codecov_auth/middleware.py
+++ b/apps/codecov-api/codecov_auth/middleware.py
@@ -201,7 +201,7 @@ def jwt_middleware(get_response):
                 token,
                 settings.SENTRY_JWT_SHARED_SECRET,
                 algorithms=["HS256"],
-                options={"verify_exp": True},
+                options={"verify_exp": True, "require": ["exp", "iat", "iss"]},
             )
 
             provider_user_id = payload.get("g_u")

--- a/apps/codecov-api/codecov_auth/middleware.py
+++ b/apps/codecov-api/codecov_auth/middleware.py
@@ -20,6 +20,11 @@ from utils.services import get_long_service_name
 log = logging.getLogger(__name__)
 
 
+class JWTClaims:
+    provider_user_id: str
+    provider: str
+
+
 def get_service(request: HttpRequest) -> str | None:
     resolver_match = resolve(request.path_info)
     service = resolver_match.kwargs.get("service")
@@ -199,7 +204,7 @@ def jwt_middleware(get_response):
             # TODO: use the correct decoding algorithm
             payload = jwt.decode(
                 token,
-                settings.SENTRY_JWT_SECRET_KEY,
+                settings.SENTRY_JWT_SHARED_SECRET,
                 algorithms=["HS256"],
                 options={"verify_exp": True},  # Explicitly enable expiry verification
             )

--- a/apps/codecov-api/codecov_auth/middleware.py
+++ b/apps/codecov-api/codecov_auth/middleware.py
@@ -20,11 +20,6 @@ from utils.services import get_long_service_name
 log = logging.getLogger(__name__)
 
 
-class JWTClaims:
-    provider_user_id: str
-    provider: str
-
-
 def get_service(request: HttpRequest) -> str | None:
     resolver_match = resolve(request.path_info)
     service = resolver_match.kwargs.get("service")
@@ -206,12 +201,11 @@ def jwt_middleware(get_response):
                 token,
                 settings.SENTRY_JWT_SHARED_SECRET,
                 algorithms=["HS256"],
-                options={"verify_exp": True},  # Explicitly enable expiry verification
+                options={"verify_exp": True},
             )
 
-            # Extract user_id from payload
-            provider_user_id = payload.get("provider_user_id")
-            provider = payload.get("provider")
+            provider_user_id = payload.get("g_u")
+            provider = payload.get("g_p")
 
             if not provider_user_id or not provider:
                 return HttpResponseForbidden("Invalid JWT payload")

--- a/apps/codecov-api/codecov_auth/tests/test_middleware.py
+++ b/apps/codecov-api/codecov_auth/tests/test_middleware.py
@@ -12,8 +12,6 @@ from codecov_auth.middleware import (
 )
 from codecov_auth.models import Owner
 
-# ... existing fixtures ...
-
 
 @pytest.fixture
 def request_factory():
@@ -31,7 +29,7 @@ def sentry_jwt_middleware_instance():
 @pytest.fixture
 def valid_jwt_token():
     return jwt.encode(
-        {"provider_user_id": "123", "provider": "github"},
+        {"g_u": "123", "g_p": "github"},
         settings.SENTRY_JWT_SHARED_SECRET,
         algorithm="HS256",
     )
@@ -95,8 +93,8 @@ async def test_sentry_jwt_expired_token(
     """Test middleware behavior with expired JWT token"""
     # Create a token with an expired timestamp
     payload = {
-        "provider_user_id": "123",
-        "provider": "github",
+        "g_u": "123",
+        "g_p": "github",
         "exp": int(time.time()) - 3600,  # Expired 1 hour ago
     }
     token = jwt.encode(payload, settings.SENTRY_JWT_SHARED_SECRET, algorithm="HS256")
@@ -115,7 +113,7 @@ async def test_sentry_jwt_missing_provider_user_id(
 ):
     """Test middleware behavior with JWT token missing provider_user_id"""
     token = jwt.encode(
-        {"provider": "github"},
+        {"g_p": "github"},
         settings.SENTRY_JWT_SHARED_SECRET,
         algorithm="HS256",
     )
@@ -134,7 +132,7 @@ async def test_sentry_jwt_missing_provider(
 ):
     """Test middleware behavior with JWT token missing provider"""
     token = jwt.encode(
-        {"provider_user_id": "123"},
+        {"g_u": "123"},
         settings.SENTRY_JWT_SHARED_SECRET,
         algorithm="HS256",
     )

--- a/apps/codecov-api/codecov_auth/tests/test_middleware.py
+++ b/apps/codecov-api/codecov_auth/tests/test_middleware.py
@@ -32,7 +32,7 @@ def sentry_jwt_middleware_instance():
 def valid_jwt_token():
     return jwt.encode(
         {"provider_user_id": "123", "provider": "github"},
-        settings.SENTRY_JWT_SECRET_KEY,
+        settings.SENTRY_JWT_SHARED_SECRET,
         algorithm="HS256",
     )
 
@@ -99,7 +99,7 @@ async def test_sentry_jwt_expired_token(
         "provider": "github",
         "exp": int(time.time()) - 3600,  # Expired 1 hour ago
     }
-    token = jwt.encode(payload, settings.SENTRY_JWT_SECRET_KEY, algorithm="HS256")
+    token = jwt.encode(payload, settings.SENTRY_JWT_SHARED_SECRET, algorithm="HS256")
     request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
 
     response = await sentry_jwt_middleware_instance(request)
@@ -115,7 +115,9 @@ async def test_sentry_jwt_missing_provider_user_id(
 ):
     """Test middleware behavior with JWT token missing provider_user_id"""
     token = jwt.encode(
-        {"provider": "github"}, settings.SENTRY_JWT_SECRET_KEY, algorithm="HS256"
+        {"provider": "github"},
+        settings.SENTRY_JWT_SHARED_SECRET,
+        algorithm="HS256",
     )
     request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
 
@@ -132,7 +134,9 @@ async def test_sentry_jwt_missing_provider(
 ):
     """Test middleware behavior with JWT token missing provider"""
     token = jwt.encode(
-        {"provider_user_id": "123"}, settings.SENTRY_JWT_SECRET_KEY, algorithm="HS256"
+        {"provider_user_id": "123"},
+        settings.SENTRY_JWT_SHARED_SECRET,
+        algorithm="HS256",
     )
     request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
 

--- a/apps/codecov-api/codecov_auth/tests/test_middleware.py
+++ b/apps/codecov-api/codecov_auth/tests/test_middleware.py
@@ -1,0 +1,215 @@
+import time
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from django.conf import settings
+from django.http import HttpResponseForbidden
+from django.test import RequestFactory
+
+from codecov_auth.middleware import (
+    jwt_middleware,
+)
+from codecov_auth.models import Owner
+
+# ... existing fixtures ...
+
+
+@pytest.fixture
+def request_factory():
+    return RequestFactory()
+
+
+@pytest.fixture
+def sentry_jwt_middleware_instance():
+    return jwt_middleware(lambda x: x)
+
+
+@pytest.fixture
+def valid_jwt_token():
+    return jwt.encode(
+        {"provider_user_id": "123", "provider": "github"},
+        settings.SENTRY_JWT_SECRET_KEY,
+        algorithm="HS256",
+    )
+
+
+@pytest.fixture
+def mock_owner():
+    owner = MagicMock(spec=Owner)
+    owner.service = "github"
+    owner.service_id = "123"
+    return owner
+
+
+# Sentry JWT Middleware tests
+def test_sentry_jwt_no_auth_header(request_factory, sentry_jwt_middleware_instance):
+    """Test middleware behavior when no Authorization header is present"""
+    request = request_factory.get("/")
+
+    response = sentry_jwt_middleware_instance(request)
+
+    assert isinstance(response, HttpResponseForbidden)
+    assert response.content.decode() == "Missing or invalid Authorization header"
+    assert request.current_owner is None
+
+
+def test_sentry_jwt_invalid_auth_format(
+    request_factory, sentry_jwt_middleware_instance
+):
+    """Test middleware behavior with invalid Authorization header format"""
+    request = request_factory.get("/", HTTP_AUTHORIZATION="InvalidFormat")
+
+    response = sentry_jwt_middleware_instance(request)
+
+    assert isinstance(response, HttpResponseForbidden)
+    assert response.content.decode() == "Missing or invalid Authorization header"
+    assert request.current_owner is None
+
+
+def test_sentry_jwt_invalid_token(request_factory, sentry_jwt_middleware_instance):
+    """Test middleware behavior with invalid JWT token"""
+    request = request_factory.get("/", HTTP_AUTHORIZATION="Bearer invalid.token.here")
+
+    response = sentry_jwt_middleware_instance(request)
+
+    assert isinstance(response, HttpResponseForbidden)
+    assert response.content.decode() == "Invalid JWT token"
+    assert request.current_owner is None
+
+
+def test_sentry_jwt_expired_token(request_factory, sentry_jwt_middleware_instance):
+    """Test middleware behavior with expired JWT token"""
+    # Create a token with an expired timestamp
+    payload = {
+        "provider_user_id": "123",
+        "provider": "github",
+        "exp": int(time.time()) - 3600,  # Expired 1 hour ago
+    }
+    token = jwt.encode(payload, settings.SENTRY_JWT_SECRET_KEY, algorithm="HS256")
+    request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    response = sentry_jwt_middleware_instance(request)
+
+    assert isinstance(response, HttpResponseForbidden)
+    assert response.content.decode() == "JWT token has expired"
+    assert request.current_owner is None
+
+
+@pytest.mark.django_db
+def test_sentry_jwt_token_expiring_soon(
+    request_factory, sentry_jwt_middleware_instance
+):
+    """Test middleware behavior with token expiring soon"""
+    # Create a token that expires in 1 second
+    payload = {
+        "provider_user_id": "123",
+        "provider": "github",
+        "exp": int(time.time()) + 1,
+    }
+    token = jwt.encode(payload, settings.SENTRY_JWT_SECRET_KEY, algorithm="HS256")
+    request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    response = sentry_jwt_middleware_instance(request)
+
+    # Token should still be valid
+    assert not isinstance(response, HttpResponseForbidden)
+    assert request.current_owner is not None
+
+
+def test_sentry_jwt_missing_provider_user_id(
+    request_factory, sentry_jwt_middleware_instance
+):
+    """Test middleware behavior with JWT token missing provider_user_id"""
+    token = jwt.encode(
+        {"provider": "github"}, settings.SENTRY_JWT_SECRET_KEY, algorithm="HS256"
+    )
+    request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    response = sentry_jwt_middleware_instance(request)
+
+    assert isinstance(response, HttpResponseForbidden)
+    assert response.content.decode() == "Invalid JWT payload"
+    assert request.current_owner is None
+
+
+def test_sentry_jwt_missing_provider(request_factory, sentry_jwt_middleware_instance):
+    """Test middleware behavior with JWT token missing provider"""
+    token = jwt.encode(
+        {"provider_user_id": "123"}, settings.SENTRY_JWT_SECRET_KEY, algorithm="HS256"
+    )
+    request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    response = sentry_jwt_middleware_instance(request)
+
+    assert isinstance(response, HttpResponseForbidden)
+    assert response.content.decode() == "Invalid JWT payload"
+    assert request.current_owner is None
+
+
+def test_sentry_jwt_decode_error(request_factory, sentry_jwt_middleware_instance):
+    """Test middleware behavior when JWT decode fails"""
+    request = request_factory.get("/", HTTP_AUTHORIZATION="Bearer invalid.token.here")
+
+    with patch("codecov_auth.middleware.jwt.decode") as mock_decode:
+        mock_decode.side_effect = jwt.InvalidTokenError("Invalid token")
+
+        response = sentry_jwt_middleware_instance(request)
+
+        assert isinstance(response, HttpResponseForbidden)
+        assert response.content.decode() == "Invalid JWT token"
+        assert request.current_owner is None
+
+
+def test_sentry_jwt_valid_token_existing_owner(
+    request_factory, sentry_jwt_middleware_instance, valid_jwt_token, mock_owner
+):
+    """Test middleware behavior with valid JWT token and existing owner"""
+    request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {valid_jwt_token}")
+
+    with patch(
+        "codecov_auth.middleware.Owner.objects.get_or_create"
+    ) as mock_get_or_create:
+        mock_get_or_create.return_value = (mock_owner, False)
+
+        response = sentry_jwt_middleware_instance(request)
+
+        assert not isinstance(response, HttpResponseForbidden)
+        assert request.current_owner == mock_owner
+        mock_get_or_create.assert_called_once_with(service_id="123", service="github")
+
+
+def test_sentry_jwt_valid_token_new_owner(
+    request_factory, sentry_jwt_middleware_instance, valid_jwt_token, mock_owner
+):
+    """Test middleware behavior with valid JWT token and new owner creation"""
+    request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {valid_jwt_token}")
+
+    with patch(
+        "codecov_auth.middleware.Owner.objects.get_or_create"
+    ) as mock_get_or_create:
+        mock_get_or_create.return_value = (mock_owner, True)
+
+        response = sentry_jwt_middleware_instance(request)
+
+        assert not isinstance(response, HttpResponseForbidden)
+        assert request.current_owner == mock_owner
+        mock_get_or_create.assert_called_once_with(service_id="123", service="github")
+
+
+def test_sentry_jwt_owner_creation_error(
+    request_factory, sentry_jwt_middleware_instance, valid_jwt_token
+):
+    """Test middleware behavior when owner creation fails"""
+    request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {valid_jwt_token}")
+
+    with patch(
+        "codecov_auth.middleware.Owner.objects.get_or_create"
+    ) as mock_get_or_create:
+        mock_get_or_create.side_effect = Exception("Database error")
+
+        response = sentry_jwt_middleware_instance(request)
+
+        assert isinstance(response, HttpResponseForbidden)
+        assert response.content.decode() == "Invalid JWT token"
+        assert request.current_owner is None

--- a/apps/codecov-api/codecov_auth/tests/test_middleware.py
+++ b/apps/codecov-api/codecov_auth/tests/test_middleware.py
@@ -29,7 +29,13 @@ def sentry_jwt_middleware_instance():
 @pytest.fixture
 def valid_jwt_token():
     return jwt.encode(
-        {"g_u": "123", "g_p": "github"},
+        {
+            "g_u": "123",
+            "g_p": "github",
+            "exp": int(time.time()) + 3600,  # Expires in 1 hour
+            "iat": int(time.time()),  # Issued at current time
+            "iss": "sentry",  # Issuer
+        },
         settings.SENTRY_JWT_SHARED_SECRET,
         algorithm="HS256",
     )
@@ -96,6 +102,8 @@ async def test_sentry_jwt_expired_token(
         "g_u": "123",
         "g_p": "github",
         "exp": int(time.time()) - 3600,  # Expired 1 hour ago
+        "iat": int(time.time()) - 7200,  # Issued 2 hours ago
+        "iss": "sentry",  # Issuer
     }
     token = jwt.encode(payload, settings.SENTRY_JWT_SHARED_SECRET, algorithm="HS256")
     request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
@@ -113,7 +121,12 @@ async def test_sentry_jwt_missing_provider_user_id(
 ):
     """Test middleware behavior with JWT token missing provider_user_id"""
     token = jwt.encode(
-        {"g_p": "github"},
+        {
+            "g_p": "github",
+            "exp": int(time.time()) + 3600,
+            "iat": int(time.time()),
+            "iss": "sentry",  # Issuer
+        },
         settings.SENTRY_JWT_SHARED_SECRET,
         algorithm="HS256",
     )
@@ -132,7 +145,12 @@ async def test_sentry_jwt_missing_provider(
 ):
     """Test middleware behavior with JWT token missing provider"""
     token = jwt.encode(
-        {"g_u": "123"},
+        {
+            "g_u": "123",
+            "exp": int(time.time()) + 3600,
+            "iat": int(time.time()),
+            "iss": "sentry",  # Issuer
+        },
         settings.SENTRY_JWT_SHARED_SECRET,
         algorithm="HS256",
     )

--- a/apps/codecov-api/graphql_api/tests/test_sentry_view.py
+++ b/apps/codecov-api/graphql_api/tests/test_sentry_view.py
@@ -1,0 +1,106 @@
+import json
+import time
+from unittest.mock import patch
+
+import jwt
+import pytest
+from django.conf import settings
+from django.test import TestCase
+
+from shared.django_apps.codecov_auth.tests.factories import OwnerFactory
+
+
+@pytest.mark.django_db
+class TestSentryAriadneView(TestCase):
+    def setUp(self):
+        self.mock_owner = self._create_mock_owner()
+        self.valid_jwt_token = self._create_valid_jwt_token()
+        self.query = """
+            query CurrentUser { me  {owner {username}} }   
+        """
+
+    def _create_valid_jwt_token(self):
+        payload = {
+            "provider_user_id": "1234567890",
+            "provider": "github",
+            "exp": int(time.time()) + 3600,  # Expires in 1 hour
+        }
+        return jwt.encode(payload, settings.SENTRY_JWT_SECRET_KEY, algorithm="HS256")
+
+    def _create_mock_owner(self):
+        owner = OwnerFactory(
+            username="sentry_ariadne_check", service="github", service_id="1234567890"
+        )
+        owner.save()
+        return owner
+
+    def do_query(self, query="{ failing }", token=""):
+        data = {"query": query}
+        headers = {}
+        if token:
+            headers["HTTP_AUTHORIZATION"] = f"Bearer {token}"
+
+        response = self.client.post(
+            "/graphql/sentry/gh",
+            data=json.dumps(data),
+            content_type="application/json",
+            **headers,
+        )
+        return response
+
+    def test_sentry_ariadne_view_valid_token(self):
+        """Test sentry_ariadne_view with valid JWT token"""
+        with patch(
+            "codecov_auth.middleware.Owner.objects.get_or_create"
+        ) as mock_get_or_create:
+            mock_get_or_create.return_value = (self.mock_owner, False)
+            response = self.do_query(query=self.query, token=self.valid_jwt_token)
+
+            assert response.status_code == 200
+            assert response.json() == {
+                "data": {"me": {"owner": {"username": str(self.mock_owner.username)}}}
+            }
+            mock_get_or_create.assert_called_once_with(
+                service_id="1234567890", service="github"
+            )
+
+    def test_sentry_ariadne_view_missing_token(self):
+        """Test sentry_ariadne_view with missing JWT token"""
+        response = self.do_query(query=self.query)
+
+        assert response.status_code == 403
+        assert response.content.decode() == "Missing or invalid Authorization header"
+
+    def test_sentry_ariadne_view_invalid_token(self):
+        """Test sentry_ariadne_view with invalid JWT token"""
+        response = self.do_query(query=self.query, token="invalid_token")
+
+        assert response.status_code == 403
+        assert response.content.decode() == "Invalid JWT token"
+
+    def test_sentry_ariadne_view_expired_token(self):
+        """Test sentry_ariadne_view with expired JWT token"""
+        payload = {
+            "provider_user_id": "1234567890",
+            "provider": "github",
+            "exp": int(time.time()) - 3600,  # Expired 1 hour ago
+        }
+        expired_token = jwt.encode(
+            payload, settings.SENTRY_JWT_SECRET_KEY, algorithm="HS256"
+        )
+
+        response = self.do_query(query=self.query, token=expired_token)
+        assert response.status_code == 403
+        assert response.content.decode() == "JWT token has expired"
+
+    def test_sentry_ariadne_view_owner_creation_error(self):
+        """Test sentry_ariadne_view when owner creation fails"""
+        with patch(
+            "codecov_auth.middleware.Owner.objects.get_or_create"
+        ) as mock_get_or_create:
+            mock_get_or_create.side_effect = Exception("Database error")
+
+            response = self.do_query(query=self.query, token=self.valid_jwt_token)
+
+            assert response.status_code == 403
+            assert response.content.decode() == "Invalid JWT token"

--- a/apps/codecov-api/graphql_api/urls.py
+++ b/apps/codecov-api/graphql_api/urls.py
@@ -21,10 +21,10 @@ ALLOWED_SERVICES = [
 service_regex = "|".join(ALLOWED_SERVICES)
 
 urlpatterns = [
-    re_path(rf"^(?P<service>({service_regex}))$", ariadne_view, name="graphql"),
     re_path(
         rf"^sentry/(?P<service>({service_regex}))$",
         sentry_ariadne_view,
         name="sentry_graphql",
     ),
+    re_path(rf"^(?P<service>({service_regex}))$", ariadne_view, name="graphql"),
 ]

--- a/apps/codecov-api/graphql_api/urls.py
+++ b/apps/codecov-api/graphql_api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import re_path
 
-from .views import ariadne_view
+from .views import ariadne_view, sentry_ariadne_view
 
 ALLOWED_SERVICES = [
     "gh",
@@ -22,4 +22,9 @@ service_regex = "|".join(ALLOWED_SERVICES)
 
 urlpatterns = [
     re_path(rf"^(?P<service>({service_regex}))$", ariadne_view, name="graphql"),
+    re_path(
+        rf"^sentry/(?P<service>({service_regex}))$",
+        sentry_ariadne_view,
+        name="sentry_graphql",
+    ),
 ]

--- a/apps/codecov-api/graphql_api/views.py
+++ b/apps/codecov-api/graphql_api/views.py
@@ -21,7 +21,6 @@ from django.http import (
     HttpResponseNotAllowed,
     JsonResponse,
 )
-from django.utils.decorators import decorator_from_middleware
 from graphql import DocumentNode
 from sentry_sdk import capture_exception
 
@@ -441,6 +440,6 @@ async def ariadne_view(request: WSGIRequest, service: str) -> HttpResponse:
     return response
 
 
-@decorator_from_middleware(jwt_middleware)
+@jwt_middleware
 async def sentry_ariadne_view(request: WSGIRequest, service: str) -> HttpResponse:
-    return ariadne_view(request, service)
+    return await ariadne_view(request, service)

--- a/apps/codecov-api/graphql_api/views.py
+++ b/apps/codecov-api/graphql_api/views.py
@@ -440,6 +440,12 @@ async def ariadne_view(request: WSGIRequest, service: str) -> HttpResponse:
     return response
 
 
+ariadne_view.csrf_exempt = True
+
+
 @jwt_middleware
 async def sentry_ariadne_view(request: WSGIRequest, service: str) -> HttpResponse:
     return await ariadne_view(request, service)
+
+
+sentry_ariadne_view.csrf_exempt = True


### PR DESCRIPTION
This change adds a new middleware to process the JWT authentication for communicating with Sentry. It also adds a new GraphQL endpoint that uses this middleware for authentication (shouldn't affect existing endpoint).

This assumes the JWT claim to look something like:

```
{
  'g_u': 'github_service_id',
  'g_p': 'github',
}
```