### PR TITLE
build: trigger all tests when reqs and build glue are changed

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -47,26 +47,34 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          # As long as worker/api/shared are submodules, we should include
-          # patterns that match the submodule placeholder to be sure submodule
-          # updates will trigger the right workflows.
           filters: |
-            worker:
-              - 'apps/worker'
-              - 'apps/worker/**'
-              - 'libs/shared'
-              - 'libs/shared/**'
-              - '.github/workflows/worker-ci.yml'
-            codecov-api:
-              - 'apps/codecov-api'
-              - 'apps/codecov-api/**'
-              - 'libs/shared'
-              - 'libs/shared/**'
-              - '.github/workflows/api-ci.yml'
-            shared:
-              - 'libs/shared'
+            build-glue: &build-glue
+              - 'Makefile'
+              - 'docker/Makefile.docker'
+              - 'docker/Makefile.ci-tests'
+              - 'docker/Dockerfile.requirements'
+              - 'docker/Dockerfile'
+              - 'uv.lock'
+              - 'ci-tests.docker-compose.yml'
+              - '.github/workflows/ci-router.yml'
+              - '.github/workflows/_build-requirements.yml'
+              - '.github/workflows/_build-app.yml'
+              - '.github/workflows/_self-hosted.yml'
+              - '.github/workflows/_run-tests.yml'
+            shared: &shared
+              - *build-glue
               - 'libs/shared/**'
               - '.github/workflows/shared-ci.yml'
+            worker:
+              - *build-glue
+              - *shared
+              - 'apps/worker/**'
+              - '.github/workflows/worker-ci.yml'
+            codecov-api:
+              - *build-glue
+              - *shared
+              - 'apps/codecov-api/**'
+              - '.github/workflows/api-ci.yml'
 
   reqs:
     name: Build Requirements


### PR DESCRIPTION
as-is you can totally break our `Makefile`s and CI workflows and required checks will all be skipped and you can merge. that's not good

> [!Note]
> if there are CI failures when you look at this, they're because i created https://github.com/codecov/umbrella/pull/188 first and this PR is using that one's cached images without the rest of its changes. there is no actual breakage. the only change here is to run CI more often.

<!-- %%% BRANCHLESS STACK INFO START %%% -->
<details open><summary> Stack info:</summary>

| Stack 1 |
|-|
|<ul><li>https://github.com/codecov/umbrella/pull/186</li><li>https://github.com/codecov/umbrella/pull/187</li><li>➡️https://github.com/codecov/umbrella/pull/190</li><li>https://github.com/codecov/umbrella/pull/188</li></ul>|

</details>
<!-- %%% BRANCHLESS STACK INFO END %%% -->