### PR TITLE
feat: separate stage workflow for ci / deploys

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -60,19 +60,6 @@ jobs:
       output_directory: apps/codecov-api
       make_target_prefix: api.
 
-  api-staging:
-    name: Push Staging Image (API)
-    needs: [api-build, api-test]
-    if: ${{ inputs.skip == false && github.event_name == 'push' && github.event.ref == 'refs/heads/staging' && github.repository_owner == 'codecov' }}
-    uses: ./.github/workflows/_push-env.yml
-    secrets: inherit
-    with:
-      environment: staging
-      repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
-      output_directory: apps/codecov-api
-      sentry_project: api
-      make_target_prefix: api.
-
   api-production:
     name: Push Production Image (API)
     needs: [api-build, api-test]

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/api-ci.yml
     secrets: inherit
     with:
-      skip: ${{ needs.change-detection.outputs.codecov-api == 'false' && github.event.ref != 'refs/heads/staging' }}
+      skip: ${{ needs.change-detection.outputs.codecov-api == 'false' }}
       event_name: ${{ github.event_name }}
 
   worker-ci:
@@ -87,7 +87,7 @@ jobs:
     uses: ./.github/workflows/worker-ci.yml
     secrets: inherit
     with:
-      skip: ${{ needs.change-detection.outputs.worker == 'false' && github.event.ref != 'refs/heads/staging' }}
+      skip: ${{ needs.change-detection.outputs.worker == 'false' }}
       event_name: ${{ github.event_name }}
 
   shared-ci:
@@ -96,5 +96,5 @@ jobs:
     uses: ./.github/workflows/shared-ci.yml
     secrets: inherit
     with:
-      skip: ${{ needs.change-detection.outputs.shared == 'false' && github.event.ref != 'refs/heads/staging' }}
+      skip: ${{ needs.change-detection.outputs.shared == 'false' }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/api-ci.yml
     secrets: inherit
     with:
-      skip: ${{ needs.change-detection.outputs.codecov-api == 'false' }}
+      skip: ${{ needs.change-detection.outputs.codecov-api == 'false' && github.event.ref != 'refs/heads/staging' }}
       event_name: ${{ github.event_name }}
 
   worker-ci:
@@ -87,7 +87,7 @@ jobs:
     uses: ./.github/workflows/worker-ci.yml
     secrets: inherit
     with:
-      skip: ${{ needs.change-detection.outputs.worker == 'false' }}
+      skip: ${{ needs.change-detection.outputs.worker == 'false' && github.event.ref != 'refs/heads/staging' }}
       event_name: ${{ github.event_name }}
 
   shared-ci:
@@ -96,5 +96,5 @@ jobs:
     uses: ./.github/workflows/shared-ci.yml
     secrets: inherit
     with:
-      skip: ${{ needs.change-detection.outputs.shared == 'false' }}
+      skip: ${{ needs.change-detection.outputs.shared == 'false' && github.event.ref != 'refs/heads/staging' }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/push-stage.yml
+++ b/.github/workflows/push-stage.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: "read"
+  id-token: "write"
+  issues: "write"
+  pull-requests: "write"
 
 jobs:
 

--- a/.github/workflows/push-stage.yml
+++ b/.github/workflows/push-stage.yml
@@ -1,0 +1,49 @@
+name: Push to Stage
+
+on:
+  push:
+    tags:
+      - stage-*
+    branches:
+      - staging
+  pull_request:
+  merge_group:
+
+
+jobs:
+
+    worker:
+        name: Push Staging Image (Worker)
+        if: ${{ github.repository_owner == 'codecov' && github.event_name == 'push' && github.event.ref == 'refs/heads/staging' }}
+        uses: ./.github/workflows/_push-env.yml
+        secrets: inherit
+        with:
+          environment: staging
+          repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
+          output_directory: apps/worker
+          sentry_project: worker
+          make_target_prefix: worker.
+
+    trigger-worker-deploy:
+        name: Trigger codecov-worker deployment
+        needs: [worker]
+        if: ${{ !cancelled() && github.event_name == 'push' }}
+        uses: ./.github/workflows/trigger-worker-deploy.yml
+
+    api:
+        name: Push Staging Image (API)
+        if: ${{ github.repository_owner == 'codecov' && github.event_name == 'push' && github.event.ref == 'refs/heads/staging' }}
+        uses: ./.github/workflows/_push-env.yml
+        secrets: inherit
+        with:
+            environment: staging
+            repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
+            output_directory: apps/codecov-api
+            sentry_project: api
+            make_target_prefix: api.
+    
+    trigger-api-deploy:
+        name: Trigger codecov-api deployment
+        needs: [api]
+        if: ${{ !cancelled() && github.event_name == 'push' }}
+        uses: ./.github/workflows/trigger-api-deploy.yml

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -59,19 +59,6 @@ jobs:
       output_directory: apps/worker
       make_target_prefix: worker.
 
-  worker-staging:
-    name: Push Staging Image (Worker)
-    needs: [worker-build, worker-test]
-    if: ${{ inputs.skip == false && github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/staging') && github.repository_owner == 'codecov' }}
-    uses: ./.github/workflows/_push-env.yml
-    secrets: inherit
-    with:
-      environment: staging
-      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
-      output_directory: apps/worker
-      sentry_project: worker
-      make_target_prefix: worker.
-
   worker-production:
     name: Push Production Image (Worker)
     needs: [worker-build, worker-test]


### PR DESCRIPTION
This PR creates a new job called push-stage.yml which will auto push images to stage if we push to the staging branch. It skips tests, shared stuff, lint, etc so we can get our changes as quick as possible.

This fixes a bug where stage and main might be on the same hash and thus, no changes would be detected if we wanted main and staging to be the same. Previously we thought to just add some conditionals to the ci-router.yml but decided to create a new job altogether via @matt-codecov's suggestion