### PR TITLE
fix: Redo SCoverage report parsing logic to parse external XML format

### DIFF
--- a/apps/worker/services/report/languages/scoverage.py
+++ b/apps/worker/services/report/languages/scoverage.py
@@ -9,53 +9,68 @@ from .base import BaseLanguageProcessor
 from .helpers import child_text
 
 
+def get_child_value(element: Element, tag: str) -> str:
+    """
+    Returns the text of the child element with the given tag if it's a child of the given element.
+    Else if it's an attribute returns the attribute value instead
+    Else returns None
+    """
+    value = child_text(element, tag)
+    # If the child is not an empty string return  (It can't be None)
+    if value:
+        return value
+    return element.attrib.get(tag, "")
+
+
 class SCoverageProcessor(BaseLanguageProcessor):
     def matches_content(self, content: Element, first_line: str, name: str) -> bool:
-        return content.tag == "statements"
+        return content.tag == "scoverage" or content.tag == "statements"
 
     @sentry_sdk.trace
     def process(
-        self, content: Element, report_builder_session: ReportBuilderSession
+            self, content: Element, report_builder_session: ReportBuilderSession
     ) -> None:
         return from_xml(content, report_builder_session)
 
 
 def from_xml(xml: Element, report_builder_session: ReportBuilderSession) -> None:
-    files: dict[str, ReportFile | None] = {}
-    for statement in xml.iter("statement"):
-        filename = child_text(statement, "source")
-        if filename not in files:
-            files[filename] = report_builder_session.create_coverage_file(filename)
+    files: dict[str, dict[int, list[Element]]] = {}
+    partials_as_hits = report_builder_session.yaml_field(("parsers", "scoverage", "partials_as_hits"),
+                                                         False)
 
-        _file = files.get(filename)
+    for statement in xml.iter("statement"):
+        filename = get_child_value(statement, "source")
+        files.setdefault(filename, {}).setdefault(int(get_child_value(statement, "line")), [])
+        files[filename][int(get_child_value(statement, "line"))].append(statement)
+
+    for filename, lines in files.items():
+        _file = report_builder_session.create_coverage_file(filename)
         if _file is None:
             continue
+        for line, statements in lines.items():
+            included_statements = [stmt for stmt in statements if get_child_value(stmt, "ignored") != "true"]
+            if len(included_statements) == 0:
+                continue
+            covered_statements = [stmt for stmt in included_statements if
+                                  int(get_child_value(stmt, "invocation-count")) > 0]
 
-        # Add the line
-        ln = int(child_text(statement, "line"))
-        hits = child_text(statement, "count")
+            is_partial = len(included_statements) > 1 and len(covered_statements) < len(included_statements)
 
-        if child_text(statement, "ignored") == "true":
-            continue
+            # CodeCov takes a maxint of 99999 as per shared.helpers.numeric.maxint
+            covered_statements_cnt = maxint(len(covered_statements))
 
-        if child_text(statement, "branch") == "true":
-            cov = f"{hits}/2"
-            _file.append(
-                ln,
-                report_builder_session.create_coverage_line(
-                    cov,
-                    CoverageType.branch,
-                ),
-            )
-        else:
-            cov = maxint(hits)
-            _file.append(
-                ln,
-                report_builder_session.create_coverage_line(
-                    cov,
-                ),
-            )
+            # Set to covered ratio if partial coverage, else set to number of invocations of the line.
+            # Since Scoverage does not provide line invocations, we set to num of covered statements as an approximation
+            # This is similar to Jacoco reports setting covered instructions as the cov value for fully covered lines
+            cov = f"{covered_statements_cnt}/{len(included_statements)}" if is_partial else covered_statements_cnt
 
-    for _file in files.values():
-        if _file is not None:
-            report_builder_session.append(_file)
+            # When partials are set as hits, we want to mark all partially covered lines as covered
+            if is_partial and partials_as_hits:
+                cov = 1
+
+            # We only mark it as a branch if it's a partial coverage
+            coverage_type = CoverageType.branch if is_partial else CoverageType.line
+            _file.append(line, report_builder_session.create_coverage_line(cov, coverage_type))
+
+        report_builder_session.append(_file)
+

