### PR TITLE
build: change how dev dependency-group is excluded from prod images

### DIFF
--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=./pyproject.toml,target=./pyproject.toml \
     --mount=type=bind,source=./uv.lock,target=./uv.lock \
     --mount=type=bind,source=libs/shared,target=libs/shared \
-    uv export --no-hashes --frozen --format requirements-txt > requirements.txt
+    uv export --no-group dev --no-hashes --frozen --format requirements-txt > requirements.txt
 
 # The resulting requirements.txt includes ourselves as a dependency we should install
 # "editably". Filter that out, leaving only external dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.13"
 
 [tool.uv]
-default-groups = ["prod"]
+default-groups = ["prod", "dev"]
 required-version = ">=0.7.5"
 
 [tool.uv.sources]


### PR DESCRIPTION
we want `pre-commit` and such to be available outside the containers, but we don't want to make everyone run `uv sync --group dev` manually. so add the group back to `default-groups` and then explicitly exclude it when building prod reqs images

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
