### PR TITLE
ci: fix _build-requirements.yml for PRs from forks

### DIFF
--- a/.github/workflows/_build-app.yml
+++ b/.github/workflows/_build-app.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   AR_REPO: ${{ inputs.repo }}
-  AR_REQS_REPO: ${{ vars.CODECOV_UMBRELLA_REQS_IMAGE }}
+  AR_REQS_REPO: ${{ vars.CODECOV_UMBRELLA_REQS_IMAGE || 'codecov/umbrella-reqs-fallback' }}
 
 jobs:
   build:
@@ -48,7 +48,9 @@ jobs:
         id: cache-requirements
         uses: actions/cache@v4
         env:
-          cache-name: umbrella-requirements
+          # Forks can't access the variable containing our actual image repository. We want to
+          # use a separate cache to make sure they don't interfere with reqs images being pushed.
+          cache-name: ${{ !github.event.pull_request.repo.fork && 'umbrella-requirements' || 'umbrella-requirements-fork' }}
         with:
           path: |
             ./requirements.tar

--- a/.github/workflows/_build-requirements.yml
+++ b/.github/workflows/_build-requirements.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  AR_REQS_REPO: ${{ vars.CODECOV_UMBRELLA_REQS_IMAGE }}
+  AR_REQS_REPO: ${{ vars.CODECOV_UMBRELLA_REQS_IMAGE || 'codecov/umbrella-reqs-fallback' }}
 
 jobs:
   build:
@@ -25,7 +25,9 @@ jobs:
         id: cache-requirements
         uses: actions/cache@v4
         env:
-          cache-name: umbrella-requirements
+          # Forks can't access the variable containing our actual image repository. We want to
+          # use a separate cache to make sure they don't interfere with reqs images being pushed.
+          cache-name: ${{ !github.event.pull_request.repo.fork && 'umbrella-requirements' || 'umbrella-requirements-fork' }}
         with:
           path: |
             ./requirements.tar

--- a/.github/workflows/_self-hosted.yml
+++ b/.github/workflows/_self-hosted.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   AR_REPO: ${{ inputs.repo }}
-  AR_REQS_REPO: ${{ vars.CODECOV_UMBRELLA_REQS_IMAGE }}
+  AR_REQS_REPO: ${{ vars.CODECOV_UMBRELLA_REQS_IMAGE || 'codecov/umbrella-reqs-fallback' }}
 
 jobs:
   build-self-hosted:
@@ -55,7 +55,9 @@ jobs:
         id: cache-requirements
         uses: actions/cache@v4
         env:
-          cache-name: umbrella-requirements
+          # Forks can't access the variable containing our actual image repository. We want to
+          # use a separate cache to make sure they don't interfere with reqs images being pushed.
+          cache-name: ${{ !github.event.pull_request.repo.fork && 'umbrella-requirements' || 'umbrella-requirements-fork' }}
         with:
           path: |
             ./requirements.tar


### PR DESCRIPTION
this should fix the `_build-requirements.yml` workflow for PRs from forks, i think

the first change is a fallback value for `AR_REQS_REPO`. it doesn't really matter for forks because they will never push images, just needs to be non-empty. the second is to use a separate reqs image cache for PRs from forks. it's a bit of a hack, but PRs from forks are uncommon so it'll do

if they use the same cache, then if a PR from a fork changes shared/deps and causes a new reqs image to be built, they will populate the cache with it and, because it's a fork, not push the image. then, when one of our own PRs comes along, it will take the reqs image from the cache, and then because it was in the cache, assume it was already pushed. so the image will never be pushed