--- a/apps/worker/services/report/languages/tests/unit/test_scoverage.py
+++ b/apps/worker/services/report/languages/tests/unit/test_scoverage.py
@@ -5,57 +5,134 @@ from shared.reports.test_utils import convert_report_to_better_readable
 
 from . import create_report_builder_session
 
+# Old internal format used for scoverage-data/scoverage.coverage.xml
 xml = """<?xml version="1.0" ?>
 <statements>
     <statement>
         <source>source.scala</source>
         <line>1</line>
         <branch>false</branch>
-        <count>1</count>
+        <invocation-count>1</invocation-count>
     </statement>
     <statement>
         <source>source.scala</source>
         <line>2</line>
         <branch>true</branch>
-        <count>0</count>
+        <invocation-count>0</invocation-count>
+        <ignored>false</ignored>
+    </statement>
+    <statement>
+        <source>source.scala</source>
+        <line>2</line>
+        <branch>true</branch>
+        <invocation-count>0</invocation-count>
         <ignored>false</ignored>
     </statement>
     <statement>
         <source>source.scala</source>
         <line>10</line>
         <branch>true</branch>
-        <count>0</count>
+        <invocation-count>0</invocation-count>
         <ignored>true</ignored>
     </statement>
     <statement>
         <source>ignore</source>
         <line>1</line>
         <branch>false</branch>
-        <count>0</count>
+        <invocation-count>0</invocation-count>
     </statement>
     <statement>
         <source>source.scala</source>
         <line>3</line>
         <branch>false</branch>
-        <count>0</count>
+        <invocation-count>0</invocation-count>
     </statement>
     <statement>
         <source>ignore</source>
         <line>1</line>
         <branch>false</branch>
-        <count>0</count>
+        <invocation-count>0</invocation-count>
     </statement>
 </statements>
 """
 
+# This is the XML report format for SCoverage reports under scoverage-report/scoverage.xml
+# Ref : https://github.com/scoverage/scalac-scoverage-plugin/blob/da4ca495dde236d6b52dd5e823a7d87324c74e57/reporter/src/main/scala/scoverage/reporter/ScoverageXmlWriter.scala#L73
+trueformat_xml = """
+<scoverage 
+statement-count="44" statements-invoked="18" statement-rate="40.91" branch-rate="25.00" version="1.0" timestamp="1740027250469">
+	<packages>
+		<package name="&lt;empty&gt;" statement-count="44" statements-invoked="18" statement-rate="40.91">
+			<classes>
+				<class 
+                name="CoverageClass" filename="CoverageClass.scala" statement-count="44" statements-invoked="18" statement-rate="40.91" branch-rate="25.00">
+					<methods>
+						<method 
+                        name="&lt;empty&gt;/CoverageClass/test" statement-count="26" statements-invoked="8" statement-rate="30.77" branch-rate="20.00">
+							<statements>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="239" end="248" line="5" branch="false" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="377" end="386" line="10" branch="false" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="506" end="532" line="19" branch="false" invocation-count="1" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="258" end="271" line="5" branch="true" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="123" end="132" line="4" branch="false" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="428" end="441" line="13" branch="false" invocation-count="1" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="205" end="214" line="5" branch="false" invocation-count="1" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="318" end="327" line="7" branch="false" invocation-count="1" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="297" end="303" line="6" branch="false" invocation-count="1" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="190" end="196" line="5" branch="false" invocation-count="1" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="227" end="233" line="5" branch="false" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="354" end="360" line="9" branch="false" invocation-count="0" ignored="true"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="351" end="500" line="9" branch="true" invocation-count="0" ignored="true"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="258" end="271" line="5" branch="false" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="98" end="107" line="4" branch="false" invocation-count="1" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="239" end="248" line="5" branch="true" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="377" end="386" line="10" branch="true" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="224" end="273" line="5" branch="true" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="148" end="161" line="4" branch="false" invocation-count="0" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="428" end="441" line="13" branch="true" invocation-count="1" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="318" end="327" line="7" branch="true" invocation-count="1" ignored="false"></statement>
+								<statement 
+                                package="tests" class="CoverageClass" class-type="Class" full-class-name="CoverageClass" source="/src/main/scala/CoverageClass.scala" method="test" start="205" end="214" line="5" branch="true" invocation-count="1" ignored="false"></statement>
+							</statements>
+						</method>
+					</methods>
+				</class>
+			</classes>
+		</package>
+	</packages>
+</scoverage>
+"""
+
+
+def fixes(path):
+    if path == "ignore":
+        return None
+    return path
+
 
 class TestSCoverage:
     def test_report(self):
