### PR TITLE
build: remove dev deps from prod image, add separate test-reqs and test-app images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+pytest_cache/
+ruff_cache/
+.venv/
+.vscode/

--- a/.github/workflows/_build-app.yml
+++ b/.github/workflows/_build-app.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: 'recursive'
+
       - id: "auth"
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         name: "Authenticate to Google Cloud"
@@ -84,3 +85,64 @@ jobs:
           make ${{ inputs.make_target_prefix }}build.app
           make ${{ inputs.make_target_prefix }}save.app
 
+  build-test-app:
+    name: Build Test App
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          submodules: 'recursive'
+
+      - id: "auth"
+        if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2.1.2"
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{ secrets.CODECOV_GCP_WIDP }}
+          service_account: ${{ secrets.CODECOV_GCP_WIDSA }}
+
+      - name: Docker configuration
+        if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |-
+          echo ${{steps.auth.outputs.access_token}} | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
+
+      - name: Cache Test Requirements
+        id: cache-test-requirements
+        uses: actions/cache@v4
+        env:
+          cache-name: umbrella-test-requirements
+        with:
+          path: |
+            ./test-requirements.tar
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('./uv.lock') }}-${{ hashFiles('docker/Dockerfile.requirements') }}-${{ hashFiles('docker/Dockerfile.test-requirements') }}-${{ hashFiles('libs/shared/**') }}
+
+      - name: Cache Test App
+        id: cache-test-app
+        uses: actions/cache@v4
+        env:
+          cache-name: ${{ inputs.repo }}-test-app
+        with:
+          path: |
+            ${{ inputs.output_directory }}/test-app.tar
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
+
+      - name: Load test requirements from cache
+        if: ${{ steps.cache-test-requirements.outputs.cache-hit == 'true' }}
+        run: |
+          make load.test-requirements
+
+      # This shouldn't happen; the _build-requirements.yml job should have run.
+      - name: Build/pull test requirements
+        if: ${{ steps.cache-test-requirements.outputs.cache-hit != 'true' }}
+        run: |
+          echo "Warning: test requirements image not in cache, building a new one"
+          make build.test-requirements
+          make save.test-requirements
+
+      - name: Build Test App
+        run: |
+          make ${{ inputs.make_target_prefix }}build.test-app
+          make ${{ inputs.make_target_prefix }}save.test-app

--- a/.github/workflows/_build-requirements.yml
+++ b/.github/workflows/_build-requirements.yml
@@ -9,18 +9,20 @@ env:
 jobs:
   build:
     name: Build Requirements
-    strategy:
-      matrix:
-        # Build on amd64 and arm64
-        # TODO Use docker buildx to build multi-arch image
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
+      ######
+      # Setting up caches for the base and test requirements images.
+      #
+      # If both caches hit, we don't need to do anything else.
+      # Otherwise, we have to auth with GCP and Docker Hub, build the missing
+      # images, and then push them.
+      ######
       - name: Cache Requirements
         id: cache-requirements
         uses: actions/cache@v4
@@ -33,8 +35,20 @@ jobs:
             ./requirements.tar
           key: ${{ runner.os }}-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('./uv.lock') }}-${{ hashFiles('docker/Dockerfile.requirements') }}-${{ hashFiles('libs/shared/**') }}
 
+      - name: Cache Test Requirements
+        id: cache-test-requirements
+        uses: actions/cache@v4
+        env:
+          cache-name: umbrella-test-requirements
+        with:
+          path: |
+            ./test-requirements.tar
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('./uv.lock') }}-${{ hashFiles('docker/Dockerfile.requirements') }}-${{ hashFiles('docker/Dockerfile.test-requirements') }}-${{ hashFiles('libs/shared/**') }}
+
       - id: "auth"
-        if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        if: |
+          (steps.cache-requirements.outputs.cache-hit != 'true' || steps.cache-test-requirements.outputs.cache-hit != 'true') &&
+          !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov'
         name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@v2.1.2"
         with:
