### PR TITLE
Add JWT permissions to Django REST Framework

### DIFF
--- a/apps/codecov-api/codecov_auth/utils.py
+++ b/apps/codecov-api/codecov_auth/utils.py
@@ -1,0 +1,25 @@
+import jwt
+from django.conf import settings
+from django.http import HttpRequest
+
+
+def get_sentry_jwt_payload(request: HttpRequest) -> dict:
+    """
+    Get the JWT Payload for requests that comes from Sentry.
+    """
+    # Extract JWT token from Authorization header
+    auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+    if not auth_header.startswith("Bearer "):
+        raise PermissionError("Missing or invalid Authorization header")
+
+    token = auth_header.split(" ")[1]
+    payload = jwt.decode(
+        token,
+        settings.SENTRY_JWT_SHARED_SECRET,
+        algorithms=["HS256"],
+        options={"verify_exp": True, "require": ["exp", "iat", "iss"]},
+    )
+
+    if payload.get("iss") != "https://sentry.io":
+        raise PermissionError("Invalid issuer")
+    return payload

--- a/apps/codecov-api/graphql_api/tests/test_sentry_view.py
+++ b/apps/codecov-api/graphql_api/tests/test_sentry_view.py
@@ -25,7 +25,7 @@ class TestSentryAriadneView(TestCase):
             "g_p": "github",
             "exp": int(time.time()) + 3600,  # Expires in 1 hour
             "iat": int(time.time()),  # Issued at current time
-            "iss": "sentry",  # Issuer
+            "iss": "https://sentry.io",  # Issuer
         }
         return jwt.encode(payload, settings.SENTRY_JWT_SHARED_SECRET, algorithm="HS256")
 
@@ -71,7 +71,7 @@ class TestSentryAriadneView(TestCase):
         response = self.do_query(query=self.query)
 
         assert response.status_code == 403
-        assert response.content.decode() == "Missing or invalid Authorization header"
+        assert response.content.decode() == "Missing or Invalid Authorization header"
 
     def test_sentry_ariadne_view_invalid_token(self):
         """Test sentry_ariadne_view with invalid JWT token"""
@@ -87,7 +87,7 @@ class TestSentryAriadneView(TestCase):
             "g_p": "github",
             "exp": int(time.time()) - 3600,  # Expired 1 hour ago
             "iat": int(time.time()),  # Issued at current time
