### PR TITLE
Add a new GraphQL mutation to sync with app token

### DIFF
--- a/apps/codecov-api/codecov_auth/commands/owner/interactors/trigger_sync.py
+++ b/apps/codecov-api/codecov_auth/commands/owner/interactors/trigger_sync.py
@@ -6,16 +6,18 @@ from services.refresh import RefreshService
 
 
 class TriggerSyncInteractor(BaseInteractor):
-    def validate(self) -> None:
-        if not self.current_user.is_authenticated:
+    def validate(self, using_integration: bool) -> None:
+        if not self.current_owner:
+            raise Unauthenticated()
+        if not using_integration and not self.current_user.is_authenticated:
             raise Unauthenticated()
 
     @sync_to_async
-    def execute(self) -> None:
-        self.validate()
+    def execute(self, using_integration: bool = False) -> None:
+        self.validate(using_integration)
         RefreshService().trigger_refresh(
             self.current_owner.ownerid,
             self.current_owner.username,
-            using_integration=False,
+            using_integration=using_integration,
             manual_trigger=True,
         )

--- a/apps/codecov-api/codecov_auth/commands/owner/owner.py
+++ b/apps/codecov-api/codecov_auth/commands/owner/owner.py
@@ -58,8 +58,8 @@ class OwnerCommands(BaseCommand):
     def fetch_owner(self, username):
         return self.get_interactor(FetchOwnerInteractor).execute(username)
 
-    def trigger_sync(self):
-        return self.get_interactor(TriggerSyncInteractor).execute()
+    def trigger_sync(self, using_integration: bool = False):
+        return self.get_interactor(TriggerSyncInteractor).execute(using_integration)
 
     def is_syncing(self):
         return self.get_interactor(IsSyncingInteractor).execute()

--- a/apps/codecov-api/graphql_api/tests/mutation/test_sync_repos.py
+++ b/apps/codecov-api/graphql_api/tests/mutation/test_sync_repos.py
@@ -1,0 +1,77 @@
+from unittest.mock import AsyncMock, patch
+
+from django.test import TestCase
+
+from codecov.commands.exceptions import Unauthenticated
+from graphql_api.tests.helper import GraphQLTestHelper
+from shared.django_apps.core.tests.factories import OwnerFactory
+
+query = """
+mutation {
+  syncRepos {
+    isSyncing
+    error {
+      __typename
+      ... on ResolverError {
+        message
+      }
+    }
+  }
+}
+"""
+
+
+class SyncReposTestCase(GraphQLTestHelper, TestCase):
+    def setUp(self):
+        self.organization_username = "sample-default-org-username"
+        self.organization = OwnerFactory(
+            username=self.organization_username, service="github"
+        )
+
+    def test_sync_repos_success(self):
+        """Test successful sync repos mutation"""
+        with patch(
+            "codecov_auth.commands.owner.owner.OwnerCommands.trigger_sync",
+            new_callable=AsyncMock,
+        ) as mock_trigger_sync:
+            response = self.gql_request(
+                query,
+                owner=self.organization,
+            )
+            mock_trigger_sync.assert_called_once_with(using_integration=True)
+        assert response == {"syncRepos": {"isSyncing": True, "error": None}}
+
+    def test_sync_repos_unauthenticated_no_user(self):
+        """Test sync repos mutation when no user is provided"""
+        response = self.gql_request(query)
+        assert response == {
+            "syncRepos": {
+                "isSyncing": None,
+                "error": {
+                    "__typename": "UnauthenticatedError",
+                    "message": "You are not authenticated",
+                },
+            }
+        }
+
+    def test_sync_repos_trigger_sync_unauthenticated_exception(self):
+        """Test sync repos when trigger_sync raises Unauthenticated exception"""
+        with patch(
+            "codecov_auth.commands.owner.owner.OwnerCommands.trigger_sync",
+            new_callable=AsyncMock,
+            side_effect=Unauthenticated(),
+        ) as mock_trigger_sync:
+            response = self.gql_request(
+                query,
+                owner=self.organization,
+            )
+            mock_trigger_sync.assert_called_once_with(using_integration=True)
+        assert response == {
+            "syncRepos": {
+                "isSyncing": None,
+                "error": {
+                    "__typename": "UnauthenticatedError",
+                    "message": "You are not authenticated",
+                },
+            }
+        }

--- a/apps/codecov-api/graphql_api/types/mutation/__init__.py
+++ b/apps/codecov-api/graphql_api/types/mutation/__init__.py
@@ -23,6 +23,7 @@ from .set_upload_token_required import gql_set_upload_token_required
 from .set_yaml_on_owner import gql_set_yaml_on_owner
 from .start_trial import gql_start_trial
 from .store_event_metrics import gql_store_event_metrics
+from .sync_repos import gql_sync_repos
 from .sync_with_git_provider import gql_sync_with_git_provider
 from .update_bundle_cache_config import gql_update_bundle_cache_config
 from .update_default_organization import gql_update_default_organization
@@ -33,6 +34,7 @@ from .update_self_hosted_settings import gql_update_self_hosted_settings
 mutation = ariadne_load_local_graphql(__file__, "mutation.graphql")
 mutation = mutation + gql_create_api_token
 mutation = mutation + gql_create_stripe_setup_intent
