### PR TITLE
feat: Add customer name and address to Customer Serializer

### DIFF
--- a/apps/codecov-api/api/internal/owner/serializers.py
+++ b/apps/codecov-api/api/internal/owner/serializers.py
@@ -9,10 +9,7 @@ from rest_framework.exceptions import PermissionDenied
 from codecov_auth.models import Owner, Plan
 from services.billing import BillingService
 from services.sentry import send_user_webhook as send_sentry_webhook
-from shared.plan.constants import (
-    TEAM_PLAN_MAX_USERS,
-    TierName,
-)
+from shared.plan.constants import TEAM_PLAN_MAX_USERS, TierName
 from shared.plan.service import PlanService
 
 log = logging.getLogger(__name__)
@@ -97,6 +94,8 @@ class StripeCustomerSerializer(serializers.Serializer):
     id = serializers.CharField()
     discount = StripeDiscountSerializer()
     email = serializers.CharField()
+    name = serializers.CharField(read_only=True)
+    address = serializers.JSONField(read_only=True)
 
 
 class StripeCardSerializer(serializers.Serializer):

--- a/apps/codecov-api/api/internal/tests/views/test_account_viewset.py
+++ b/apps/codecov-api/api/internal/tests/views/test_account_viewset.py
@@ -56,6 +56,13 @@ class MockSubscription:
             "id": "cus_LK&*Hli8YLIO",
             "discount": None,
             "email": None,
+            "name": "Cool guy",
+            "address": {
+                "line1": "123 Main St",
+                "city": "Anytown",
+                "state": "CA",
+                "postal_code": "12345",
+            },
         }
         self.schedule = subscription_params.get("schedule_id")
         self.status = subscription_params.get("status", "active")
@@ -296,7 +303,18 @@ class AccountViewSetTests(APITestCase):
                 "default_payment_method": None,
                 "cancel_at_period_end": False,
                 "current_period_end": 1633512445,
-                "customer": {"id": "cus_LK&*Hli8YLIO", "discount": None, "email": None},
+                "customer": {
+                    "id": "cus_LK&*Hli8YLIO",
+                    "discount": None,
+                    "email": None,
+                    "name": "Cool guy",
+                    "address": {
+                        "line1": "123 Main St",
+                        "city": "Anytown",
+                        "state": "CA",
+                        "postal_code": "12345",
+                    },
+                },
                 "collection_method": "charge_automatically",
                 "tax_ids": None,
                 "trial_end": None,
@@ -382,7 +400,18 @@ class AccountViewSetTests(APITestCase):
                 "default_payment_method": None,
                 "cancel_at_period_end": False,
                 "current_period_end": 1633512445,
-                "customer": {"id": "cus_LK&*Hli8YLIO", "discount": None, "email": None},
+                "customer": {
+                    "id": "cus_LK&*Hli8YLIO",
+                    "discount": None,
+                    "email": None,
+                    "name": "Cool guy",
+                    "address": {
+                        "line1": "123 Main St",
+                        "city": "Anytown",
+                        "state": "CA",
+                        "postal_code": "12345",
+                    },
+                },
                 "collection_method": "charge_automatically",
                 "trial_end": 1633512445,
                 "tax_ids": None,
@@ -456,7 +485,18 @@ class AccountViewSetTests(APITestCase):
                 "default_payment_method": None,
                 "cancel_at_period_end": False,
                 "current_period_end": 1633512445,
-                "customer": {"id": "cus_LK&*Hli8YLIO", "discount": None, "email": None},
+                "customer": {
+                    "id": "cus_LK&*Hli8YLIO",
+                    "discount": None,
+                    "email": None,
+                    "name": "Cool guy",
+                    "address": {
+                        "line1": "123 Main St",
+                        "city": "Anytown",
+                        "state": "CA",
+                        "postal_code": "12345",
+                    },
+                },
                 "collection_method": "charge_automatically",
                 "trial_end": None,
                 "tax_ids": None,
@@ -633,7 +673,18 @@ class AccountViewSetTests(APITestCase):
                     "last4": "abcd",
                 }
             },
-            "customer": {"id": "cus_LK&*Hli8YLIO", "discount": None, "email": None},
+            "customer": {
+                "id": "cus_LK&*Hli8YLIO",
+                "discount": None,
+                "email": None,
+                "name": "Cool guy",
+                "address": {
+                    "line1": "123 Main St",
+                    "city": "Anytown",
+                    "state": "CA",
+                    "postal_code": "12345",
+                },
+            },
             "collection_method": "charge_automatically",
             "trial_end": None,
             "tax_ids": None,


### PR DESCRIPTION
This PR aims to add a few new fields to the customer serializer used in the account-details endpoint when fetching subscription details to display on the plan page. The "best way" to have done this would be to push this information to GQL and create a new hook that retrieves stripe customer information, but this way is a lot faster particularly if we don't intend on putting too many additional cycles in updating gazebo / API in the long run.

Relates to https://linear.app/getsentry/issue/CCMRG-477/reflect-customer-address-as-well-as-billing-details-address-in-the