### PR TITLE
build: make shared use the same makefile and ci setup as worker/api

### DIFF
--- a/.github/workflows/_build-requirements.yml
+++ b/.github/workflows/_build-requirements.yml
@@ -12,6 +12,9 @@ on:
       make_target_prefix:
         type: string
         default: ""
+      push_reqs:
+        type: boolean
+        default: true
 
 env:
   AR_REPO: ${{ inputs.repo }}
@@ -62,6 +65,6 @@ jobs:
           make ${{ inputs.make_target_prefix }}save.requirements
 
       - name: Push Requirements
-        if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        if: ${{ inputs.push_reqs && steps.cache-requirements.outputs.cache-hit != 'true' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
           make ${{ inputs.make_target_prefix }}push.requirements

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -10,7 +10,48 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: "read"
+  id-token: "write"
+  issues: "write"
+  pull-requests: "write"
+
 jobs:
+  shared-reqs:
+    name: Build Requirements (Shared)
+    if: ${{ inputs.skip == false }}
+    uses: ./.github/workflows/_build-requirements.yml
+    secrets: inherit
+    with:
+      repo: codecov/dev-shared
+      output_directory: libs/shared
+      make_target_prefix: shared.
+      push_reqs: false
+
+  shared-build:
+    name: Build App (Shared)
+    needs: shared-reqs
+    if: ${{ inputs.skip == false }}
+    uses: ./.github/workflows/_build-app.yml
+    secrets: inherit
+    with:
+      repo: codecov/dev-shared
+      output_directory: libs/shared
+      make_target_prefix: shared.
+
+  shared-test:
+    name: Test (Shared)
+    if: ${{ inputs.skip == false }}
+    needs: [shared-build]
+    uses: ./.github/workflows/_run-tests.yml
+    secrets: inherit
+    with:
+      repo: codecov/dev-shared
+      output_directory: libs/shared
+      flag_prefix: shared
+      pytest_rootdir: /app
+      make_target_prefix: shared.
+
   shared-benchmark:
     name: Benchmarks (Shared)
     if: ${{ inputs.skip == false }}
@@ -31,108 +72,6 @@ jobs:
         with:
           run: uv run --project libs/shared pytest --rootdir=libs/shared libs/shared/tests/benchmarks/ --codspeed
           token: ${{ secrets.CODSPEED_TOKEN }}
-
-  shared-test:
-    name: Test (Shared)
-    if: ${{ inputs.skip == false }}
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: libs/shared
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
-
-      - name: Build test environment
-        run: |
-          make test_env.build
-
-      - name: Bring containers up
-        run: |
-          make test_env.up
-
-      - name: Run tests
-        run: |
-          make test_env.test PYTEST_ROOTDIR=/app
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: shared-coveragefiles
-          path: libs/shared/tests/*.coverage.xml
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: shared-junitfiles
-          path: libs/shared/tests/*junit*.xml
-
-  shared-upload-to-codecov:
-    name: Upload to Codecov (shared)
-    if: ${{ inputs.skip == false }}
-    needs: [shared-test]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - codecov_url_secret: CODECOV_URL
-            codecov_token_secret: CODECOV_ORG_TOKEN
-            name: prod
-          - codecov_url_secret: CODECOV_STAGING_URL
-            codecov_token_secret: CODECOV_ORG_TOKEN_STAGING
-            name: staging
-          - codecov_url_secret: CODECOV_QA_URL
-            codecov_token_secret: CODECOV_QA_ORG
-            name: qa
-          - codecov_url_secret: CODECOV_PUBLIC_QA_URL
-            codecov_token_secret: CODECOV_PUBLIC_QA_TOKEN
-            name: public qa
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Download coverage
-        id: download_coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: shared-coveragefiles
-
-      - name: Download test results
-        id: download_test_results
-        uses: actions/download-artifact@v4
-        with:
-          name: shared-junitfiles
-
-      - name: Uploading unit test coverage (${{ matrix.name }})
-        uses: codecov/codecov-action@v5
-        with:
-          files: ${{ steps.download_coverage.outputs.download-path }}/unit.coverage.xml
-          flags: shared-docker-uploader
-          disable_search: true
-          # Strange workaround: API has a `codecov` directory in the repo root
-          # which conflicts with the action's `codecov` binary
-          use_pypi: true
-          token: ${{ secrets[matrix.codecov_token_secret] }}
-          url: ${{ secrets[matrix.codecov_url_secret] }}
-          recurse_submodules: true
-
-      - name: Uploading unit test results (${{ matrix.name }})
-        uses: codecov/test-results-action@v1
-        with:
-          files: ${{ steps.download_test_results.outputs.download-path }}/unit.junit.xml
-          flags: shared-docker-uploader
-          disable_search: true
-          token: ${{ secrets[matrix.codecov_token_secret] }}
-          url: ${{ secrets[matrix.codecov_url_secret] }}
-          # The coverage action will have installed codecovcli with pip. The
-          # actual binary will be found in $PATH.
-          binary: codecovcli
 
   # This job works around a strange interaction between reusable workflows and
   # path filters.

--- a/ci-tests.docker-compose.yml
+++ b/ci-tests.docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - redis
       - timescale
     volumes:
-      - ./${APP_DIR}:/app/${APP_DIR}
+      - ./:/app
       - ./tools/devenv/config/test.yml:/config/codecov.yml
     environment:
       # Improves pytest-cov performance in python 3.12

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,29 @@
 ignore:
   - "**tests**/test_*.py"
 
-flag_management:
-  default_rules:
-    carryforward: true
-    statuses:
-      - type: project
+coverage:
+  status:
+    project:
+      default:
         target: auto
         threshold: 1
-      - type: patch
+    patch:
+      default:
         target: 90
+
+flags:
+  workerunit:
+    carryforward: true
+  workerintegration:
+    carryforward: true
+  apiunit:
+    carryforward: true
+  apiintegration:
+    carryforward: true
+  sharedunit:
+    carryforward: true
+  sharedintegration:
+    carryforward: true
 
 component_management:
   individual_components:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
   # Dummy service to run shared tests
   shared:
     # This is the name of the image build in libs/shared
-    image: shared-shared
+    image: ${AR_REPO_PREFIX-codecov}/dev-shared
     tty: true
     environment:
       - SETUP__TA_TIMESERIES__ENABLED=true

--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -41,11 +41,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # The resulting requirements.txt includes ourselves as a dependency we should install
 # "editably". Filter that out, leaving only external dependencies.
-RUN grep -v '^-e ' requirements.txt > ${APP_DIR}/requirements.remote.txt
+RUN grep -v '^-e ' requirements.txt > requirements.remote.txt
 
 # Fetch/build wheels for all external dependencies.
 RUN --mount=type=bind,source=libs/shared,target=libs/shared \
-    (cd ${APP_DIR} && pip wheel -w /wheels --find-links /wheels -r requirements.remote.txt)
+    (cd ${APP_DIR} && pip wheel -w /wheels --find-links /wheels -r /requirements.remote.txt)
 
 # Build a wheel for ourselves
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/docker/Makefile.ci-tests
+++ b/docker/Makefile.ci-tests
@@ -27,6 +27,7 @@ _test_env.prepare:
 	docker-compose -f ci-tests.docker-compose.yml exec repo apt-get update
 	docker-compose -f ci-tests.docker-compose.yml exec repo apt-get install -y git build-essential netcat-traditional
 	docker-compose -f ci-tests.docker-compose.yml exec repo git config --global --add safe.directory /app || true
+	docker-compose -f ci-tests.docker-compose.yml exec repo pip install -e ../../libs/shared
 
 # Outside the Docker env: Block until Postgres and Timescale are healthy.
 _test_env.check_db:

--- a/libs/shared/docker/Dockerfile
+++ b/libs/shared/docker/Dockerfile
@@ -1,32 +1,12 @@
 # syntax=docker/dockerfile:1.4
-ARG PYTHON_IMAGE=ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+ARG REQUIREMENTS_IMAGE
 
-FROM $PYTHON_IMAGE as build
+ARG PYTHON_IMAGE=ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    git
-
-ENV UV_LINK_MODE=copy
-ENV PATH=/root/.local/bin:/app/libs/shared/.venv/bin:$PATH
-
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv tool install codecov-cli
+FROM $REQUIREMENTS_IMAGE as app
 
 # Change the working directory to the `app/libs/shared` directory
+COPY . /app/libs/shared
 WORKDIR /app/libs/shared
-
-# Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project
-
-# Copy the project into the image
-ADD . /app/libs/shared
-
-# Sync the project
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen
 
 CMD ["uv", "run", "bash"]

--- a/tools/devenv/Makefile.devenv
+++ b/tools/devenv/Makefile.devenv
@@ -8,7 +8,7 @@ devenv.build.api:
 
 .PHONY: devenv.build.shared
 devenv.build.shared:
-	$(MAKE) -C libs/shared test_env.build
+	$(MAKE) shared.build
 
 .PHONY: devenv.build
 devenv.build: devenv.build.api devenv.build.worker devenv.build.shared


### PR DESCRIPTION
more cleanup. moves closer towards a monolith

<!-- %%% BRANCHLESS STACK INFO START %%% -->
<details open><summary> Stack info:</summary>

| Stack 1 |
|-|
|<ul><li>https://github.com/codecov/umbrella/pull/167</li><li>https://github.com/codecov/umbrella/pull/168</li><li>https://github.com/codecov/umbrella/pull/169</li><li>➡️https://github.com/codecov/umbrella/pull/170</li></ul>|

</details>
<!-- %%% BRANCHLESS STACK INFO END %%% -->