### PR TITLE
fix: Local stripe proxy post umbrella

### DIFF
--- a/apps/codecov-api/Makefile
+++ b/apps/codecov-api/Makefile
@@ -1,13 +1,13 @@
 sha ?= $(shell git rev-parse --short=7 HEAD)
 long_sha ?= $(shell git rev-parse HEAD)
 merge_sha ?= $(shell git merge-base HEAD^ origin/main)
-release_version ?= `cat VERSION`
+release_version ?= `cat ../../VERSION`
 build_date ?= $(shell git show -s --date=iso8601-strict --pretty=format:%cd $$sha)
 branch ?= $(shell git branch | grep \* | cut -f2 -d' ')
 epoch ?= $(shell date +"%s")
 AR_REPO ?= codecov/api
 DOCKERHUB_REPO ?= codecov/self-hosted-api
-REQUIREMENTS_TAG ?= requirements-v1-$(shell sha1sum uv.lock | cut -d ' ' -f 1)-$(shell sha1sum docker/Dockerfile.requirements | cut -d ' ' -f 1)
+REQUIREMENTS_TAG ?= requirements-v1-$(shell sha1sum ../../uv.lock | cut -d ' ' -f 1)-$(shell sha1sum docker/Dockerfile.requirements | cut -d ' ' -f 1)
 VERSION ?= release-${sha}
 CODECOV_UPLOAD_TOKEN ?= "notset"
 CODECOV_STATIC_TOKEN ?= "notset"
@@ -17,9 +17,9 @@ export API_DOCKER_REPO=${AR_REPO}
 export API_DOCKER_VERSION=${VERSION}
 export CODECOV_TOKEN=${CODECOV_UPLOAD_TOKEN}
 API_DOMAIN ?= api
-PROXY_NETWORK ?= api_default
+PROXY_NETWORK ?= umbrella_codecov
 
-DEFAULT_REQS_TAG := requirements-v1-$(shell sha1sum uv.lock | cut -d ' ' -f 1)-$(shell sha1sum docker/Dockerfile.requirements | cut -d ' ' -f 1)
+DEFAULT_REQS_TAG := requirements-v1-$(shell sha1sum ../../uv.lock | cut -d ' ' -f 1)-$(shell sha1sum docker/Dockerfile.requirements | cut -d ' ' -f 1)
 REQUIREMENTS_TAG ?= ${DEFAULT_REQS_TAG}
 
 # We allow this to be overridden so that we can run `pytest` from this directory

--- a/apps/codecov-api/billing/views.py
+++ b/apps/codecov-api/billing/views.py
@@ -441,6 +441,7 @@ class StripeWebhookHandler(APIView):
         incomplete_expired = subscription.status == "incomplete_expired"
 
         # Only update if there is not a scheduled subscription
+        # https://docs.stripe.com/billing/subscriptions/subscription-schedules
         if subscription_schedule_id:
             return
 


### PR DESCRIPTION
Tweaks the old stripe proxy make commands to work with the new directory structure and docker network. Also adds an unrelated comment to some billing code.
