### PR TITLE
fix(shared): Clear environment to reduce flakiness from external variables

### DIFF
--- a/libs/shared/tests/unit/test_config.py
+++ b/libs/shared/tests/unit/test_config.py
@@ -400,6 +400,7 @@ class TestConfig:
                     {"assets": "aaa", "dependancies": "bbb"}
                 ),
             },
+            clear=True,
         )
         expected_res = {
             "services": {


### PR DESCRIPTION
When running the local development environment, `SETUP__TA_TIMESERIES__ENABLED` gets set in `docker-compose.yml` which this test includes in the returned config and causes it to fail. Adding the clear option ensures that only the expected mock environment variables get used for the test.