### PR TITLE
refactor(shared): Centralize Postgres partition location

### DIFF
--- a/libs/shared/shared/django_apps/db_settings.py
+++ b/libs/shared/shared/django_apps/db_settings.py
@@ -201,10 +201,8 @@ if TA_TIMESERIES_ENABLED:
 # See https://django-postgres-extra.readthedocs.io/en/main/settings.html
 POSTGRES_EXTRA_DB_BACKEND_BASE: "django_prometheus.db.backends.postgresql"  # type: ignore
 
-# Allows to use the pgpartition command
-PSQLEXTRA_PARTITIONING_MANAGER = (
-    "shared.django_apps.user_measurements.partitioning.manager"
-)
+# Allows use of the pgpartition command
+PSQLEXTRA_PARTITIONING_MANAGER = "shared.django_apps.utils.partitioning.manager"
 
 DATABASE_ROUTERS = [
     "shared.django_apps.db_routers.MultiDatabaseRouter",

--- a/libs/shared/shared/django_apps/utils/partitioning.py
+++ b/libs/shared/shared/django_apps/utils/partitioning.py
@@ -10,12 +10,12 @@ from shared.django_apps.reports.models import DailyTestRollup
 from shared.django_apps.user_measurements.models import UserMeasurement
 
 # Overlapping partitions will cause errors - https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE -> "create partitions"
+# Note that the partitioning manager will not perform the actual creation and deletion of partitions automatically, we have a Celery task for that.
 manager = PostgresPartitioningManager(
     [
         # 12 partitions ahead, each partition is 1 month
-        # Partitions can be deleted after 12 months of their starting date, not their creation, via the pgpartition command.
-        # They won't be automatically deleted though.
-        # Partitions will be named `[table_name]_[year]_[3-letter month name]`.
+        # Delete partitions older than 3 months
+        # Partitions will be named `[table_name]_[year]_[3-letter month name]`
         PostgresPartitioningConfig(
             model=UserMeasurement,
             strategy=PostgresCurrentTimePartitioningStrategy(
@@ -24,6 +24,9 @@ manager = PostgresPartitioningManager(
                 max_age=relativedelta(months=12),
             ),
         ),
+        # 3 partitions ahead, each partition is one month
+        # Delete partitions older than 3 months
+        # Partitions will be named `[table_name]_[year]_[3-letter month name]`
         PostgresPartitioningConfig(
             model=DailyTestRollup,
             strategy=PostgresCurrentTimePartitioningStrategy(


### PR DESCRIPTION
Move the Postgres partition management definitions into a shared location and correct associated comments.

Note that I tested that the `pgpartition` command still works in staging
