### PR TITLE
fix(api): Add missing CORS headers on external `OPTIONS` requests

### DIFF
--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -368,9 +368,10 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = int(
 # This is read by our custom CORS middleware and will set the allowed origins header to
 # "*" for all origins other than the ones explicitly allowed in CORS_ALLOWED_ORIGINS
 # and CORS_ALLOWED_ORIGIN_REGEXES, in which case it will rely on the default CORS
-# middleware behavior. This ensures that CORS_ALLOW_CREDENTIALS can never be enabled
-# on a request that does not come from an explicitly allowed origin.
-EXTERNAL_CORS_ALLOW_ALL_ORIGINS = True
+# middleware (which also reads this value) behavior. This ensures that
+# CORS_ALLOW_CREDENTIALS can never be enabled on a request that does not come from an
+# explicitly allowed origin.
+CORS_ALLOW_ALL_ORIGINS = True
 
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOW_HEADERS = (

--- a/apps/codecov-api/codecov_auth/tests/unit/test_middleware.py
+++ b/apps/codecov-api/codecov_auth/tests/unit/test_middleware.py
@@ -6,27 +6,93 @@ from utils.test_utils import Client
 @override_settings(
     CORS_ALLOWED_ORIGINS=["http://localhost:3000"],
     CORS_ALLOWED_ORIGIN_REGEXES=[],
-    EXTERNAL_CORS_ALLOW_ALL_ORIGINS=True,
+    CORS_ALLOW_ALL_ORIGINS=True,
+    CORS_ALLOW_CREDENTIALS=True,
+    CORS_EXPOSE_HEADERS=["Test-Expose"],
 )
 class MiddlewareTest(TestCase):
+    options_cors_headers = (
+        "Access-Control-Allow-Headers",
+        "Access-Control-Allow-Methods",
+        "Access-Control-Max-Age",
+    )
+
     def setUp(self):
         self.client = Client()
 
-    def test_whitelisted_origin(self):
+    def test_get_whitelisted_origin(self):
         res = self.client.get("/health", headers={"Origin": "http://localhost:3000"})
 
         assert res.headers["Access-Control-Allow-Origin"] == "http://localhost:3000"
         assert res.headers["Access-Control-Allow-Credentials"] == "true"
+        assert res.headers["Access-Control-Expose-Headers"] == "Test-Expose"
 
-    def test_non_whitelisted_origin(self):
+        for header in self.options_cors_headers:
+            assert header not in res.headers
+
+    def test_options_whitelisted_origin(self):
+        res = self.client.options(
+            "/health", headers={"Origin": "http://localhost:3000"}
+        )
+
+        assert res.headers["Access-Control-Allow-Origin"] == "http://localhost:3000"
+        assert res.headers["Access-Control-Allow-Credentials"] == "true"
+        assert res.headers["Access-Control-Expose-Headers"] == "Test-Expose"
+
+        for header in self.options_cors_headers:
+            assert header in res.headers
+
+    def test_get_non_whitelisted_origin(self):
         res = self.client.get("/health", headers={"Origin": "http://example.com"})
 
         assert res.headers["Access-Control-Allow-Origin"] == "*"
         assert "Access-Control-Allow-Credentials" not in res.headers
+        assert res.headers["Access-Control-Expose-Headers"] == "Test-Expose"
 
-    @override_settings(EXTERNAL_CORS_ALLOW_ALL_ORIGINS=False)
-    def test_external_cors_allow_all_origins_false(self):
+        for header in self.options_cors_headers:
+            assert header not in res.headers
+
+    def test_options_non_whitelisted_origin(self):
+        res = self.client.options("/health", headers={"Origin": "http://example.com"})
+
+        assert res.headers["Access-Control-Allow-Origin"] == "*"
+        assert "Access-Control-Allow-Credentials" not in res.headers
+        assert res.headers["Access-Control-Expose-Headers"] == "Test-Expose"
+
+        for header in self.options_cors_headers:
+            assert header in res.headers
+
+    @override_settings(CORS_ALLOW_ALL_ORIGINS=False)
+    def test_options_cors_allow_all_origins_false(self):
+        res = self.client.options("/health", headers={"Origin": "http://example.com"})
+
+        assert "Access-Control-Allow-Origin" not in res.headers
+        assert "Access-Control-Allow-Credentials" not in res.headers
+        assert "Access-Control-Expose-Headers" not in res.headers
+
+        for header in self.options_cors_headers:
+            assert header not in res.headers
+
+    @override_settings(CORS_ALLOW_ALL_ORIGINS=False, CORS_ALLOW_CREDENTIALS=False)
+    def test_get_cors_allow_all_origins_credentials_false(self):
         res = self.client.get("/health", headers={"Origin": "http://example.com"})
 
         assert "Access-Control-Allow-Origin" not in res.headers
         assert "Access-Control-Allow-Credentials" not in res.headers
+        assert "Access-Control-Expose-Headers" not in res.headers
+
+        for header in self.options_cors_headers:
+            assert header not in res.headers
+
+    @override_settings(CORS_ALLOW_CREDENTIALS=False)
+    def test_options_cors_allow_credentials_false(self):
+        res = self.client.options(
+            "/health", headers={"Origin": "http://localhost:3000"}
+        )
+
+        assert res.headers["Access-Control-Allow-Origin"] == "*"
+        assert "Access-Control-Allow-Credentials" not in res.headers
+        assert res.headers["Access-Control-Expose-Headers"] == "Test-Expose"
+
+        for header in self.options_cors_headers:
+            assert header in res.headers


### PR DESCRIPTION
We previously did not return the `Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`, and `Access-Control-Max-Age`, headers on `OPTIONS` requests coming from an external (non-whitelisted domain). With this change, we properly allow for 3rd parties to use our API with CORS-enabled requests.

Shout out to @spalmurray for pointing out the missing headers.