### PR TITLE
feat: Celery task to run `pgpartition` on a schedule

### DIFF
--- a/apps/worker/celery_config.py
+++ b/apps/worker/celery_config.py
@@ -1,7 +1,6 @@
-# http://docs.celeryq.org/en/latest/configuration.html#configuration
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html
 import gc
 import logging
-import logging.config
 from datetime import timedelta
 
 from celery import signals
@@ -16,6 +15,7 @@ from shared.celery_config import (
     brolly_stats_rollup_task_name,
     gh_app_webhook_check_task_name,
     health_check_task_name,
+    partition_management_task_name,
 )
 from shared.config import get_config
 from shared.helpers.cache import RedisBackend, cache
@@ -93,6 +93,13 @@ def _beat_schedule():
         "regular_cleanup": {
             "task": regular_cleanup_cron_task_name,
             "schedule": crontab(minute="0", hour="4"),
+            "kwargs": {
+                "cron_task_generation_time_iso": BeatLazyFunc(get_utc_now_as_iso_format)
+            },
+        },
+        "partition_management": {
+            "task": partition_management_task_name,
+            "schedule": crontab(minute="0", hour="5"),  # 5 AM UTC
             "kwargs": {
                 "cron_task_generation_time_iso": BeatLazyFunc(get_utc_now_as_iso_format)
             },

--- a/apps/worker/tasks/__init__.py
+++ b/apps/worker/tasks/__init__.py
@@ -33,6 +33,7 @@ from tasks.manual_trigger import manual_trigger_task
 from tasks.new_user_activated import new_user_activated_task
 from tasks.notify import notify_task
 from tasks.notify_error import notify_error_task
+from tasks.partition_management import partition_management_task
 from tasks.plan_manager_task import daily_plan_manager_task_name
 from tasks.preprocess_upload import preprocess_upload_task
 from tasks.process_flakes import process_flakes_task

--- a/apps/worker/tasks/partition_management.py
+++ b/apps/worker/tasks/partition_management.py
@@ -1,0 +1,55 @@
+import logging
+import sys
+from io import StringIO
+
+from django.core.management import call_command
+
+from app import celery_app
+from shared.celery_config import partition_management_task_name
+from tasks.crontasks import CodecovCronTask
+
+log = logging.getLogger(__name__)
+
+
+class PartitionManagementTask(CodecovCronTask, name=partition_management_task_name):
+    """
+    Task to manage database partitions by running the pgpartition command.
+    This handles creating future partitions and deleting old partitions
+    based on the configuration in partitioning.py.
+    """
+
+    @classmethod
+    def get_min_seconds_interval_between_executions(cls):
+        return 18000  # 5h
+
+    def run_cron_task(self, db_session, *args, **kwargs):
+        log.info("Starting partition management task")
+        # Using the stdout and stderr arguments to call_command
+        # does not work for Celery tasks, so we redirect sys.stdout
+        prev, sys.stdout = sys.stdout, StringIO()
+        try:
+            call_command("pgpartition", "--yes")
+        except Exception as e:
+            log.exception(
+                "Error running partition management",
+                extra={"exception": str(e), "task_output": sys.stdout.getvalue()},
+            )
+            return {
+                "successful": False,
+                "reason": "Failed with exception",
+                "exception": str(e),
+                "task_output": sys.stdout.getvalue(),
+            }
+        finally:
+            out = sys.stdout.getvalue()
+            sys.stdout = prev
+
+        log.info(
+            "Partition management completed successfully",
+            extra={"task_output": out},
+        )
+        return {"successful": True}
+
+
+RegisteredPartitionManagementTask = celery_app.register_task(PartitionManagementTask())
+partition_management_task = celery_app.tasks[RegisteredPartitionManagementTask.name]

--- a/apps/worker/tasks/tests/unit/test_partition_management_task.py
+++ b/apps/worker/tasks/tests/unit/test_partition_management_task.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+from tasks.partition_management import PartitionManagementTask
+
+
+class TestPartitionsManagement:
+    def __mock_output_with_exception(self, *args, **kwargs):
+        print("Mocking sys.stdout")  # noqa: T201
+        raise Exception("Test exception")
+
+    @patch("tasks.partition_management.call_command")
+    def test_run_cron_task_success(self, mock_call_command, dbsession):
+        mock_call_command.return_value = None
+        task = PartitionManagementTask()
+        result = task.run_cron_task(dbsession)
+        assert result == {"successful": True}
+        assert mock_call_command.called
+
+    @patch("tasks.partition_management.call_command")
+    def test_run_cron_task_failure(self, mock_call_command, dbsession):
+        mock_call_command.side_effect = self.__mock_output_with_exception
+        task = PartitionManagementTask()
+        result = task.run_cron_task(dbsession)
+        assert result == {
+            "successful": False,
+            "reason": "Failed with exception",
+            "exception": "Test exception",
+            "task_output": "Mocking sys.stdout\n",
+        }
+        assert mock_call_command.called
+
+    def test_get_min_seconds_interval_between_executions(self, dbsession):
+        assert isinstance(
+            PartitionManagementTask.get_min_seconds_interval_between_executions(), int
+        )
+        # The specifics don't matter, but the number needs to be somewhat big
+        assert (
+            PartitionManagementTask.get_min_seconds_interval_between_executions() > 600
+        )

--- a/libs/shared/shared/celery_config.py
+++ b/libs/shared/shared/celery_config.py
@@ -53,6 +53,10 @@ cache_test_rollups_redis_task_name = (
     f"app.tasks.{TaskConfigGroup.cache_rollup.value}.CacheTestRollupsRedisTask"
 )
 
+partition_management_task_name = (
+    f"app.tasks.{TaskConfigGroup.partition_management.value}.PartitionManagementTask"
+)
+
 process_flakes_task_name = f"app.tasks.{TaskConfigGroup.flakes.value}.ProcessFlakesTask"
 
 manual_upload_completion_trigger_task_name = (

--- a/libs/shared/shared/utils/enums.py
+++ b/libs/shared/shared/utils/enums.py
@@ -32,6 +32,7 @@ class TaskConfigGroup(Enum):
     healthcheck = "healthcheck"
     new_user_activated = "new_user_activated"
     notify = "notify"
+    partition_management = "partition_management"
     profiling = "profiling"
     pulls = "pulls"
     send_email = "send_email"

--- a/libs/shared/tests/unit/test_celery_config.py
+++ b/libs/shared/tests/unit/test_celery_config.py
@@ -81,6 +81,10 @@ def test_celery_config():
             TaskConfigGroup.new_user_activated.value,
         ),
         ("app.tasks.notify.Notify", TaskConfigGroup.notify.value),
+        (
+            "app.tasks.partition_management.PartitionManagementTask",
+            TaskConfigGroup.partition_management.value,
+        ),
         ("app.tasks.profiling.collection", TaskConfigGroup.profiling.value),
         ("app.tasks.profiling.normalizer", TaskConfigGroup.profiling.value),
         ("app.tasks.profiling.summarization", TaskConfigGroup.profiling.value),


### PR DESCRIPTION
This Celery task ensures that partitions are automatically managed (created and deleted) instead of relying on startup scripts running on new deploys.