### PR TITLE
[fix] Safe fetch org yaml when parsing PR webhooks for GitHub

### DIFF
--- a/apps/codecov-api/webhook_handlers/views/github.py
+++ b/apps/codecov-api/webhook_handlers/views/github.py
@@ -440,7 +440,7 @@ class GithubWebhookHandler(APIView):
             service_id=request.data["repository"]["owner"]["id"],
         )
 
-        auto_review_enabled = org.yaml.get("ai_pr_review", {}).get("auto_review", False)
+        auto_review_enabled = (org.yaml or {}).get("ai_pr_review", {}).get("auto_review", False)
         return Response(
             data={
                 "auto_review_enabled": auto_review_enabled,


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixes https://codecov.sentry.io/issues/6670469327/?project=5215654&query=is%3Aunresolved&referrer=issue-stream&stream_index=2


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
