### PR TITLE
add redis mock to test that fails locally

### DIFF
--- a/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
@@ -133,7 +133,9 @@ class TestUploadFinisherTask:
         mock_storage,
         mock_checkpoint_submit,
         mock_repo_provider,
+        mock_redis
     ):
+        mock_redis.scard.return_value = 0
         mocker.patch("tasks.upload_finisher.load_intermediate_reports", return_value=[])
         mocker.patch("tasks.upload_finisher.update_uploads")
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"


### PR DESCRIPTION
TestUploadFinisherTask::test_upload_finisher_task_call fails on my local but passes on ci runs