### PR TITLE
fix: CORS custom logic returns `*` for external origins

### DIFF
--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -353,12 +353,6 @@ GITLAB_ENTERPRISE_TOKENLESS_BOT_KEY = get_config(
 GITLAB_ENTERPRISE_URL = get_config("gitlab_enterprise", "url")
 GITLAB_ENTERPRISE_API_URL = get_config("gitlab_enterprise", "api_url")
 
-CORS_ALLOW_HEADERS = (
-    list(default_headers)
-    + ["token-type"]
-    + get_config("setup", "api_cors_extra_headers", default=["baggage"])
-)
-
 SKIP_RISKY_MIGRATION_STEPS = get_config("migrations", "skip_risky_steps", default=False)
 
 DJANGO_ADMIN_URL = get_config("django", "admin_url", default="admin")
@@ -370,7 +364,19 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = int(
     get_config("setup", "http", "file_upload_max_memory_size", default=2621440)
 )
 
+# This is read by our custom CORS middleware and will set the allowed origins header to
+# "*" for all origins other than the ones explicitly allowed in CORS_ALLOWED_ORIGINS
+# and CORS_ALLOWED_ORIGIN_REGEXES, in which case it will rely on the default CORS
+# middleware behavior. This ensures that CORS_ALLOW_CREDENTIALS can never be enabled
+# on a request that does not come from an explicitly allowed origin.
+EXTERNAL_CORS_ALLOW_ALL_ORIGINS = True
+
 CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_HEADERS = (
+    list(default_headers)
+    + ["token-type"]
+    + get_config("setup", "api_cors_extra_headers", default=["baggage"])
+)
 CORS_ALLOWED_ORIGIN_REGEXES = get_config(
     "setup", "api_cors_allowed_origin_regexes", default=[]
 )

--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -56,10 +56,10 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "core.middleware.AppMetricsBeforeMiddlewareWithUA",
+    "codecov_auth.middleware.cors_middleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "codecov_auth.middleware.cors_middleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -68,8 +68,8 @@ MIDDLEWARE = [
     "core.middleware.ServiceMiddleware",
     "codecov_auth.middleware.current_owner_middleware",
     "codecov_auth.middleware.impersonation_middleware",
-    "core.middleware.AppMetricsAfterMiddlewareWithUA",
     "csp.middleware.CSPMiddleware",
+    "core.middleware.AppMetricsAfterMiddlewareWithUA",
 ]
 
 ROOT_URLCONF = "codecov.urls"

--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -370,6 +370,7 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = int(
     get_config("setup", "http", "file_upload_max_memory_size", default=2621440)
 )
 
+CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGIN_REGEXES = get_config(
     "setup", "api_cors_allowed_origin_regexes", default=[]
 )

--- a/apps/codecov-api/codecov/settings_dev.py
+++ b/apps/codecov-api/codecov/settings_dev.py
@@ -27,8 +27,7 @@ CODECOV_DASHBOARD_URL = get_config(
 
 CORS_ALLOWED_ORIGINS = [
     CODECOV_DASHBOARD_URL,
-    "http://localhost",
-    "http://localhost:9002",
+    "http://localhost:9002",  # Minio port when not using gateway
 ]
 
 COOKIES_DOMAIN = "localhost"

--- a/apps/codecov-api/codecov/settings_dev.py
+++ b/apps/codecov-api/codecov/settings_dev.py
@@ -19,7 +19,6 @@ STRIPE_ENDPOINT_SECRET = get_config(
     "services", "stripe", "endpoint_secret", default="default"
 )
 
-CORS_ALLOW_CREDENTIALS = True
 
 CODECOV_URL = "localhost"
 CODECOV_API_URL = get_config("setup", "codecov_api_url", default=CODECOV_URL)

--- a/apps/codecov-api/codecov/settings_dev.py
+++ b/apps/codecov-api/codecov/settings_dev.py
@@ -19,10 +19,11 @@ STRIPE_ENDPOINT_SECRET = get_config(
     "services", "stripe", "endpoint_secret", default="default"
 )
 
-
-CODECOV_URL = "localhost"
+CODECOV_URL = get_config("setup", "codecov_url", default="http://localhost:8080")
 CODECOV_API_URL = get_config("setup", "codecov_api_url", default=CODECOV_URL)
-CODECOV_DASHBOARD_URL = "http://localhost:3000"
+CODECOV_DASHBOARD_URL = get_config(
+    "setup", "codecov_dashboard_url", default=CODECOV_URL
+)
 
 CORS_ALLOWED_ORIGINS = [
     CODECOV_DASHBOARD_URL,

--- a/apps/codecov-api/codecov/settings_enterprise.py
+++ b/apps/codecov-api/codecov/settings_enterprise.py
@@ -9,7 +9,6 @@ THIS_POD_IP = os.environ.get("THIS_POD_IP")
 ALLOWED_HOSTS = get_config("setup", "api_allowed_hosts", default=["*"])
 if THIS_POD_IP:
     ALLOWED_HOSTS.append(THIS_POD_IP)
-CORS_ALLOW_CREDENTIALS = True
 # Setting default to localhost to avoid errors when running compilation steps.
 # This is "fine" because the app surely won't be in a working state without a valid url.
 CODECOV_URL = get_config("setup", "codecov_url", default="http://localhost")

--- a/apps/codecov-api/codecov/settings_prod.py
+++ b/apps/codecov-api/codecov/settings_prod.py
@@ -17,7 +17,6 @@ STRIPE_API_KEY = os.environ.get("SERVICES__STRIPE__API_KEY", None)
 STRIPE_ENDPOINT_SECRET = os.environ.get("SERVICES__STRIPE__ENDPOINT_SECRET", None)
 
 CORS_ALLOW_HEADERS += ["sentry-trace", "baggage"]
-CORS_ALLOW_CREDENTIALS = True
 CODECOV_URL = get_config("setup", "codecov_url", default="https://codecov.io")
 CODECOV_API_URL = get_config("setup", "codecov_api_url", default=CODECOV_URL)
 CODECOV_DASHBOARD_URL = get_config(

--- a/apps/codecov-api/codecov/settings_staging.py
+++ b/apps/codecov-api/codecov/settings_staging.py
@@ -29,7 +29,6 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^(https:\/\/)?\w+--gazebo\.netlify\.app$",
     r"^(https:\/\/)?preview-[\w\d\-]+\.codecov\.dev$",
 ]
-CORS_ALLOW_CREDENTIALS = True
 
 CODECOV_URL = get_config(
     "setup", "codecov_url", default="https://stage-web.codecov.dev"

--- a/apps/codecov-api/codecov_auth/tests/unit/test_middleware.py
+++ b/apps/codecov-api/codecov_auth/tests/unit/test_middleware.py
@@ -3,7 +3,11 @@ from django.test import TestCase, override_settings
 from utils.test_utils import Client
 
 
-@override_settings(CORS_ALLOWED_ORIGINS=["http://localhost:3000"])
+@override_settings(
+    CORS_ALLOWED_ORIGINS=["http://localhost:3000"],
+    CORS_ALLOWED_ORIGIN_REGEXES=[],
+    EXTERNAL_CORS_ALLOW_ALL_ORIGINS=True,
+)
 class MiddlewareTest(TestCase):
     def setUp(self):
         self.client = Client()
@@ -17,5 +21,12 @@ class MiddlewareTest(TestCase):
     def test_non_whitelisted_origin(self):
         res = self.client.get("/health", headers={"Origin": "http://example.com"})
 
-        assert res.headers["Access-Control-Allow-Origin"] == "http://example.com"
+        assert res.headers["Access-Control-Allow-Origin"] == "*"
+        assert "Access-Control-Allow-Credentials" not in res.headers
+
+    @override_settings(EXTERNAL_CORS_ALLOW_ALL_ORIGINS=False)
+    def test_external_cors_allow_all_origins_false(self):
+        res = self.client.get("/health", headers={"Origin": "http://example.com"})
+
+        assert "Access-Control-Allow-Origin" not in res.headers
         assert "Access-Control-Allow-Credentials" not in res.headers

--- a/apps/codecov-api/codecov_auth/tests/unit/views/test_base.py
+++ b/apps/codecov-api/codecov_auth/tests/unit/views/test_base.py
@@ -29,6 +29,9 @@ def set_up_mixin(to=None):
     return mixin
 
 
+@override_settings(
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 def test_generate_state_without_redirection_url(mock_redis):
     mixin = set_up_mixin()
     state = mixin.generate_state()
@@ -54,8 +57,10 @@ def test_generate_state_with_safe_domain_redirection_url(mock_redis):
     )
 
 
-@override_settings(CORS_ALLOWED_ORIGINS=[])
-@override_settings(CORS_ALLOWED_ORIGIN_REGEXES=[r"^(https:\/\/)?(.+)\.codecov\.io$"])
+@override_settings(
+    CORS_ALLOWED_ORIGINS=[],
+    CORS_ALLOWED_ORIGIN_REGEXES=[r"^(https:\/\/)?(.+)\.codecov\.io$"],
+)
 def test_generate_state_with_safe_domain_regex_redirection_url(mock_redis):
     mixin = set_up_mixin("https://app.codecov.io/gh/codecov")
     state = mixin.generate_state()
@@ -65,8 +70,11 @@ def test_generate_state_with_safe_domain_regex_redirection_url(mock_redis):
     )
 
 
-@override_settings(CORS_ALLOWED_ORIGINS=[])
-@override_settings(CORS_ALLOWED_ORIGIN_REGEXES=[])
+@override_settings(
+    CORS_ALLOWED_ORIGINS=[],
+    CORS_ALLOWED_ORIGIN_REGEXES=[],
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 def test_generate_state_with_unsafe_domain(mock_redis):
     mixin = set_up_mixin("http://hacker.com/i-steal-cookie")
     state = mixin.generate_state()
@@ -77,8 +85,11 @@ def test_generate_state_with_unsafe_domain(mock_redis):
     )
 
 
-@override_settings(CORS_ALLOWED_ORIGINS=[])
-@override_settings(CORS_ALLOWED_ORIGIN_REGEXES=[])
+@override_settings(
+    CORS_ALLOWED_ORIGINS=[],
+    CORS_ALLOWED_ORIGIN_REGEXES=[],
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 def test_generate_state_when_wrong_url(mock_redis):
     mixin = set_up_mixin("http://localhost:]/")
     state = mixin.generate_state()
@@ -89,6 +100,7 @@ def test_generate_state_when_wrong_url(mock_redis):
     )
 
 
+@override_settings(CODECOV_DASHBOARD_URL="http://localhost:3000")
 def test_get_redirection_url_from_state_without_redis_state(mock_redis):
     mixin = set_up_mixin()
     assert mixin.get_redirection_url_from_state("not exist") == (
@@ -97,6 +109,7 @@ def test_get_redirection_url_from_state_without_redis_state(mock_redis):
     )
 
 
+@override_settings(CODECOV_DASHBOARD_URL="http://localhost:3000")
 def test_get_redirection_url_from_state_without_session_state(mock_redis):
     mixin = set_up_mixin()
     state = "abc"
@@ -107,6 +120,7 @@ def test_get_redirection_url_from_state_without_session_state(mock_redis):
     )
 
 
+@override_settings(CODECOV_DASHBOARD_URL="http://localhost:3000")
 def test_get_redirection_url_from_state_with_session_state_mismatch(mock_redis):
     mixin = set_up_mixin()
     state = "abc"

--- a/apps/codecov-api/codecov_auth/tests/unit/views/test_gitlab.py
+++ b/apps/codecov-api/codecov_auth/tests/unit/views/test_gitlab.py
@@ -119,6 +119,7 @@ def test_get_gitlab_already_with_code_no_session(
     )
     settings.COOKIES_DOMAIN = ".simple.site"
     settings.COOKIE_SECRET = "cookie-secret"
+    settings.CODECOV_DASHBOARD_URL = "http://localhost:3000"
 
     access_token = "testp2twc8gxedplfn91tm4zn4r4ak2xgyr4ug96q86r2gr0re0143f20nuftka8"
     refresh_token = "testqyuk6z4s086jcvwoncxz8owl57o30qx1mhxlw3lgqliisujsiakh3ejq91tt"

--- a/apps/codecov-api/codecov_auth/tests/unit/views/test_okta_cloud.py
+++ b/apps/codecov-api/codecov_auth/tests/unit/views/test_okta_cloud.py
@@ -141,6 +141,9 @@ def test_okta_login_no_okta_settings(
     assert res.status_code == 404
 
 
+@override_settings(
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 @pytest.mark.django_db
 def test_okta_login_already_signed_into_okta(
     signed_in_client: TestClient,
@@ -177,6 +180,9 @@ def test_okta_login_redirect_to_okta_issuer(
     )
 
 
+@override_settings(
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 @pytest.mark.django_db
 def test_okta_callback_login_success(
     signed_in_client: TestClient,
@@ -214,6 +220,9 @@ def test_okta_callback_login_success(
     mocked_validate_id_token.assert_called_with("https://foo-bar.okta.com", ANY, ANY)
 
 
+@override_settings(
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 @pytest.mark.django_db
 def test_okta_callback_login_success_multiple_accounts(
     signed_in_client: TestClient,
@@ -384,6 +393,9 @@ def test_okta_callback_no_code(
     assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
 
 
+@override_settings(
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 @pytest.mark.django_db
 def test_okta_callback_perform_login_invalid_state(
     signed_in_client: TestClient,
@@ -420,6 +432,9 @@ def test_okta_callback_perform_login_invalid_state(
     assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
 
 
+@override_settings(
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 @pytest.mark.django_db
 def test_okta_callback_perform_login_no_user_data(
     mocker: MockerFixture,
@@ -465,6 +480,9 @@ def test_okta_callback_perform_login_no_user_data(
     assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
 
 
+@override_settings(
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 @pytest.mark.django_db
 def test_okta_callback_perform_login_invalid_id_token(
     mocker: MockerFixture,
@@ -513,6 +531,9 @@ def test_okta_callback_perform_login_invalid_id_token(
     assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
 
 
+@override_settings(
+    CODECOV_DASHBOARD_URL="http://localhost:3000",
+)
 @pytest.mark.django_db
 def test_okta_callback_perform_login_access_denied(
     mocker: MockerFixture,


### PR DESCRIPTION
Our API currently adds the `Access-Control-Allow-Credentials` header to requests originating from our whitelisted domains and sets `Access-Control-Allow-Origin` to the request origin for **all requests**. This is misleading since it implies every origin is on our whitelist and it risks us accidentally setting `Access-Control-Allow-Credentials` on non-whitelisted origins (whereas setting `Access-Control-Allow-Credentials` is a specification violation if `Access-Control-Allow-Origin` is set to `*`). To this point, we have received two security reports about our CORS configuration, where the researchers assume we have unintentionally allowed requests from every domain.

This PR fixes the issue by leaving credentials and standard origin headers to the base CORS module and then based on a global setting, will set `Access-Control-Allow-Origin` to `*` for all external origins if enabled.

Closes https://github.com/codecov/engineering-team/issues/2850