### PR TITLE
ci: change how push-stage.yml job is run

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - prod-*
+      - stage-*
     branches:
       - main
       - staging
@@ -98,3 +99,12 @@ jobs:
     with:
       skip: ${{ needs.change-detection.outputs.shared == 'false' }}
       event_name: ${{ github.event_name }}
+
+  push-staging:
+    name: Push to staging
+    # We want to push to staging after the images have been built. We use `always()`
+    # to run this job even if tests failed.
+    needs: [reqs, worker-ci, api-ci]
+    if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/staging' && github.repository_owner == 'codecov' && always()}}
+    uses: ./.github/workflows/push-stage.yml
+    secrets: inherit

--- a/.github/workflows/push-stage.yml
+++ b/.github/workflows/push-stage.yml
@@ -1,13 +1,7 @@
 name: Push to Stage
 
 on:
-  push:
-    tags:
-      - stage-*
-    branches:
-      - staging
-  pull_request:
-  merge_group:
+  workflow_call:
 
 permissions:
   contents: "read"
@@ -16,19 +10,8 @@ permissions:
   pull-requests: "write"
 
 jobs:
-
-    worker-build:
-      name: Build App (Worker)
-      uses: ./.github/workflows/_build-app.yml
-      secrets: inherit
-      with:
-        repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
-        output_directory: apps/worker
-        make_target_prefix: worker.
-
     worker:
         name: Push Staging Image (Worker)
-        needs: [worker-build]
         if: ${{ github.repository_owner == 'codecov' && github.event_name == 'push' && github.event.ref == 'refs/heads/staging' }}
         uses: ./.github/workflows/_push-env.yml
         secrets: inherit
@@ -45,18 +28,8 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'push' }}
         uses: ./.github/workflows/trigger-worker-deploy.yml
 
-    api-build:
-      name: Build App (API)
-      uses: ./.github/workflows/_build-app.yml
-      secrets: inherit
-      with:
-        repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
-        output_directory: apps/codecov-api
-        make_target_prefix: api.
-
     api:
         name: Push Staging Image (API)
-        needs: [api-build]
         if: ${{ github.repository_owner == 'codecov' && github.event_name == 'push' && github.event.ref == 'refs/heads/staging' }}
         uses: ./.github/workflows/_push-env.yml
         secrets: inherit
@@ -66,7 +39,7 @@ jobs:
             output_directory: apps/codecov-api
             sentry_project: api
             make_target_prefix: api.
-    
+
     trigger-api-deploy:
         name: Trigger codecov-api deployment
         needs: [api]


### PR DESCRIPTION
this PR makes `push-stage.yml` wait for `worker-ci.yml` and `api-ci.yml` to run before running. otherwise, it will trigger a whole bunch of duplicated image-building work:
- it will build a worker image while `worker-ci.yml` is also building one
- it will build an api image while `api-ci.yml` is also building one
- it will not wait on `_build-requirements.yml`, so both of the above images will also build (but not cache) the requirements image

this PR waits until `worker-ci.yml` and `api-ci.yml` have run before kicking off `push-stage.yml` so that it can reuse the images they built, and it uses `always()` to run regardless of whether the tests passed in those workflows