### PR TITLE
fix: Use hooky name in stage action

### DIFF
--- a/.github/workflows/push-stage.yml
+++ b/.github/workflows/push-stage.yml
@@ -23,7 +23,7 @@ jobs:
           make_target_prefix: worker.
 
     trigger-worker-deploy:
-        name: Trigger codecov-worker deployment
+        name: Trigger worker deployment
         needs: [worker]
         if: ${{ !cancelled() && github.event_name == 'push' }}
         uses: ./.github/workflows/trigger-worker-deploy.yml


### PR DESCRIPTION
Updates the stage action name for worker deploy image to match what hooky is expecting.

https://github.com/codecov/hooky/blob/0ece194f56d09b237d983f4e009f4ab27b59ec2e/app/Services/GithubService.php#L520-L523

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
