### PR TITLE
[fix] Remove gen unit tests button

### DIFF
--- a/libs/shared/shared/torngit/github.py
+++ b/libs/shared/shared/torngit/github.py
@@ -17,7 +17,7 @@ from shared.helpers.cache import cache
 from shared.helpers.redis import get_redis_connection
 from shared.metrics import Counter
 from shared.rate_limits import set_entity_to_rate_limited
-from shared.rollouts.features import INCLUDE_GITHUB_COMMENT_ACTIONS_BY_OWNER
+
 from shared.torngit.base import TokenType, TorngitBaseAdapter
 from shared.torngit.enums import Endpoints
 from shared.torngit.exceptions import (
@@ -613,26 +613,7 @@ class Github(TorngitBaseAdapter):
         upload_type = self.data.get("additional_data", {}).get("upload_type")
         if upload_type in [UploadType.BUNDLE_ANALYSIS, UploadType.TEST_RESULTS]:
             return body
-        try:
-            ownerid = self.data["owner"].get("ownerid")
-            if (
-                issueid is not None
-                and await INCLUDE_GITHUB_COMMENT_ACTIONS_BY_OWNER.check_value_async(
-                    identifier=ownerid, default=False
-                )
-            ):
-                bot_name = get_config(
-                    "github", "comment_action_bot_name", default="sentry"
-                )
-                body["actions"] = [
-                    {
-                        "name": "Generate Unit Tests",
-                        "type": "copilot-chat",
-                        "prompt": f"@{bot_name} generate tests for this PR.",
-                    }
-                ]
-        except Exception:
-            pass
+
 
         return body
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

This button is no longer supported, and is broken in prod due to failing auth workflows. We should either re-create this button to trigger seer directly or direct users to use commands. 


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