-        def fixes(path):
-            if path == "ignore":
-                return None
-            return path
-
         report_builder_session = create_report_builder_session(path_fixer=fixes)
         scoverage.from_xml(etree.fromstring(xml), report_builder_session)
         report = report_builder_session.output_report()
@@ -63,8 +140,27 @@ class TestSCoverage:
 
         assert processed_report["archive"] == {
             "source.scala": [
-                (1, 1, None, [[0, 1]], None, None),
-                (2, "0/2", "b", [[0, "0/2"]], None, None),
-                (3, 0, None, [[0, 0]], None, None),
+                (1, 1, None, [[0, 1, None, None, None]], None, None),
+                (2, "0/2", "b", [[0, "0/2", None, None, None]], None, None),
+                (3, 0, None, [[0, 0, None, None, None]], None, None),
             ]
+        }
+
+    def test_true_format_report(self):
+        report_builder_session = create_report_builder_session(path_fixer=fixes)
+        scoverage.from_xml(etree.fromstring(trueformat_xml), report_builder_session)
+        report = report_builder_session.output_report()
+        processed_report = convert_report_to_better_readable(report)
+
+        assert processed_report["archive"] == {
+            '/src/main/scala/CoverageClass.scala': [(4, '1/3', 'b', [[0, '1/3', None, None, None]], None, None),
+                                                    (5, '3/9', 'b', [[0, '3/9', None, None, None]], None, None),
+                                                    (6, 1, None, [[0, 1, None, None, None]], None, None),
+                                                    (7, 2, None, [[0, 2, None, None, None]], None, None),
+                                                    # 9 is completely ignored and should not be present
+                                                    # 10 is completely not covered and should be present as a branch
+                                                    (10, '0/2', 'b', [[0, '0/2', None, None, None]], None, None),
+                                                    # 13 is branched but fully covered, so it should not be a branch
+                                                    (13, 2, None, [[0, 2, None, None, None]], None, None),
+                                                    (19, 1, None, [[0, 1, None, None, None]], None, None)]
         }

--- a/libs/shared/shared/validation/user_schema.py
+++ b/libs/shared/shared/validation/user_schema.py
@@ -509,6 +509,10 @@ schema = {
                 "type": "dict",
                 "schema": {"partials_as_hits": {"type": "boolean"}},
             },
+            "scoverage": {
+                "type": "dict",
+                "schema": {"partials_as_hits": {"type": "boolean"}},
+            },
             "cobertura": {
                 "type": "dict",
                 "schema": {


### PR DESCRIPTION
The current parsers use the scoverage-data/scoverage.coverage.xml file which is meant to be used internally for storing data. SCoverage has a different XML reporting format for external consumption. Newer versions of the library default to txt files for internal data. SonarQube and other similar tools rely on the external format. The new implementation adds capability to parse the external format from XML attributes and computes partial lines based on the executed statements. Also adds new test case which is inline with the external format.

Changes are not breaking, the previous format is also supported.

Reference Links:
1. SCoverage XML Writer : https://github.com/scoverage/scalac-scoverage-plugin/blob/da4ca495dde236d6b52dd5e823a7d87324c74e57/reporter/src/main/scala/scoverage/reporter/ScoverageXmlWriter.scala#L73
2. SonarQube's expected file format : https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/test-coverage/test-coverage-parameters/#scala