### PR TITLE
fix: make docker-compose.yml "expose" api port internally instead of binding to host port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - ./apps/codecov-api:/app/apps/codecov-api:cached
       - ./libs/shared:/app/libs/shared:cached
     ports:
-      - "8000:8000"
+      - "8000"
     networks:
       - codecov
     depends_on:


### PR DESCRIPTION
"exposing" the port makes the container listen on that port internally without binding any ports on the host machine. we don't actually need/want port 8000 on the host bound to the api because we can access it through codecov-gateway on port 8080

EDIT: apparently "expose" makes API non-responsive in my local CC instance so i changed back to "ports" but am only supplying the container's port. it will bind to a random host port