### PR TITLE
fix: handle new TA task failures gracefully

### DIFF
--- a/apps/worker/tasks/tests/unit/test_test_results_processor_task.py
+++ b/apps/worker/tasks/tests/unit/test_test_results_processor_task.py
@@ -705,6 +705,77 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
         )
 
 
+@pytest.mark.integration
+def test_test_results_processor_new_impl_fail(
+    mocker,
+    mock_configuration,
+    dbsession,
+    codecov_vcr,
+    mock_storage,
+    mock_redis,
+    celery_app,
+):
+    url = "whatever.txt"
+    with open(here.parent.parent / "samples" / "sample_test.json") as f:
+        content = f.read()
+        mock_storage.write_file("archive", url, content)
+    upload = UploadFactory.create(storage_path=url)
+    dbsession.add(upload)
+    dbsession.flush()
+    redis_queue = [{"url": url, "upload_id": upload.id_}]
+    mocker.patch.object(TestResultsProcessorTask, "app", celery_app)
+
+    mocker.patch(
+        "tasks.test_results_processor.TestResultsProcessorTask._new_impl",
+        side_effect=Exception("test"),
+    )
+
+    commit = CommitFactory.create(
+        message="hello world",
+        commitid="cd76b0821854a780b60012aed85af0a8263004ad",
+        repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
+        repository__owner__username="joseph-sentry",
+        repository__owner__service="github",
+        repository__name="codecov-demo",
+    )
+    dbsession.add(commit)
+    dbsession.flush()
+
+    current_report_row = CommitReport(commit_id=commit.id_)
+    dbsession.add(current_report_row)
+    dbsession.flush()
+
+    result = TestResultsProcessorTask().run_impl(
+        dbsession,
+        previous_result=False,
+        repoid=upload.report.commit.repoid,
+        commitid=commit.commitid,
+        commit_yaml={},
+        arguments_list=redis_queue,
+        impl_type="both",
+    )
+
+    tests = dbsession.query(Test).all()
+    test_instances = dbsession.query(TestInstance).all()
+    failures = dbsession.query(TestInstance).filter_by(outcome="failure").all()
+
+    assert result is True
+    assert len(tests) == 4
+    assert len(test_instances) == 4
+    assert len(failures) == 1
+
+    with pytest.raises(Exception, match="test"):
+        TestResultsProcessorTask().run_impl(
+            dbsession,
+            previous_result=False,
+            repoid=upload.report.commit.repoid,
+            commitid=commit.commitid,
+            commit_yaml={},
+            arguments_list=redis_queue,
+            impl_type="new",
+        )
+
+
 # def test_test_result_processor_task_warnings(dbsession, mock_storage, snapshot):
 #     with open(here.parent.parent / "samples" / "sample-warnings-junit.xml") as f:
 #         content = f.read()


### PR DESCRIPTION
Previously if the new TA processor was failing while in both mode, we would crash the entire test results processor task, but we want to have the old implementation still run even if the new one fails, so this fixes that.