### PR TITLE
Implement consuming `vitest` json with `evals` metadata

### DIFF
--- a/apps/worker/rollouts/__init__.py
+++ b/apps/worker/rollouts/__init__.py
@@ -14,3 +14,5 @@ PARALLEL_COMPONENT_COMPARISON = Feature("parallel_component_comparison")
 TA_TIMESERIES = Feature("ta_timeseries")
 
 DISABLE_CROSS_POLLINATION_MESSAGE = Feature("disable_cross_pollination_message")
+
+ALLOW_VITEST_EVALS = Feature("vitest_evals")

--- a/apps/worker/services/test_analytics/ta_processor.py
+++ b/apps/worker/services/test_analytics/ta_processor.py
@@ -1,8 +1,12 @@
+import base64
 import logging
+import zlib
 from typing import Any
 
+import orjson
 from test_results_parser import parse_raw_upload
 
+from rollouts import ALLOW_VITEST_EVALS
 from services.processing.types import UploadArguments
 from services.test_analytics.ta_metrics import write_tests_summary
 from services.test_analytics.ta_processing import (
@@ -61,7 +65,24 @@ def ta_processor_impl(
         return False
 
     try:
-        parsing_infos, readable_file = parse_raw_upload(payload_bytes)
+        # Consuming `vitest` JSON output is just a temporary solution until we have
+        # a properly standardized and implemented junit xml extension for carrying
+        # evals metadata (or any kind of metadata/properties really).
+        # This code is just for internal testing, it should *not* be stabilized,
+        # but rather removed completely once we have implemented this properly.
+        # "famous last words" applies here, lol.
+        parsing_infos = None
+        try_vitest_evals = ALLOW_VITEST_EVALS.check_value(
+            ta_proc_info.repository.repoid, default=False
+        )
+        if try_vitest_evals:
+            try:
+                parsing_infos, readable_file = try_parsing_vitest_evals(payload_bytes)
+            except Exception:
+                pass
+
+        if not parsing_infos:
+            parsing_infos, readable_file = parse_raw_upload(payload_bytes)
     except RuntimeError as exc:
         if update_state:
             handle_parsing_error(upload, exc)
@@ -93,3 +114,44 @@ def ta_processor_impl(
             archive_service, ta_proc_info.user_yaml, upload, readable_file
         )
     return True
+
+
+def try_parsing_vitest_evals(raw_upload: bytes):
+    json = orjson.loads(raw_upload)
+
+    parsing_infos = []
+    readable_file = b""
+
+    for file in json["test_results_files"]:
+        data = zlib.decompress(base64.b64decode(file["data"]))
+        file_json = orjson.loads(data)
+
+        readable_file += f"# path={file['filename']}\n".encode()
+        readable_file += data
+        readable_file += b"\n<<<<<< EOF\n"
+
+        testruns = []
+
+        for test_file in file_json["testResults"]:
+            testruns = [
+                {
+                    "filename": test_file["name"],
+                    "classname": test_result["ancestorTitles"][-1],
+                    "name": test_result["title"],
+                    "computed_name": f"{test_result['ancestorTitles'][-1]} > {test_result['title']}",
+                    "testsuite": "",
+                    "duration": test_result["duration"] / 1000.0,
+                    "outcome": "pass"
+                    if test_result["status"] == "passed"
+                    else "failure",
+                    "properties": test_result.get("meta"),
+                    "failure_message": "\n".join(test_result["failureMessages"]),
+                }
+                for test_result in test_file["assertionResults"]
+            ]
+
+        parsing_infos.append(
+            {"framework": "Vitest", "testruns": testruns, "warnings": []}
+        )
+
+    return (parsing_infos, readable_file)

--- a/apps/worker/services/test_analytics/ta_timeseries.py
+++ b/apps/worker/services/test_analytics/ta_timeseries.py
@@ -73,6 +73,7 @@ def insert_testrun(
                 failure_message=testrun["failure_message"],
                 framework=parsing_info["framework"],
                 filename=testrun["filename"],
+                properties=testrun.get("properties"),
                 repo_id=repo_id,
                 commit_sha=commit_sha,
                 branch=branch,

--- a/apps/worker/services/test_analytics/tests/test_ta_vitest_evals.py
+++ b/apps/worker/services/test_analytics/tests/test_ta_vitest_evals.py
@@ -1,0 +1,75 @@
+import base64
+import zlib
+
+import orjson
+import pytest
+
+from services.processing.types import UploadArguments
+from services.test_analytics.ta_processor import ta_processor_impl
+from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
+from shared.django_apps.reports.tests.factories import UploadFactory
+from shared.django_apps.ta_timeseries.models import Testrun
+
+
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
+def test_ta_stores_vitest_evals(mocker, mock_storage):
+    mocker.patch("rollouts.ALLOW_VITEST_EVALS.check_value", return_value=True)
+
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch="main")
+    upload = UploadFactory.create(
+        report__commit=commit, state="processing", storage_path="path/to/valid.json"
+    )
+
+    argument: UploadArguments = {"upload_id": upload.id}
+
+    # Example output taken from <https://github.com/getsentry/vitest-evals/issues/13#issuecomment-2835687888>
+    meta = {
+        "eval": {
+            "scores": [
+                {
+                    "score": 0.6,
+                    "metadata": {
+                        "rationale": "The submitted answer includes all the factual content of the expert answer, specifically the SENTRY_DSN URL, which is the key piece of information. Additionally, the submission provides extra context by mentioning the project name and suggesting how the DSN can be used to initialize Sentry's SDKs. This makes the submission a superset of the expert answer, as it contains all the information from the expert answer plus additional relevant details. There is no conflict between the two answers, and the additional information in the submission is consistent with the expert answer."
+                    },
+                    "name": "Factuality2",
+                }
+            ],
+            "avgScore": 0.6,
+        }
+    }
+    vitest_json = {
+        "testResults": [
+            {
+                "assertionResults": [
+                    {
+                        "ancestorTitles": ["create-project"],
+                        "status": "passed",
+                        "title": "Create a new SENTRY_DSN for 'sentry-mcp-evals/cloudflare-mcp'",
+                        "duration": 7217.116875,
+                        "failureMessages": [],
+                        "meta": meta,
+                    }
+                ],
+                "status": "passed",
+                "name": "/Users/dcramer/src/sentry-mcp/packages/mcp-server-evals/src/evals/create-dsn.eval.ts",
+            }
+        ]
+    }
+    vitest_data = base64.b64encode(zlib.compress(orjson.dumps(vitest_json))).decode()
+    upload_contents = orjson.dumps(
+        {"test_results_files": [{"filename": "foo.json", "data": vitest_data}]}
+    )
+    mock_storage.write_file("archive", "path/to/valid.json", upload_contents)
+
+    result = ta_processor_impl(
+        repository.repoid, commit.commitid, {}, argument, update_state=True
+    )
+
+    assert result is True
+
+    testrun_db = Testrun.objects.filter(upload_id=upload.id).first()
+    assert testrun_db is not None
+    assert testrun_db.branch == commit.branch
+    assert testrun_db.upload_id == upload.id
+    assert testrun_db.properties == meta

--- a/apps/worker/tasks/tests/integration/test_upload_e2e.py
+++ b/apps/worker/tasks/tests/integration/test_upload_e2e.py
@@ -31,6 +31,7 @@ def write_raw_upload(
     commitid: str,
     contents: bytes,
     upload_json: dict | None = None,
+    key_suffix: str = "",
 ):
     report_id = uuid4().hex
     written_path = f"upload/{report_id}.txt"
@@ -40,7 +41,7 @@ def write_raw_upload(
     upload_json.update({"reportid": report_id, "url": written_path})
     upload = json.dumps(upload_json)
 
-    redis_key = f"uploads/{repoid}/{commitid}"
+    redis_key = f"uploads/{repoid}/{commitid}{key_suffix}"
     redis.lpush(redis_key, upload)
 
     return upload_json


### PR DESCRIPTION
This is just a temporary solution to ingest and store evals metadata, before we have this properly standardized/implemented as a junit xml extension.
    
Eventually, we want to display this metadata as part of the PR comment.

---

The example snippet comes from https://github.com/getsentry/vitest-evals/issues/13#issuecomment-2835687888, first step of https://github.com/codecov/test-results-action/issues/120