+mutation = mutation + gql_sync_repos
 mutation = mutation + gql_sync_with_git_provider
 mutation = mutation + gql_delete_session
 mutation = mutation + gql_set_yaml_on_owner

--- a/apps/codecov-api/graphql_api/types/mutation/mutation.graphql
+++ b/apps/codecov-api/graphql_api/types/mutation/mutation.graphql
@@ -7,6 +7,7 @@ type Mutation {
   startTrial(input: StartTrialInput!): StartTrialPayload
   cancelTrial(input: CancelTrialInput!): CancelTrialPayload
   syncWithGitProvider: SyncWithGitProviderPayload
+  syncRepos: SyncReposPayload
   updateProfile(input: UpdateProfileInput!): UpdateProfilePayload
   updateDefaultOrganization(
     input: UpdateDefaultOrganizationInput!

--- a/apps/codecov-api/graphql_api/types/mutation/mutation.py
+++ b/apps/codecov-api/graphql_api/types/mutation/mutation.py
@@ -49,6 +49,7 @@ from .set_upload_token_required import (
 from .set_yaml_on_owner import error_set_yaml_error, resolve_set_yaml_on_owner
 from .start_trial import error_start_trial, resolve_start_trial
 from .store_event_metrics import error_store_event_metrics, resolve_store_event_metrics
+from .sync_repos import error_sync_repos, resolve_sync_repos
 from .sync_with_git_provider import (
     error_sync_with_git_provider,
     resolve_sync_with_git_provider,
@@ -77,6 +78,7 @@ mutation_bindable.field("createUserToken")(resolve_create_user_token)
 mutation_bindable.field("revokeUserToken")(resolve_revoke_user_token)
 mutation_bindable.field("setYamlOnOwner")(resolve_set_yaml_on_owner)
 mutation_bindable.field("syncWithGitProvider")(resolve_sync_with_git_provider)
+mutation_bindable.field("syncRepos")(resolve_sync_repos)
 mutation_bindable.field("deleteSession")(resolve_delete_session)
 mutation_bindable.field("updateProfile")(resolve_update_profile)
 mutation_bindable.field("updateDefaultOrganization")(
@@ -118,6 +120,7 @@ mutation_resolvers = [
     error_revoke_user_token,
     error_set_yaml_error,
     error_sync_with_git_provider,
+    error_sync_repos,
     error_delete_session,
     error_update_profile,
     error_update_default_organization,

--- a/apps/codecov-api/graphql_api/types/mutation/sync_repos/__init__.py
+++ b/apps/codecov-api/graphql_api/types/mutation/sync_repos/__init__.py
@@ -1,0 +1,11 @@
+from graphql_api.helpers.ariadne import ariadne_load_local_graphql
+
+from .sync_repos import (
+    error_sync_repos,
+    resolve_sync_repos,
+)
+
+gql_sync_repos = ariadne_load_local_graphql(__file__, "sync_repos.graphql")
+
+
+__all__ = ["resolve_sync_repos", "error_sync_repos"]

--- a/apps/codecov-api/graphql_api/types/mutation/sync_repos/sync_repos.graphql
+++ b/apps/codecov-api/graphql_api/types/mutation/sync_repos/sync_repos.graphql
@@ -1,0 +1,6 @@
+union SyncReposError = UnauthenticatedError
+
+type SyncReposPayload {
+  isSyncing: Boolean
+  error: SyncReposError
+}

--- a/apps/codecov-api/graphql_api/types/mutation/sync_repos/sync_repos.py
+++ b/apps/codecov-api/graphql_api/types/mutation/sync_repos/sync_repos.py
@@ -1,0 +1,24 @@
+from ariadne import UnionType
+
+from graphql_api.helpers.mutation import (
+    resolve_union_error_type,
+    wrap_error_handling_mutation,
+)
+
+
+@wrap_error_handling_mutation
+async def resolve_sync_repos(_, info):
+    """
+    Mutation to trigger a sync of all repos for an organization.
+
+    This mutation will trigger a sync of all repos for an organization.
+    The sync will be triggered using the integration flag,
+    as opposed to sync_with_git_provider, which uses the User's token.
+    """
+    command = info.context["executor"].get_command("owner")
+    await command.trigger_sync(using_integration=True)
+    return {"is_syncing": True}
+
+
+error_sync_repos = UnionType("SyncReposError")
+error_sync_repos.type_resolver(resolve_union_error_type)

--- a/apps/codecov-api/services/repo_providers.py
+++ b/apps/codecov-api/services/repo_providers.py
@@ -35,7 +35,7 @@ class TorngitInitializationFailed(Exception):
 
 def get_token_refresh_callback(
     owner: Owner | None, service: Service
-) -> Callable[[dict], None]:
+) -> Callable[[OauthConsumerToken], None] | None:
     """
     Produces a callback function that will encode and update the oauth token of an owner.
     This callback is passed to the TorngitAdapter for the service.


### PR DESCRIPTION
This change makes the sync task use an app token rather than the user's token. It's a separate mutation, so it shouldn't conflict with the existing sync trigger.

Just also note that the `current_owner` is set to be the org with the JWT middleware: https://github.com/codecov/umbrella/blob/3541fdac533c9542505ab97d5ce5855db61278bd/apps/codecov-api/codecov_auth/middleware.py#L200.