### PR TITLE
Use the correct user removal for webhooks remove

### DIFF
--- a/apps/codecov-api/webhook_handlers/views/github.py
+++ b/apps/codecov-api/webhook_handlers/views/github.py
@@ -716,7 +716,7 @@ class GithubWebhookHandler(APIView):
 
             try:
                 if org.plan_activated_users:
-                    org.plan_activated_users.remove(member.ownerid)
+                    org.deactivate_user(member)
                     org.save(update_fields=["plan_activated_users"])
             except ValueError:
                 pass


### PR DESCRIPTION
The `deactivate_user` function also gives us the side effect of updating associated accounts as well. We should be using this.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