-            "iss": "sentry",  # Issuer
+            "iss": "https://sentry.io",  # Issuer
         }
         expired_token = jwt.encode(
             payload, settings.SENTRY_JWT_SHARED_SECRET, algorithm="HS256"
@@ -115,7 +115,7 @@ class TestSentryAriadneView(TestCase):
             "g_u": "1234567890",
             "g_p": "github",
             "iat": int(time.time()),
-            "iss": "sentry",
+            "iss": "https://sentry.io",
         }
         token = jwt.encode(
             payload, settings.SENTRY_JWT_SHARED_SECRET, algorithm="HS256"

--- a/apps/codecov-api/webhook_handlers/permissions.py
+++ b/apps/codecov-api/webhook_handlers/permissions.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+import jwt
+from rest_framework.permissions import BasePermission
+
+from codecov_auth.utils import get_sentry_jwt_payload
+from webhook_handlers.views import WEBHOOKS_ERRORED
+
+
+class JWTAuthenticationPermission(BasePermission):
+    """
+    Permission class to validate JWT tokens in Sentry webhook requests.
+    """
+
+    def has_permission(self, request: Any, view: Any) -> bool:
+        try:
+            payload = get_sentry_jwt_payload(request)
+        except PermissionError:
+            self._inc_err("missing_or_invalid_auth_header")
+            return False
+        except jwt.ExpiredSignatureError:
+            self._inc_err("token_expired")
+            return False
+        except jwt.InvalidTokenError:
+            self._inc_err("invalid_token")
+            return False
+
+        # Set the validated payload on the request for use in the view
+        request.jwt_payload = payload
+        return True
+
+    def _inc_err(self, reason: str) -> None:
+        """Increment error counter for metrics tracking"""
+        WEBHOOKS_ERRORED.labels(
+            service="sentry",
+            event="webhook",
+            action="",
+            error_reason=reason,
+        ).inc()

--- a/apps/codecov-api/webhook_handlers/tests/test_jwt_permissions.py
+++ b/apps/codecov-api/webhook_handlers/tests/test_jwt_permissions.py
@@ -1,0 +1,96 @@
+import time
+from unittest.mock import patch
+
+import jwt
+import pytest
+from django.conf import settings
+from rest_framework.test import APIRequestFactory
+
+from webhook_handlers.permissions import JWTAuthenticationPermission
+
+
+@pytest.fixture
+def request_factory():
+    return APIRequestFactory()
+
+
+@pytest.fixture
+def valid_jwt_token():
+    return jwt.encode(
+        {
+            "exp": int(time.time()) + 3600,  # Expires in 1 hour
+            "iat": int(time.time()),  # Issued at current time
+            "iss": "https://sentry.io",  # Issuer
+        },
+        settings.SENTRY_JWT_SHARED_SECRET,
+        algorithm="HS256",
+    )
+
+
+def test_valid_token(request_factory, valid_jwt_token):
+    """Test that a valid JWT token is accepted"""
+    request = request_factory.get(
+        "/",
+        HTTP_AUTHORIZATION=f"Bearer {valid_jwt_token}",
+    )
+    permission = JWTAuthenticationPermission()
+    assert permission.has_permission(request, None) is True
+    assert request.jwt_payload is not None
+
+
+def test_missing_auth_header(request_factory):
+    """Test that missing Authorization header is rejected"""
+    request = request_factory.get("/")
+    permission = JWTAuthenticationPermission()
+    assert permission.has_permission(request, None) is False
+
+
+def test_invalid_auth_format(request_factory):
+    """Test that invalid Authorization header format is rejected"""
+    request = request_factory.get("/", HTTP_AUTHORIZATION="InvalidFormat")
+    permission = JWTAuthenticationPermission()
+    assert permission.has_permission(request, None) is False
+
+
+def test_expired_token(request_factory):
+    """Test that expired token is rejected"""
+    token = jwt.encode(
+        {
+            "exp": int(time.time()) - 3600,  # Expired 1 hour ago
+            "iat": int(time.time()) - 7200,  # Issued 2 hours ago
+            "iss": "https://sentry.io",
+        },
+        settings.SENTRY_JWT_SHARED_SECRET,
+        algorithm="HS256",
+    )
+    request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+    permission = JWTAuthenticationPermission()
+    assert permission.has_permission(request, None) is False
+
+
+def test_missing_required_claims(request_factory):
+    """Test that token missing required claims is rejected"""
+    token = jwt.encode(
+        {},
+        settings.SENTRY_JWT_SHARED_SECRET,
+        algorithm="HS256",
+    )
+    request = request_factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+    permission = JWTAuthenticationPermission()
+    assert permission.has_permission(request, None) is False
+
+
+def test_error_tracking(request_factory):
+    """Test that errors are tracked with metrics"""
+    request = request_factory.get("/")
+    permission = JWTAuthenticationPermission()
+
+    with patch("webhook_handlers.permissions.WEBHOOKS_ERRORED") as mock_metrics:
+        permission.has_permission(request, None)
+        mock_metrics.labels.assert_called_once_with(
+            service="sentry",
+            event="webhook",
+            action="",
+            error_reason="missing_or_invalid_auth_header",
+        )
+        mock_metrics.labels.return_value.inc.assert_called_once()


### PR DESCRIPTION
This change adds the JWT auth check for Sentry requests. It also removes the user/provider claims requirements, as it's not required for webhook requests.

This is specifically for Webhooks, but does not add the Webhook API endpoint.