### PR TITLE
fix: error code gql resolver

### DIFF
--- a/apps/codecov-api/graphql_api/types/enums/upload_error_enum.graphql
+++ b/apps/codecov-api/graphql_api/types/enums/upload_error_enum.graphql
@@ -7,4 +7,6 @@ enum UploadErrorEnum {
 
   UNKNOWN_PROCESSING
   UNKNOWN_STORAGE
+
+  UNKNOWN_ERROR_CODE
 }

--- a/apps/codecov-api/graphql_api/types/upload/upload.py
+++ b/apps/codecov-api/graphql_api/types/upload/upload.py
@@ -48,7 +48,10 @@ def resolve_errors(report_session: ReportSession, info: GraphQLResolveInfo, **kw
 
 @upload_error_bindable.field("errorCode")
 def resolve_error_code(error, info: GraphQLResolveInfo) -> UploadErrorEnum:
-    return UploadErrorEnum(error.error_code)
+    try:
+        return UploadErrorEnum(error.error_code)
+    except ValueError:
+        return UploadErrorEnum.UNKNOWN_ERROR_CODE
 
 
 @upload_bindable.field("ciUrl")

--- a/libs/shared/shared/upload/constants.py
+++ b/libs/shared/shared/upload/constants.py
@@ -234,3 +234,5 @@ class UploadErrorCode(StrEnum):
     # We don't want these - try to add error cases when they arise
     UNKNOWN_PROCESSING = "unknown_processing"
     UNKNOWN_STORAGE = "unknown_storage"
+
+    UNKNOWN_ERROR_CODE = "unknown_error_code"


### PR DESCRIPTION
we don't want unknown error codes to cause exceptions so i'm adding an unkown_error_code variant to the enum that we can fallback to when we encounter an error code

the frontend components that encounter an unknown error code should probably ignore it most of the time, it will probably signify error codes that are only relevant to backend components and thus don't get a dedicated variant in the UploadErrorEnum gql type