@@ -43,10 +57,15 @@ jobs:
           service_account: ${{ secrets.CODECOV_GCP_WIDSA }}
 
       - name: Docker configuration
-        if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        if: |
+          (steps.cache-requirements.outputs.cache-hit != 'true' || steps.cache-test-requirements.outputs.cache-hit != 'true') &&
+          !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov'
         run: |-
           echo ${{steps.auth.outputs.access_token}} | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
 
+      ######
+      # Building/pushing the base requirements image if not cached
+      ######
       - name: Build/pull requirements
         if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' }}
         run: |
@@ -57,3 +76,17 @@ jobs:
         if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
           make push.requirements
+
+      ######
+      # Building/pushing the test requirements image if not cached
+      ######
+      - name: Build/pull test requirements
+        if: ${{ steps.cache-test-requirements.outputs.cache-hit != 'true' }}
+        run: |
+          make build.test-requirements
+          make save.test-requirements
+
+      - name: Push Test Requirements
+        if: ${{ steps.cache-test-requirements.outputs.cache-hit != 'true' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |
+          make push.test-requirements

--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -41,18 +41,18 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - name: Cache App
-        id: cache-app
+      - name: Cache Test App
+        id: cache-test-app
         uses: actions/cache@v4
         env:
-          cache-name: ${{ inputs.repo }}-app
+          cache-name: ${{ inputs.repo }}-test-app
         with:
           path: |
-            ${{ inputs.output_directory }}/app.tar
+            ${{ inputs.output_directory }}/test-app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          docker load --input ${{ inputs.output_directory }}/app.tar
+          docker load --input ${{ inputs.output_directory }}/test-app.tar
       - name: Install docker compose
         run: |
           sudo curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -53,6 +53,7 @@ jobs:
               - 'docker/Makefile.docker'
               - 'docker/Makefile.ci-tests'
               - 'docker/Dockerfile.requirements'
+              - 'docker/Dockerfile.test-requirements'
               - 'docker/Dockerfile'
               - 'uv.lock'
               - 'ci-tests.docker-compose.yml'

--- a/ci-tests.docker-compose.yml
+++ b/ci-tests.docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   repo:
-    image: ${AR_REPO}:${VERSION}
+    image: ${AR_REPO}:test-${VERSION}
     tty: true
     depends_on:
       - minio

--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -29,6 +29,7 @@ ENV UV_LINK_MODE=copy \
     UV_PROJECT_ENVIRONMENT=/app
 
 # Export a requirements.txt
+# See pyproject.toml's default-groups attribute for contents
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=./pyproject.toml,target=./pyproject.toml \
     --mount=type=bind,source=./uv.lock,target=./uv.lock \

--- a/docker/Dockerfile.test-requirements
+++ b/docker/Dockerfile.test-requirements
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.4
+ARG REQUIREMENTS_IMAGE
+
+FROM $REQUIREMENTS_IMAGE as test_reqs
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_PROJECT_ENVIRONMENT=/app
+
+RUN apt-get update
+RUN apt-get install -y git build-essential netcat-traditional
+RUN git config --global --add safe.directory /app || true
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=./pyproject.toml,target=./pyproject.toml \
+    --mount=type=bind,source=./uv.lock,target=./uv.lock \
+    --mount=type=bind,source=libs/shared,target=libs/shared \
+    uv pip install --group dev --system

--- a/docker/Makefile.ci-tests
+++ b/docker/Makefile.ci-tests
@@ -23,10 +23,8 @@ _test_env.up:
 	docker compose -f ci-tests.docker-compose.yml up -d
 
 # Outside the Docker env: Install some runtime dependencies inside the running Docker env.
+# TODO: Remove this step entirely after shared is no longer a package.
 _test_env.prepare:
-	docker-compose -f ci-tests.docker-compose.yml exec -u root repo apt-get update
-	docker-compose -f ci-tests.docker-compose.yml exec -u root repo apt-get install -y git build-essential netcat-traditional
-	docker-compose -f ci-tests.docker-compose.yml exec repo git config --global --add safe.directory /app || true
 	docker-compose -f ci-tests.docker-compose.yml exec repo pip install -e ../../libs/shared
 
 # Outside the Docker env: Block until Postgres and Timescale are healthy.

--- a/docker/Makefile.docker
+++ b/docker/Makefile.docker
@@ -10,6 +10,9 @@ DOCKER_REQS_SHA := $(shell sha1sum docker/Dockerfile.requirements | head -c 40)
 UV_LOCK_SHA := $(shell sha1sum ./uv.lock | head -c 40)
 export REQUIREMENTS_TAG := reqs-${UV_LOCK_SHA}-${DOCKER_REQS_SHA}-${SHARED_SHA}
 
+DOCKER_TEST_REQS_SHA := $(shell sha1sum docker/Dockerfile.test-requirements | head -c 40)
+export TEST_REQS_TAG := test-$(shell echo ${DOCKER_TEST_REQS_SHA} ${REQUIREMENTS_TAG} | sha1sum | head -c 40)
+
 ######
 # Generic targets for building images.
 #
@@ -37,12 +40,21 @@ build.requirements:
                -t ${AR_REQS_REPO}:${REQUIREMENTS_TAG} \
 	       -t ${CI_REQS_REPO}:${REQUIREMENTS_TAG}
 
+# Build a test requirements image. Requires that the base reqs image exist.
+build.test-requirements:
+	docker pull ${AR_REQS_REPO}:${TEST_REQS_TAG} || docker build \
+			   --network host \
+	       -f docker/Dockerfile.test-requirements . \
+	       -t ${AR_REQS_REPO}:${TEST_REQS_TAG} \
+	       -t ${CI_REQS_REPO}:${TEST_REQS_TAG} \
+	       --build-arg REQUIREMENTS_IMAGE=${AR_REQS_REPO}:${REQUIREMENTS_TAG}
+
 # Build an image for local development.
 _build.local:
 	docker build -f docker/Dockerfile . \
 		-t ${AR_REPO}:latest \
 		-t ${AR_REPO}:${VERSION} \
-		--build-arg REQUIREMENTS_IMAGE=${AR_REQS_REPO}:${REQUIREMENTS_TAG} \
+		--build-arg REQUIREMENTS_IMAGE=${AR_REQS_REPO}:${TEST_REQS_TAG} \
 		--build-arg WORKDIR=/app/${APP_DIR} \
 		--build-arg ENTRYPOINT=${ENTRYPOINT} \
 		--build-arg DJANGO_SETTINGS_PARENT=${DJANGO_SETTINGS_PARENT} \
@@ -51,6 +63,7 @@ _build.local:
 # Build an image (+ its reqs base) for local development.
 _build:
 	$(MAKE) build.requirements
+	$(MAKE) build.test-requirements
 	$(MAKE) _build.local
 
 # Build a production image.
@@ -66,6 +79,21 @@ _build.app:
 		--build-arg WORKDIR=/app/${APP_DIR} \
 		--build-arg ENTRYPOINT=${ENTRYPOINT} \
 		--build-arg DJANGO_SETTINGS_PARENT=${DJANGO_SETTINGS_PARENT} \
+		--build-arg RELEASE_VERSION=${VERSION} \
+		--build-arg BUILD_ENV=cloud
+
+# Build a production image based on the test requirements image.
+_build.test-app:
+	docker build -f docker/Dockerfile . \
+		-t ${AR_REPO}:test-latest \
+		-t ${AR_REPO}:test-${VERSION} \
+		--label "org.label-schema.vendor"="Codecov" \
+		--label "org.label-schema.version"="${release_version}-${sha}" \
+		--label "org.opencontainers.image.revision"="$(full_sha)" \
+		--label "org.opencontainers.image.source"="github.com/codecov/umbrella" \
+		--build-arg REQUIREMENTS_IMAGE=${AR_REQS_REPO}:${TEST_REQS_TAG} \
+		--build-arg WORKDIR=/app/${APP_DIR} \
+		--build-arg ENTRYPOINT=${ENTRYPOINT} \
 		--build-arg RELEASE_VERSION=${VERSION} \
 		--build-arg BUILD_ENV=cloud
 
@@ -124,6 +152,11 @@ load.requirements:
 	docker load --input requirements.tar
 	docker tag ${CI_REQS_REPO}:${REQUIREMENTS_TAG} ${AR_REQS_REPO}:${REQUIREMENTS_TAG}
 
+# Load an exported test requirements image (e.g. from GHA's cache)
+load.test-requirements:
+	docker load --input test-requirements.tar
+	docker tag ${CI_REQS_REPO}:${TEST_REQS_TAG} ${AR_REQS_REPO}:${TEST_REQS_TAG}
+
 # Load an exported self-hosted image (e.g. from GHA's cache)
 _load.self-hosted:
 	docker load --input ${APP_DIR}/self-hosted-runtime.tar
@@ -133,10 +166,19 @@ _load.self-hosted:
 _save.app:
 	docker save -o ${APP_DIR}/app.tar ${AR_REPO}:${VERSION}
 
+# Export a production image with test dependencies.
+_save.test-app:
+	docker save -o ${APP_DIR}/test-app.tar ${AR_REPO}:test-${VERSION}
+
 # Export a requirements image.
 save.requirements:
 	docker tag ${AR_REQS_REPO}:${REQUIREMENTS_TAG} ${CI_REQS_REPO}:${REQUIREMENTS_TAG}
 	docker save -o requirements.tar ${CI_REQS_REPO}:${REQUIREMENTS_TAG}
+
+# Export a test requirements image.
+save.test-requirements:
+	docker tag ${AR_REQS_REPO}:${TEST_REQS_TAG} ${CI_REQS_REPO}:${TEST_REQS_TAG}
+	docker save -o test-requirements.tar ${CI_REQS_REPO}:${TEST_REQS_TAG}
 
 # Export a self-hosted image pair (base and runtime)
 _save.self-hosted:
@@ -158,8 +200,14 @@ _push.staging:
 _push.production:
 	docker push ${AR_REPO}:production-${VERSION}
 
+_push.test-app:
+	docker push ${AR_REPO}:test-${VERSION}
+
 push.requirements:
 	docker push ${AR_REQS_REPO}:${REQUIREMENTS_TAG}
+
+push.test-requirements:
+	docker push ${AR_REQS_REPO}:${TEST_REQS_TAG}
 
 _push.self-hosted-release:
 	docker push ${DOCKERHUB_REPO}:${release_version}_no_dependencies

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,11 +16,27 @@ as the Rust compiler, which are needed to install everything but not actually
 needed to run the service. The second image copies only the _runtime dependencies_
 over from the first image. This is the image "returned by" `docker build`.
 
-The requirements image is pushed under the name `<GCP repo prefix/umbrella-reqs`.
+The requirements image is pushed under the name `<GCP repo prefix>/umbrella-reqs`.
 Its tag includes the SHA1 hash of its inputs:
 - `uv.lock`
 - `docker/Dockerfile.requirements`
 - `libs/shared/**`
+
+### The "test requirements image": `Dockerfile.test-requirements`
+
+On top of the base "requirements image", this image installs development
+dependencies like linters and such which don't belong in our production
+deployments.
+
+The image name is the same as the base requirements image, but test requirements
+use a different tag.
+
+Like the base requirements image, we want to tag the test requirements image
+based on the SHA1 hash of its inputs. However, the test requirements image has
+a fourth input (`docker/Dockerfile.test-requirements`) and four hashes is too
+long for an image tag. So, we compute the SHA of `docker/Dockerfile.test-requirements`,
+concatenate the base image's tag to the end, take the SHA of that, and add `test-`
+to the front. See `TEST_REQS_TAG` in `docker/Makefile.docker`.
 
 ### The "app image": `Dockerfile`
 
@@ -33,9 +49,14 @@ self-hosted, local, or production (a.k.a. "cloud"). All three flavors are pretty
 trivial variants on the same base, so we build all three and then choose which
 one to "return" based on a build arg with the final line: `FROM ${BUILD_ENV}`.
 
+The base image for each "app image" is passed in as the `REQUIREMENTS_IMAGE`
+build argument. Production images will use the `Dockerfile.requirements` image
+as a base while tests and local development will use `Dockerfile.test-requirements`.
+
 These images are pushed with names like:
 - `<GCP repo prefix>/codecov/worker`
 - `<GCP repo prefix>/codecov/api`
 - `<GCP repo prefix>/codecov/dev-shared`
 
-Tags include `:latest` or things like `:release-<short-commit-sha>`.
+Tags include `:latest` or things like `:release-<short-commit-sha>`. When built
+against `Dockerfile.test-requirements`, add `test-` to the start of the tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.13"
 
 [tool.uv]
-default-groups = ["everything"] # TODO: Switch to "prod" when we can
+default-groups = ["prod"]
 required-version = ">=0.7.5"
 
 [tool.uv.sources]
@@ -126,5 +126,3 @@ dev = [
 ]
 
 prod = [{ include-group = "codecov-api" }, { include-group = "worker" }]
-
-everything = [{ include-group = "prod" }, { include-group = "dev" }]

--- a/tools/devenv/Makefile.devenv
+++ b/tools/devenv/Makefile.devenv
@@ -1,17 +1,22 @@
+.PHONY: devenv.build.requirements
+devenv.build.requirements:
+	$(MAKE) build.requirements
+	$(MAKE) build.test-requirements
+
 .PHONY: devenv.build.worker
-devenv.build.worker:
-	$(MAKE) worker.build
+devenv.build.worker: devenv.build.requirements
+	$(MAKE) worker.build.local
 
 .PHONY: devenv.build.api
-devenv.build.api:
-	$(MAKE) api.build
+devenv.build.api: devenv.build.requirements
+	$(MAKE) api.build.local
 
 .PHONY: devenv.build.shared
-devenv.build.shared:
-	$(MAKE) shared.build
+devenv.build.shared: devenv.build.requirements
+	$(MAKE) shared.build.local
 
 .PHONY: devenv.build
-devenv.build: devenv.build.api devenv.build.worker devenv.build.shared
+devenv.build: devenv.build.requirements devenv.build.api devenv.build.worker devenv.build.shared
 
 .PHONY: devenv.start.deps
 devenv.start.deps:

--- a/tools/devenv/Makefile.test
+++ b/tools/devenv/Makefile.test
@@ -23,7 +23,7 @@ devenv.upload.api:
 
 .PHONY: devenv.test.shared
 devenv.test.shared:
-	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=shared.django_apps.settings_test -it umbrella-shared-1 uv run pytest --cov ./shared --cov-report=xml:tests/coverage.xml --junitxml=tests/junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini
+	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=shared.django_apps.settings_test -it umbrella-shared-1 pytest --cov ./shared --cov-report=xml:tests/coverage.xml --junitxml=tests/junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini
 
 .PHONY: devenv.upload.shared
 devenv.upload.shared:


### PR DESCRIPTION
as title

this should clean up our production image as well as save some CI time. as-is, _every_ CI run for worker, api, and shared all must run `apt-get install ...` and `pip install ...` to install the same junk inside the container. this PR caches that junk so all that must be done most of the time is copying the repo into the image

further changes are possible. all three test images are essentially identical; we could just build/publish a generic test image and override the workdir and entrypoint in docker-compose. i may try to do basically that for our production images.

<!-- %%% BRANCHLESS STACK INFO START %%% -->
<details open><summary> Stack info:</summary>

| Stack 1 |
|-|
|<ul><li>https://github.com/codecov/umbrella/pull/186</li><li>https://github.com/codecov/umbrella/pull/187</li><li>https://github.com/codecov/umbrella/pull/190</li><li>➡️https://github.com/codecov/umbrella/pull/188</li></ul>|

</details>
<!-- %%% BRANCHLESS STACK INFO END %%% -->