### PR TITLE
Convert Upload Received to Repository Activated event

### DIFF
--- a/apps/codecov-api/upload/tests/views/test_bundle_analysis.py
+++ b/apps/codecov-api/upload/tests/views/test_bundle_analysis.py
@@ -108,7 +108,7 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
 
     # emits Amplitude event
     mock_amplitude.assert_called_with(
-        "Upload Received",
+        "Repository Activated",
         {
             "user_ownerid": UNKNOWN_USER_OWNERID,
             "ownerid": commit.repository.author.ownerid,

--- a/apps/codecov-api/upload/tests/views/test_test_results.py
+++ b/apps/codecov-api/upload/tests/views/test_test_results.py
@@ -119,7 +119,7 @@ def test_upload_test_results(db, client, mocker, mock_redis):
 
     # emits Amplitude event
     mock_amplitude.assert_called_with(
-        "Upload Received",
+        "Repository Activated",
         {
             "user_ownerid": UNKNOWN_USER_OWNERID,
             "ownerid": commit.repository.author.ownerid,

--- a/apps/codecov-api/upload/tests/views/test_upload_coverage.py
+++ b/apps/codecov-api/upload/tests/views/test_upload_coverage.py
@@ -153,7 +153,7 @@ def test_upload_coverage_post(db, mocker):
         == f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/commit/{commit.commitid}"
     )
     amplitude_mock.assert_called_with(
-        "Upload Received",
+        "Repository Activated",
         {
             "user_ownerid": commit.author.ownerid,
             "ownerid": commit.repository.author.ownerid,

--- a/apps/codecov-api/upload/tests/views/test_uploads.py
+++ b/apps/codecov-api/upload/tests/views/test_uploads.py
@@ -265,7 +265,7 @@ def test_uploads_post(db, mocker, mock_redis):
     )
 
     amplitude_mock.assert_called_with(
-        "Upload Received",
+        "Repository Activated",
         {
             "user_ownerid": commit.author.ownerid,
             "ownerid": repository.author.ownerid,
@@ -829,7 +829,8 @@ def test_activate_repo(db):
     repo = RepositoryFactory(
         active=False, deleted=True, activated=False, coverage_enabled=False
     )
-    activate_repo(repo)
+    commit = CommitFactory.create()
+    activate_repo(repo, commit)
     assert repo.active
     assert repo.activated
     assert not repo.deleted

--- a/libs/shared/shared/events/amplitude/types.py
+++ b/libs/shared/shared/events/amplitude/types.py
@@ -24,7 +24,7 @@ type AmplitudeEventType = Literal[
     "User Created",
     "User Logged in",
     "App Installed",
-    "Upload Received",
+    "Repository Activated",
     "set_orgs",  # special event for setting a user's member orgs
 ]
 
@@ -69,5 +69,5 @@ AMPLITUDE_REQUIRED_PROPERTIES: dict[
     "User Created": [],
     "User Logged in": [],
     "App Installed": ["ownerid"],
-    "Upload Received": ["ownerid", "repoid", "commitid", "pullid", "upload_type"],
+    "Repository Activated": ["ownerid", "repoid", "commitid", "pullid", "upload_type"],
 }

--- a/libs/shared/tests/unit/events/test_amplitude.py
+++ b/libs/shared/tests/unit/events/test_amplitude.py
@@ -135,7 +135,7 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
     amplitude.client.track = Mock()
 
     amplitude.publish(
-        "Upload Received",
+        "Repository Activated",
         {
             "user_ownerid": 123,
             "ownerid": 321,
@@ -149,7 +149,7 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
     amplitude_mock.assert_called_once()
     amplitude.client.track.assert_called_once()
     base_event_mock.assert_called_once_with(
-        "Upload Received",
+        "Repository Activated",
         user_id="123",
         event_properties={
             "ownerid": 321,
@@ -175,7 +175,7 @@ def test_publish_converts_anonymous_owner_id_to_user_id(
     amplitude.client.track = Mock()
 
     amplitude.publish(
-        "Upload Received",
+        "Repository Activated",
         {
             "user_ownerid": UNKNOWN_USER_OWNERID,
             "ownerid": 321,
@@ -189,7 +189,7 @@ def test_publish_converts_anonymous_owner_id_to_user_id(
     amplitude_mock.assert_called_once()
     amplitude.client.track.assert_called_once()
     base_event_mock.assert_called_once_with(
-        "Upload Received",
+        "Repository Activated",
         user_id="anon",
         event_properties={
             "ownerid": 321,


### PR DESCRIPTION
Converts the Upload Received event to a new Repository Activated event. This is meant to reduce event volume while still capturing the first upload received by an owner.
