### PR TITLE
Increase the timeout for delete task

### DIFF
--- a/libs/shared/shared/celery_config.py
+++ b/libs/shared/shared/celery_config.py
@@ -203,8 +203,8 @@ class BaseCeleryConfig:
 
     task_annotations = {
         delete_owner_task_name: {
-            "soft_time_limit": 2 * task_soft_time_limit,
-            "time_limit": 2 * task_time_limit,
+            "soft_time_limit": 4 * task_soft_time_limit,
+            "time_limit": 4 * task_time_limit,
         },
         notify_task_name: {
             "soft_time_limit": notify_soft_time_limit,


### PR DESCRIPTION
We are finding that there are some delete tasks that are timing out and aren't being reprocessed. The tasks are currently hitting the hard time limit (of 24 minutes) and the process gets killed. This means that the task doesn't get retried. So increasing the time limit to see if it will actually finish.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
