### PR TITLE
[fix] Add github service filter check to Gen AI auth

### DIFF
--- a/apps/codecov-api/api/gen_ai/tests/test_gen_ai.py
+++ b/apps/codecov-api/api/gen_ai/tests/test_gen_ai.py
@@ -127,14 +127,12 @@ class GenAIAuthViewTests(APITestCase):
             owner = OwnerFactory(
                 service="gitlab", service_id="owner4", username="test4"
             )
-            # Create an installation with a non-github service
             GithubAppInstallationFactory(
                 installation_id=12345,
                 owner=owner,
                 name="ai-features",
                 repository_service_ids=["101", "202"],
                 app_id=12345,
-                service="gitlab",
             )
             payload = b'{"external_owner_id":"owner4","repo_service_id":"101"}'
             sig, data = sign_payload(payload)

--- a/apps/codecov-api/api/gen_ai/tests/test_gen_ai.py
+++ b/apps/codecov-api/api/gen_ai/tests/test_gen_ai.py
@@ -142,5 +142,4 @@ class GenAIAuthViewTests(APITestCase):
                 content_type="application/json",
                 HTTP_HTTP_X_GEN_AI_AUTH_SIGNATURE=sig,
             )
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.data, {"is_valid": False})
+            self.assertEqual(response.status_code, 404)

--- a/apps/codecov-api/api/gen_ai/tests/test_gen_ai.py
+++ b/apps/codecov-api/api/gen_ai/tests/test_gen_ai.py
@@ -120,3 +120,29 @@ class GenAIAuthViewTests(APITestCase):
             )
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data, {"is_valid": False})
+
+    @patch("api.gen_ai.views.get_config", return_value=PAYLOAD_SECRET)
+    def test_non_github_service(self, mock_config):
+        with patch("api.gen_ai.views.AI_FEATURES_GH_APP_ID", 12345):
+            owner = OwnerFactory(
+                service="gitlab", service_id="owner4", username="test4"
+            )
+            # Create an installation with a non-github service
+            GithubAppInstallationFactory(
+                installation_id=12345,
+                owner=owner,
+                name="ai-features",
+                repository_service_ids=["101", "202"],
+                app_id=12345,
+                service="gitlab",
+            )
+            payload = b'{"external_owner_id":"owner4","repo_service_id":"101"}'
+            sig, data = sign_payload(payload)
+            response = self.client.post(
+                VIEW_URL,
+                data=data,
+                content_type="application/json",
+                HTTP_HTTP_X_GEN_AI_AUTH_SIGNATURE=sig,
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.data, {"is_valid": False})

--- a/apps/codecov-api/api/gen_ai/views.py
+++ b/apps/codecov-api/api/gen_ai/views.py
@@ -40,14 +40,14 @@ class GenAIAuthView(APIView):
         if not external_owner_id or not repo_service_id:
             return Response("Missing required parameters", status=400)
         try:
-            owner = Owner.objects.get(service_id=external_owner_id)
+            owner = Owner.objects.get(service_id=external_owner_id, service="github")
         except Owner.DoesNotExist:
             raise NotFound("Owner not found")
 
         is_authorized = True
 
         app_install = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid, app_id=AI_FEATURES_GH_APP_ID, service="github"
+            owner_id=owner.ownerid, app_id=AI_FEATURES_GH_APP_ID
         ).first()
 
         if not app_install:

--- a/apps/codecov-api/api/gen_ai/views.py
+++ b/apps/codecov-api/api/gen_ai/views.py
@@ -47,7 +47,7 @@ class GenAIAuthView(APIView):
         is_authorized = True
 
         app_install = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid, app_id=AI_FEATURES_GH_APP_ID
+            owner_id=owner.ownerid, app_id=AI_FEATURES_GH_APP_ID, service="github"
         ).first()
 
         if not app_install:


### PR DESCRIPTION
We use this endpoint to validate that a user has the Codecov AI app installed before initiating any Seer workflows. It's possible for multiple owners to have the same service ID so there were cases where we were not fetching the right owner. This change fixes that. 