### PR TITLE
chore: Resolve new ruff checks

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: pre-commit/action@v3.0.1
 
   change-detection:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.12.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
   - repo: local

--- a/apps/codecov-api/api/internal/tests/views/test_repo_view.py
+++ b/apps/codecov-api/api/internal/tests/views/test_repo_view.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 from django.utils import timezone
 from rest_framework.reverse import reverse
 
-from api.internal.commit.serializers import CommitTotalsSerializer
+from api.internal.commit.serializers import (
+    CommitTotalsSerializer,
+    CommitWithFileLevelReportSerializer,
+)
 from api.internal.tests.test_utils import GetAdminProviderAdapter
 from codecov.tests.base_test import InternalAPITest
 from core.models import Repository
@@ -750,8 +753,6 @@ class TestRepositoryViewSetDetailActions(RepositoryViewSetTestSuite):
                 "sessions": {},
             },
         )
-
-        from api.internal.commit.serializers import CommitWithFileLevelReportSerializer
 
         expected_commit_payload = CommitWithFileLevelReportSerializer(commit).data
 

--- a/apps/codecov-api/codecov/commands/base.py
+++ b/apps/codecov-api/codecov/commands/base.py
@@ -120,7 +120,7 @@ class BaseCommand:
         if not self.executor:
             # local import to avoid circular import; I'm not too happy about
             # this pattern yet
-            from .executor import get_executor_from_command
+            from .executor import get_executor_from_command  # noqa: PLC0415
 
             self.executor = get_executor_from_command(self)
         return self.executor.get_command(namespace)

--- a/apps/codecov-api/codecov_auth/apps.py
+++ b/apps/codecov-api/codecov_auth/apps.py
@@ -5,4 +5,4 @@ class CodecovAuthConfig(AppConfig):
     name = "codecov_auth"
 
     def ready(self):
-        import codecov_auth.signals  # noqa: F401
+        import codecov_auth.signals  # noqa: F401, PLC0415

--- a/apps/codecov-api/codecov_auth/managers.py
+++ b/apps/codecov-api/codecov_auth/managers.py
@@ -23,7 +23,7 @@ class OwnerQuerySet(QuerySet):
         if a given user is activated in organization "owner", false
         otherwise.
         """
-        from codecov_auth.models import Owner
+        from codecov_auth.models import Owner  # noqa: PLC0415
 
         return self.annotate(
             activated=Coalesce(
@@ -47,7 +47,7 @@ class OwnerQuerySet(QuerySet):
         if a given user is an admin in organization "owner", and
         false otherwise.
         """
