### PR TITLE
refactor: clean up worker initialization

### DIFF
--- a/apps/worker/conftest.py
+++ b/apps/worker/conftest.py
@@ -13,6 +13,7 @@ from celery_config import initialize_logging
 from database.base import Base
 from database.engine import json_dumps
 from helpers.environment import _get_cached_current_env
+from helpers.logging_config import get_logging_config_dict
 from shared.config import ConfigHelper
 from shared.storage.memory import MemoryStorageService
 from shared.torngit import Github as GithubHandler
@@ -27,7 +28,12 @@ def pytest_configure(config):
     """
     os.environ["CURRENT_ENVIRONMENT"] = "local"
     os.environ["RUN_ENV"] = "DEV"
+
+    _config_dict = get_logging_config_dict()
+    logging.config.dictConfig(_config_dict)
+
     _get_cached_current_env.cache_clear()
+
     initialize_logging()
 
 

--- a/apps/worker/services/test_analytics/tests/test_ta_processor.py
+++ b/apps/worker/services/test_analytics/tests/test_ta_processor.py
@@ -176,7 +176,9 @@ def test_ta_processor_impl_warning(mock_storage, snapshot):
         "metadata": {},
     }
 
-    mock_storage.write_file("archive", "path/to/invalid.xml", json.dumps(sample_content))
+    mock_storage.write_file(
+        "archive", "path/to/invalid.xml", json.dumps(sample_content)
+    )
 
     result = ta_processor_impl(
         repository.repoid, commit.commitid, commit_yaml, argument, update_state=True

--- a/apps/worker/tasks/tests/integration/test_notify_task.py
+++ b/apps/worker/tasks/tests/integration/test_notify_task.py
@@ -49,7 +49,6 @@ class TestNotifyTask:
         mock_configuration.params["setup"]["codecov_dashboard_url"] = (
             "https://codecov.io"
         )
-        mocked_app = mocker.patch.object(NotifyTask, "app")
         repository = RepositoryFactory.create(
             owner__unencrypted_oauth_token=sample_token,
             owner__username="ThiagoCodecov",

--- a/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
@@ -133,7 +133,7 @@ class TestUploadFinisherTask:
         mock_storage,
         mock_checkpoint_submit,
         mock_repo_provider,
-        mock_redis
+        mock_redis,
     ):
         mock_redis.scard.return_value = 0
         mocker.patch("tasks.upload_finisher.load_intermediate_reports", return_value=[])

--- a/apps/worker/tests/unit/test_main.py
+++ b/apps/worker/tests/unit/test_main.py
@@ -4,7 +4,9 @@ from unittest import mock
 
 from click.testing import CliRunner
 
-from main import _get_queues_param_from_queue_input, cli, main, setup_worker, test, web
+# Import `app` to register logs correctly before calling `worker_main` in tests.
+import app as _  # noqa: F401
+from main import _get_queues_param_from_queue_input, cli, main, setup_worker
 from shared.celery_config import BaseCeleryConfig
 
 
@@ -97,25 +99,12 @@ def test_get_cli_help(mocker, mock_license_logging):
             "  --help  Show this message and exit.",
             "",
             "Commands:",
-            "  test",
-            "  web",
             "  worker",
             "",
         ]
     )
 
     assert res.output == expected_output
-    mock_license_logging.assert_not_called()
-
-
-@mock.patch("main.startup_license_logging")
-@mock.patch("main.start_prometheus")
-def test_deal_unsupported_commands(mocker, mock_license_logging):
-    runner = CliRunner()
-    test_res = runner.invoke(test, [])
-    assert test_res.output == "Error: System not suitable to run TEST mode\n"
-    web_res = runner.invoke(web, [])
-    assert web_res.output == "Error: System not suitable to run WEB mode\n"
     mock_license_logging.assert_not_called()
 
 
@@ -133,7 +122,7 @@ def test_deal_worker_command_default(
     res = runner.invoke(cli, ["worker"])
     expected_output = "\n".join(
         [
-            "",
+            "INFO: ",
             "  _____          _",
             " / ____|        | |",
             "| |     ___   __| | ___  ___ _____   __",
@@ -141,12 +130,9 @@ def test_deal_worker_command_default(
             "| |___| (_) | (_| |  __/ (_| (_) \\ V /",
             " \\_____\\___/ \\__,_|\\___|\\___\\___/ \\_/",
             "                              some_version_12.3",
-            "",
-            "",
-            "",
         ]
     )
-    assert res.output == expected_output
+    assert res.output.startswith(expected_output)
     mocked_get_current_version.assert_called_with()
     mock_app.celery_app.worker_main.assert_called_with(
         argv=[
@@ -181,7 +167,7 @@ def test_deal_worker_command(
     res = runner.invoke(cli, ["worker", "--queue", "simple,one,two", "--queue", "some"])
     expected_output = "\n".join(
         [
-            "",
+            "INFO: ",
             "  _____          _",
             " / ____|        | |",
             "| |     ___   __| | ___  ___ _____   __",
@@ -189,12 +175,9 @@ def test_deal_worker_command(
             "| |___| (_) | (_| |  __/ (_| (_) \\ V /",
             " \\_____\\___/ \\__,_|\\___|\\___\\___/ \\_/",
             "                              some_version_12.3",
-            "",
-            "",
-            "",
         ]
     )
-    assert res.output == expected_output
+    assert res.output.startswith(expected_output)
     mocked_get_current_version.assert_called_with()
     mock_app.celery_app.worker_main.assert_called_with(
         argv=[
@@ -231,7 +214,7 @@ def test_deal_worker_no_beat(
     res = runner.invoke(cli, ["worker", "--queue", "simple,one,two", "--queue", "some"])
     expected_output = "\n".join(
         [
-            "",
+            "INFO: ",
             "  _____          _",
             " / ____|        | |",
             "| |     ___   __| | ___  ___ _____   __",
@@ -239,12 +222,9 @@ def test_deal_worker_no_beat(
             "| |___| (_) | (_| |  __/ (_| (_) \\ V /",
             " \\_____\\___/ \\__,_|\\___|\\___\\___/ \\_/",
             "                              some_version_12.3",
-            "",
-            "",
-            "",
         ]
     )
-    assert res.output == expected_output
+    assert res.output.startswith(expected_output)
     mocked_get_current_version.assert_called_with()
     mock_app.celery_app.worker_main.assert_called_with(
         argv=[
@@ -279,7 +259,7 @@ def test_deal_worker_no_queues(
     res = runner.invoke(cli, ["worker", "--queue", "simple,one,two", "--queue", "some"])
     expected_output = "\n".join(
         [
-            "",
+            "INFO: ",
             "  _____          _",
             " / ____|        | |",
             "| |     ___   __| | ___  ___ _____   __",
@@ -287,12 +267,9 @@ def test_deal_worker_no_queues(
             "| |___| (_) | (_| |  __/ (_| (_) \\ V /",
             " \\_____\\___/ \\__,_|\\___|\\___\\___/ \\_/",
             "                              some_version_12.3",
-            "",
-            "",
-            "",
         ]
     )
-    assert res.output == expected_output
+    assert res.output.startswith(expected_output)
     mocked_get_current_version.assert_called_with()
     mock_app.celery_app.worker_main.assert_called_with(
         argv=[
@@ -331,7 +308,7 @@ def test_deal_worker_no_queues_or_beat(
     )
     expected_output = "\n".join(
         [
-            "",
+            "INFO: ",
             "  _____          _",
             " / ____|        | |",
             "| |     ___   __| | ___  ___ _____   __",
@@ -339,12 +316,9 @@ def test_deal_worker_no_queues_or_beat(
             "| |___| (_) | (_| |  __/ (_| (_) \\ V /",
             " \\_____\\___/ \\__,_|\\___|\\___\\___/ \\_/",
             "                              some_version_12.3",
-            "",
-            "",
-            "",
         ]
     )
-    assert res.output == expected_output
+    assert res.output.startswith(expected_output)
     mocked_get_current_version.assert_called_with()
     mock_app.celery_app.worker_main.assert_called_with(
         argv=[

--- a/libs/shared/shared/storage/memory.py
+++ b/libs/shared/shared/storage/memory.py
@@ -104,9 +104,7 @@ class MemoryStorageService(BaseStorageService):
         if file_obj is None:
             return data
         else:
-            chunks = [
-                data[i : i + CHUNK_SIZE] for i in range(0, len(data), CHUNK_SIZE)
-            ]
+            chunks = [data[i : i + CHUNK_SIZE] for i in range(0, len(data), CHUNK_SIZE)]
             for chunk in chunks:
                 file_obj.write(chunk)
 

--- a/libs/shared/tests/unit/storage/test_memory.py
+++ b/libs/shared/tests/unit/storage/test_memory.py
@@ -40,7 +40,9 @@ def test_write_then_read_file():
     data = "lorem ipsum dolor test_write_then_read_file á"
 
     ensure_bucket(storage)
-    writing_result = storage.write_file(BUCKET_NAME, path, data, metadata={"foo": "bar"})
+    writing_result = storage.write_file(
+        BUCKET_NAME, path, data, metadata={"foo": "bar"}
+    )
     assert writing_result
 
     meta = {}
@@ -60,7 +62,9 @@ def test_write_then_read_file_obj():
     with open(local_path, "w") as f:
         f.write(data)
     with open(local_path, "rb") as f:
-        writing_result = storage.write_file(BUCKET_NAME, path, f, metadata={"foo": "bar"})
+        writing_result = storage.write_file(
+            BUCKET_NAME, path, f, metadata={"foo": "bar"}
+        )
     assert writing_result
 
     _, local_path = tempfile.mkstemp()


### PR DESCRIPTION
stop doing the "initialize django in the middle of our imports and disable all the lints that get mad" thing, and get rid of the `print()` that we do because our log initialization was sloppy

there is still a stupid import hack, but it's confined to `test_main.py` and is specifically for asserting on the thing that used to be a `print()`

<!-- %%% BRANCHLESS STACK INFO START %%% -->
<details open><summary> Stack info:</summary>

| Stack 1 |
|-|
|<ul><li>https://github.com/codecov/umbrella/pull/214</li><li>➡️https://github.com/codecov/umbrella/pull/215</li></ul>|

</details>
<!-- %%% BRANCHLESS STACK INFO END %%% -->