### PR TITLE
Make Accounts more apparent on Owner admin

### DIFF
--- a/apps/codecov-api/codecov_auth/admin.py
+++ b/apps/codecov-api/codecov_auth/admin.py
@@ -649,9 +649,10 @@ class OwnerAdmin(AdminMixin, admin.ModelAdmin):
             },
         ),
         (
-            "Plan fields",
+            "Plan fields - if the Owner has an Account, none of these fields are used, refer to the ones on the Account",
             {
                 "fields": [
+                    "account",
                     "plan_auto_activate",
                     "plan",
                     "plan_user_count",
@@ -687,7 +688,6 @@ class OwnerAdmin(AdminMixin, admin.ModelAdmin):
                     "bot",
                     "max_upload_limit",
                     "organizations",
-                    "account",
                     "permission",
                     "student_created_at",
                     "student_updated_at",


### PR DESCRIPTION
small change to help anyone using the admin to change plan or seats

preview:
![Screenshot 2025-05-21 at 5 24 22 PM](https://github.com/user-attachments/assets/b4bba928-0c46-42e6-9ce6-d173e629e8b3)