-        from codecov_auth.models import Owner
+        from codecov_auth.models import Owner  # noqa: PLC0415
 
         return self.annotate(
             is_admin=Coalesce(

--- a/apps/codecov-api/core/apps.py
+++ b/apps/codecov-api/core/apps.py
@@ -13,7 +13,7 @@ class CoreConfig(AppConfig):
     name = "core"
 
     def ready(self):
-        import core.signals  # noqa: F401
+        import core.signals  # noqa: F401, PLC0415
 
         if settings.RUN_ENV not in ["DEV", "TESTING"]:
             cache_backend = RedisBackend(get_redis_connection())

--- a/apps/codecov-api/services/tests/test_comparison.py
+++ b/apps/codecov-api/services/tests/test_comparison.py
@@ -10,6 +10,9 @@ import pytest
 import pytz
 from django.test import TestCase
 
+from api.internal.tests.views.test_compare_viewset import (
+    MockedComparisonAdapter,
+)
 from compare.models import CommitComparison
 from compare.tests.factories import CommitComparisonFactory
 from core.models import Commit
@@ -801,10 +804,6 @@ class ComparisonTests(TestCase):
         head_report_mock,
         git_comparison_mock,
     ):
-        from api.internal.tests.views.test_compare_viewset import (
-            MockedComparisonAdapter,
-        )
-
         src = b"two\nlines"
         git_comparison_mock.return_value = {"diff": {"files": {}}}
         mocked_comparison_adapter.return_value = MockedComparisonAdapter(
@@ -828,10 +827,6 @@ class ComparisonTests(TestCase):
         head_report_mock,
         git_comparison_mock,
     ):
-        from api.internal.tests.views.test_compare_viewset import (
-            MockedComparisonAdapter,
-        )
-
         src = "two\nlines"
         git_comparison_mock.return_value = {"diff": {"files": {}}}
         mocked_comparison_adapter.return_value = MockedComparisonAdapter(

--- a/apps/codecov-api/upload/tests/test_helpers.py
+++ b/apps/codecov-api/upload/tests/test_helpers.py
@@ -17,6 +17,7 @@ from shared.django_apps.core.tests.factories import (
     RepositoryFactory,
 )
 from shared.django_apps.reports.models import ReportType
+from shared.github import InvalidInstallationError
 from shared.plan.constants import DEFAULT_FREE_PLAN
 from shared.upload.utils import UploaderType, insert_coverage_measurement
 from upload.helpers import (
@@ -107,8 +108,6 @@ def test_try_to_get_best_possible_bot_token_using_integration(
 def test_try_to_get_best_possible_bot_token_using_invalid_integration(
     get_github_integration_token,
 ):
-    from shared.github import InvalidInstallationError  # circular imports
-
     get_github_integration_token.side_effect = InvalidInstallationError(
         error_cause="installation_not_found"
     )

--- a/apps/codecov-api/upload/tests/views/test_bundle_analysis.py
+++ b/apps/codecov-api/upload/tests/views/test_bundle_analysis.py
@@ -1,5 +1,6 @@
 import json
 import re
+from json import JSONDecodeError
 from unittest.mock import ANY, patch
 
 import pytest
@@ -741,8 +742,6 @@ def test_upload_bundle_analysis_tokenless_bad_json(db, client, mocker, mock_redi
 
     repository = RepositoryFactory.create(private=False)
     commit_sha = "6fd5b89357fc8cdf34d6197549ac7c6d7e5977ef"
-
-    from json import JSONDecodeError
 
     with patch(
         "codecov_auth.authentication.repo_auth.json.loads",

--- a/apps/worker/helpers/checkpoint_logger/__init__.py
+++ b/apps/worker/helpers/checkpoint_logger/__init__.py
@@ -427,7 +427,7 @@ def subflows(*args: tuple[str, str, str]) -> TClassDecorator:
     return class_decorator
 
 
-def reliability_counters(klass: type[T]) -> type[T]:
+def reliability_counters[T: "BaseFlow"](klass: type[T]) -> type[T]:
     """
     Class decorator that enables computing success/failure rates for a flow. It
     is expected that you invoke this **after** @success_events and/or
@@ -478,11 +478,11 @@ def _get_milli_timestamp() -> int:
     return time.time_ns() // 1000000
 
 
-def _kwargs_key(cls: type[T]) -> str:
+def _kwargs_key[T: "BaseFlow"](cls: type[T]) -> str:
     return f"checkpoints_{cls.__name__}"
 
 
-def from_kwargs(
+def from_kwargs[T: "BaseFlow"](
     flows: list[type[T]], kwargs: MutableMapping[str, Any], strict: bool = False
 ):
     checkpoints_data = {}

--- a/apps/worker/main.py
+++ b/apps/worker/main.py
@@ -10,6 +10,7 @@ from prometheus_client import REGISTRY, CollectorRegistry, multiprocess
 import app
 import shared.storage
 from helpers.environment import get_external_dependencies_folder
+from helpers.logging_config import get_logging_config_dict
 from helpers.version import get_current_version
 from shared.celery_config import BaseCeleryConfig
 from shared.config import get_config
@@ -46,8 +47,6 @@ def cli(ctx: click.Context):
 
 
 def setup_worker():
-    from helpers.logging_config import get_logging_config_dict
-
     _config_dict = get_logging_config_dict()
     logging.config.dictConfig(_config_dict)
 

--- a/apps/worker/manage.py
+++ b/apps/worker/manage.py
@@ -13,7 +13,7 @@ def main():
         "DJANGO_SETTINGS_MODULE", get_settings_module("django_scaffold")
     )
     try:
-        from django.core.management import execute_from_command_line
+        from django.core.management import execute_from_command_line  # noqa: PLC0415
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "

--- a/apps/worker/services/bundle_analysis/notify/contexts/__init__.py
+++ b/apps/worker/services/bundle_analysis/notify/contexts/__init__.py
@@ -1,6 +1,6 @@
 from enum import Enum, auto
 from functools import cached_property
-from typing import Generic, Literal, Self, TypeVar
+from typing import Literal, Self, TypeVar
 
 import sentry_sdk
 
@@ -37,7 +37,7 @@ class CommitStatusLevel(Enum):
         return "success"
 
 
-class NotificationContextField(Generic[T]):
+class NotificationContextField[T]:
     """NotificationContextField is a descriptor akin to a Django model field.
     If you create one as a class member named `foo`, it will define the behavior to get and set an instance member named `foo`.
     It is also similar to @property

--- a/apps/worker/services/test_results.py
+++ b/apps/worker/services/test_results.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import Generic, Literal, TypedDict, TypeVar
+from typing import Literal, TypedDict, TypeVar
 
 import sentry_sdk
 from sqlalchemy import desc, func
@@ -130,7 +130,7 @@ T = TypeVar("T", str, bytes)
 
 
 @dataclass
-class TestResultsNotificationFailure(Generic[T]):
+class TestResultsNotificationFailure[T: (str, bytes)]:
     failure_message: str
     display_name: str
     envs: list[str]
@@ -146,13 +146,13 @@ class FlakeInfo:
 
 
 @dataclass
-class TACommentInDepthInfo(Generic[T]):
+class TACommentInDepthInfo[T: (str, bytes)]:
     failures: list[TestResultsNotificationFailure[T]]
     flaky_tests: dict[T, FlakeInfo]
 
 
 @dataclass
-class TestResultsNotificationPayload(Generic[T]):
+class TestResultsNotificationPayload[T: (str, bytes)]:
     failed: int
     passed: int
     skipped: int
@@ -190,7 +190,7 @@ def display_duration(f: float) -> str:
         return f"{f:.3g}"
 
 
-def generate_failure_info(
+def generate_failure_info[T: (str, bytes)](
     fail: TestResultsNotificationFailure[T],
 ):
     if fail.failure_message is not None:
@@ -211,7 +211,7 @@ def generate_view_test_analytics_line(commit: Commit) -> str:
     return f"\nTo view more test analytics, go to the [Test Analytics Dashboard]({test_analytics_url})\n<sub>📋 Got 3 mins? [Take this short survey](https://forms.gle/BpocVj23nhr2Y45G7) to help us improve Test Analytics.</sub>"
 
 
-def messagify_failure(
+def messagify_failure[T: (str, bytes)](
     failure: TestResultsNotificationFailure[T],
 ) -> str:
     test_name = wrap_in_code(failure.display_name.replace("\x1f", " "))
@@ -224,7 +224,7 @@ def messagify_failure(
     return make_quoted(f"{test_name}\n{stack_trace}")
 
 
-def messagify_flake(
+def messagify_flake[T: (str, bytes)](
     flaky_failure: TestResultsNotificationFailure[T],
     flake_info: FlakeInfo,
 ) -> str:
@@ -287,7 +287,7 @@ def specific_error_message(error: ErrorPayload) -> str:
 
 
 @dataclass
-class TestResultsNotifier(BaseNotifier, Generic[T]):
+class TestResultsNotifier[T: (str, bytes)](BaseNotifier):
     payload: TestResultsNotificationPayload[T] | None = None
     error: ErrorPayload | None = None
 

--- a/apps/worker/tasks/base.py
+++ b/apps/worker/tasks/base.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 
+import psycopg2
 import sentry_sdk
 from celery._state import get_current_task
 from celery.exceptions import MaxRetriesExceededError, SoftTimeLimitExceeded
@@ -191,8 +192,6 @@ class BaseCodecovTask(celery_app.Task):
 
     def _analyse_error(self, exception: SQLAlchemyError, *args, **kwargs):
         try:
-            import psycopg2
-
             if hasattr(exception, "orig") and isinstance(
                 exception.orig, psycopg2.errors.DeadlockDetected
             ):

--- a/apps/worker/tasks/tests/unit/test_sync_teams_task.py
+++ b/apps/worker/tasks/tests/unit/test_sync_teams_task.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -75,8 +76,6 @@ class TestSyncTeamsTaskUnit:
     def test_gitlab_subgroups(
         self, mocker, mock_configuration, dbsession, codecov_vcr, caplog
     ):
-        import logging
-
         caplog.set_level(logging.DEBUG)
         token = "testenll80qbqhofao65"
         user = OwnerFactory.create(

--- a/libs/shared/shared/django_apps/codecov_auth/managers.py
+++ b/libs/shared/shared/django_apps/codecov_auth/managers.py
@@ -23,7 +23,7 @@ class OwnerQuerySet(QuerySet):
         if a given user is activated in organization "owner", false
         otherwise.
         """
-        from shared.django_apps.codecov_auth.models import Owner
+        from shared.django_apps.codecov_auth.models import Owner  # noqa: PLC0415
 
         return self.annotate(
             activated=Coalesce(
@@ -47,7 +47,7 @@ class OwnerQuerySet(QuerySet):
         if a given user is an admin in organization "owner", and
         false otherwise.
         """
-        from shared.django_apps.codecov_auth.models import Owner
+        from shared.django_apps.codecov_auth.models import Owner  # noqa: PLC0415
 
         return self.annotate(
             is_admin=Coalesce(

--- a/libs/shared/shared/django_apps/core/managers.py
+++ b/libs/shared/shared/django_apps/core/managers.py
@@ -66,7 +66,7 @@ class RepositoryQuerySet(QuerySet):
         are not changing as the most recent commit is uploading coverage
         reports.
         """
-        from shared.django_apps.core.models import Commit
+        from shared.django_apps.core.models import Commit  # noqa: PLC0415
 
         timestamp = timezone.now() - timezone.timedelta(hours=1)
 
@@ -114,7 +114,7 @@ class RepositoryQuerySet(QuerySet):
         """
         Annotates queryset with coverage of latest commit totals before cerain date.
         """
-        from shared.django_apps.core.models import Commit
+        from shared.django_apps.core.models import Commit  # noqa: PLC0415
 
         # Parsing the date given in parameters so we receive a datetime rather than a string
         timestamp = parser.parse(before_date)
@@ -165,7 +165,7 @@ class RepositoryQuerySet(QuerySet):
         - latest_commit_at as the true_coverage except NULL are transformed to 1/1/1900
         This make sure when we order the repo with no commit appears last.
         """
-        from shared.django_apps.core.models import Commit
+        from shared.django_apps.core.models import Commit  # noqa: PLC0415
 
         latest_commit_at = Subquery(
             Commit.objects.filter(repository_id=OuterRef("pk"))
@@ -183,7 +183,7 @@ class RepositoryQuerySet(QuerySet):
         """
         Annotates the queryset with the oldest commit timestamp.
         """
-        from shared.django_apps.core.models import Commit
+        from shared.django_apps.core.models import Commit  # noqa: PLC0415
 
         commits = Commit.objects.filter(repository_id=OuterRef("pk")).order_by(
             "timestamp"
@@ -193,7 +193,7 @@ class RepositoryQuerySet(QuerySet):
         )
 
     def get_or_create_from_git_repo(self, git_repo, owner):
-        from shared.django_apps.codecov_auth.models import Owner
+        from shared.django_apps.codecov_auth.models import Owner  # noqa: PLC0415
 
         service_id = git_repo.get("service_id") or git_repo.get("id")
         name = git_repo["name"]

--- a/libs/shared/shared/django_apps/core/models.py
+++ b/libs/shared/shared/django_apps/core/models.py
@@ -274,7 +274,9 @@ class Commit(ExportModelOperationsMixin("core.commit"), models.Model):
         # TODO: we should probably remove use of this method since it inverts the
         # dependency tree (services should be importing models and not the other
         # way around).  The caching should be preserved somehow though.
-        from shared.reports.api_report_service import build_report_from_commit
+        from shared.reports.api_report_service import (  # noqa: PLC0415
+            build_report_from_commit,
+        )
 
         return build_report_from_commit(self)
 

--- a/libs/shared/shared/django_apps/core/tests/factories.py
+++ b/libs/shared/shared/django_apps/core/tests/factories.py
@@ -109,7 +109,7 @@ class CommitWithReportFactory(CommitFactory):
         # The following replaces the old `commits.report` JSON column
         # TODO: we may want to find another way to create this since the imports below
         # create a cyclic dependency
-        from shared.django_apps.reports.tests.factories import (
+        from shared.django_apps.reports.tests.factories import (  # noqa: PLC0415
             CommitReportFactory,
             ReportLevelTotalsFactory,
             UploadFactory,

--- a/libs/shared/shared/django_apps/manage.py
+++ b/libs/shared/shared/django_apps/manage.py
@@ -9,7 +9,7 @@ def main():
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "shared.django_apps.settings_test")
     try:
-        from django.core.management import execute_from_command_line
+        from django.core.management import execute_from_command_line  # noqa: PLC0415
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "

--- a/libs/shared/shared/django_apps/rollouts/models.py
+++ b/libs/shared/shared/django_apps/rollouts/models.py
@@ -22,7 +22,9 @@ class RolloutUniverse(models.TextChoices):
 
 def default_random_salt():
     # to resolve circular dependency
-    from shared.django_apps.utils.rollout_utils import default_random_salt
+    from shared.django_apps.utils.rollout_utils import (  # noqa: PLC0415
+        default_random_salt,
+    )
 
     return default_random_salt()
 

--- a/libs/shared/shared/django_apps/utils/model_utils.py
+++ b/libs/shared/shared/django_apps/utils/model_utils.py
@@ -153,7 +153,7 @@ class ArchiveField:
 def get_ownerid_if_member(
     service: str, owner_username: str, owner_id: int
 ) -> int | None:
-    from shared.django_apps.codecov_auth.models import Owner
+    from shared.django_apps.codecov_auth.models import Owner  # noqa: PLC0415
 
     """
     This is a Python representation of the get_ownerid_if_member DB function.

--- a/libs/shared/shared/rate_limits/__init__.py
+++ b/libs/shared/shared/rate_limits/__init__.py
@@ -44,8 +44,8 @@ def determine_entity_redis_key(
 
     It should only be used for github git instances
     """
-    from shared.bots import get_adapter_auth_information
-    from shared.bots.types import AdapterAuthInformation
+    from shared.bots import get_adapter_auth_information  # noqa: PLC0415
+    from shared.bots.types import AdapterAuthInformation  # noqa: PLC0415
 
     if not owner:
         return default_bot_key_name()

--- a/libs/shared/shared/torngit/status.py
+++ b/libs/shared/shared/torngit/status.py
@@ -55,6 +55,9 @@ class Status:
         assert other in ("success", "failure", "pending")
         return self._state == other
 
+    def __hash__(self):
+        return hash(self._state)
+
     def __str__(self):
         """Returns the current ci status"""
         return self._state

--- a/libs/shared/shared/utils/sessions.py
+++ b/libs/shared/shared/utils/sessions.py
@@ -68,6 +68,28 @@ class Session:
             and self.session_extras == other.session_extras
         )
 
+    def __hash__(self):
+        return hash(
+            (
+                self.id,
+                self.totals.astuple()
+                if isinstance(self.totals, ReportTotals)
+                else frozenset(self.totals or ()),
+                self.time,
+                self.archive,
+                self.flags,
+                self.provider,
+                self.build,
+                self.job,
+                self.url,
+                self.state,
+                self.env,
+                self.name,
+                self.session_type,
+                repr(self.session_extras),
+            )
+        )
+
     def __repr__(self):
         return f"Session<{self._encode()}>"
 

--- a/libs/shared/shared/yaml/user_yaml.py
+++ b/libs/shared/shared/yaml/user_yaml.py
@@ -108,6 +108,16 @@ class UserYaml:
             return False
         return self.to_dict() == other.to_dict()
 
+    def __hash__(self):
+        return hash(self.__freeze(self.inner_dict))
+
+    def __freeze(self, d):
+        if isinstance(d, dict):
+            return frozenset((key, self.__freeze(value)) for key, value in d.items())
+        elif isinstance(d, list):
+            return tuple(self.__freeze(value) for value in d)
+        return d
+
     def __str__(self):
         return f"UserYaml<{self.inner_dict}>"
 

--- a/libs/shared/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/libs/shared/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -1,3 +1,4 @@
+import tempfile
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
@@ -1125,8 +1126,6 @@ def test_bundle_report_cleans_bad_chunks(version):
             content = f.read().replace("__VERSION__", version)
 
         # Create a temporary file with the modified content
-        import tempfile
-
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".json", delete=False
         ) as temp:

--- a/libs/shared/tests/unit/bundle_analysis/test_bundle_comparison.py
+++ b/libs/shared/tests/unit/bundle_analysis/test_bundle_comparison.py
@@ -13,7 +13,7 @@ from shared.bundle_analysis import (
     MissingHeadReportError,
     RouteChange,
 )
-from shared.bundle_analysis.models import Bundle, get_db_session
+from shared.bundle_analysis.models import Asset, Bundle, get_db_session
 
 here = Path(__file__)
 base_report_bundle_stats_path = (
@@ -400,8 +400,6 @@ def test_bundle_asset_comparison_using_uuid(mock_storage):
 
     # Update the UUIDs
     with get_db_session(comparison.base_report.db_path) as db_session:
-        from shared.bundle_analysis.models import Asset
-
         db_session.query(Asset).filter(Asset.name == "assets/index-666d2e09.js").update(
             {Asset.uuid: "123"}, synchronize_session="fetch"
         )
@@ -411,8 +409,6 @@ def test_bundle_asset_comparison_using_uuid(mock_storage):
         db_session.commit()
 
     with get_db_session(comparison.head_report.db_path) as db_session:
-        from shared.bundle_analysis.models import Asset
-
         db_session.query(Asset).filter(Asset.name == "assets/index-666d2e09.js").update(
             {Asset.uuid: "456"}, synchronize_session="fetch"
         )

--- a/libs/shared/tests/unit/test_status.py
+++ b/libs/shared/tests/unit/test_status.py
@@ -189,3 +189,41 @@ def test_fetch_most_relevant_status_per_context():
         {"context": "other", "state": "pending", "time": None, "url": None},
     ]
     assert expected_res == res
+
+
+def test_eq_hash():
+    status1 = Status(
+        [
+            {
+                "url": None,
+                "state": "success",
+                "context": "ci",
+                "time": "2023-10-01T12:00:00Z",
+            }
+        ]
+    )
+    status2 = Status(
+        [
+            {
+                "url": None,
+                "state": "success",
+                "context": "ci",
+                "time": "2023-10-01T12:00:00Z",
+            }
+        ]
+    )
+    status3 = Status(
+        [
+            {
+                "url": None,
+                "state": "failure",
+                "context": "ci",
+                "time": "2023-10-01T12:00:00Z",
+            }
+        ]
+    )
+
+    assert status1 == status2
+    assert hash(status1) == hash(status2)
+    assert status1 != status3
+    assert hash(status1) != hash(status3)

--- a/libs/shared/tests/unit/utils/test_sessions.py
+++ b/libs/shared/tests/unit/utils/test_sessions.py
@@ -133,3 +133,46 @@ def test_parse_session_then_encode():
     }
     sess = Session.parse_session(**encoded_session)
     assert sess._encode() == reencoded_session
+
+
+def test_eq_hash():
+    encoded_session = {
+        "t": ReportTotals(files=1, lines=3, hits=5, misses=6),
+        "d": "time",
+        "a": "archive",
+        "f": "flags",
+        "c": "provider",
+        "n": "build",
+        "N": "name",
+        "j": "job",
+        "u": "url",
+        "p": "state",
+        "e": "env",
+        "st": "uploaded",
+        "se": {},
+    }
+    encoded_session_diff = {
+        "t": [1, 3, 5, 6],
+        "d": "time",
+        "a": "archive",
+        "f": "flags",
+        "c": "provider",
+        "n": "build",
+        "N": "name2",
+        "j": "job",
+        "u": "url",
+        "p": "state",
+        "e": "env",
+        "st": "uploaded",
+        "se": {},
+    }
+    sess = Session.parse_session(**encoded_session)
+    sess2 = Session.parse_session(**encoded_session)
+    sess_diff = Session.parse_session(**encoded_session_diff)
+    assert sess == sess2
+    assert hash(sess) == hash(sess2)
+    assert repr(sess) == repr(sess2)
+
+    assert sess != sess_diff
+    assert hash(sess) != hash(sess_diff)
+    assert repr(sess) != repr(sess_diff)

--- a/libs/shared/tests/unit/yaml/test_user_yaml.py
+++ b/libs/shared/tests/unit/yaml/test_user_yaml.py
@@ -65,17 +65,19 @@ class TestUserYaml:
         assert d == {"value": "sample"}
         assert dicted == {"value": "sample", "l": "banana"}
 
-    def test_eq(self):
+    def test_eq_hash(self):
         d1 = {
             "key_one": "value",
             "key_two": {"sub": "p"},
             "key_three": "super",
             "key_four": "pro",
         }
-        d2 = {"key_two": "textnow", "key_three": "super", "key_four": "mega"}
+        d2 = {"key_two": "textnow", "key_three": "super", "key_four": ["mega"]}
         assert UserYaml(d1) == UserYaml(d1)
+        assert hash(UserYaml(d1)) == hash(UserYaml(d1))
         assert UserYaml(d1) != UserYaml(d2)
         assert UserYaml(d1) != d1
+        assert hash(UserYaml(d1)) != hash(UserYaml(d2))
 
     def test_read_yaml_field(self):
         my_dict = {

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,5 @@
 src = ["apps/*", "libs/*"]
+exclude = ["tools/git-filter-repo/*"]
 
 [lint]
 # https://docs.astral.sh/ruff/rules/
@@ -25,12 +26,8 @@ ignore = [
     "F405",    # `{name}` may be undefined, or defined from star imports
     "F841",    # Local variable `{name}` is assigned to but never used
     "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
-    "PLC0415", # import-outside-top-level
-    "PLW1641", # Object does not implement `__hash__` method
     "PERF203", # `try`-`except` within a loop incurs performance overhead
     # Trailing whitespace, and blank lines which we use in test assertions:
     "W291",
     "W293",
-    "UP047",   # Generic functions should use type parameters
-    "UP046",   # Generic classes uses `Generic` subclass instead of type parameters
 ]


### PR DESCRIPTION
* Added explicit ignores where circular imports were a problem
  * Move imports to the top of the file where it wasn't
* Ran ruff `--fix` for the generic type fixes
* Implemented missing hash functions for classes that implement `__eq__`