### PR TITLE
ci(shared): Skip CodSpeed benchmark on `merge_group`

### DIFF
--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -2,7 +2,7 @@ name: Shared CI
 
 on:
   workflow_call:
-    inputs: 
+    inputs:
       skip:
         type: boolean
         default: false
@@ -54,7 +54,9 @@ jobs:
 
   shared-benchmark:
     name: Benchmarks (Shared)
-    if: ${{ inputs.skip == false }}
+    # Skip on merge_group because CodSpeed does not support it yet.
+    # Ref: https://github.com/CodSpeedHQ/action/issues/126
+    if: ${{ inputs.skip == false && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
CodSpeed does not yet support merge queues (https://github.com/CodSpeedHQ/action/issues/126) so this reduces the resulting false failures.

Example of one such failure: https://github.com/codecov/umbrella/actions/runs/15303668976/job/43050709204