### PR TITLE
fix(worker): Make Copilot exempt from seat count checks

### DIFF
--- a/apps/worker/services/decoration.py
+++ b/apps/worker/services/decoration.py
@@ -20,12 +20,14 @@ BOT_USER_EMAILS = [
     "49699333+dependabot[bot]@users.noreply.github.com",
     "29139614+renovate[bot]@users.noreply.github.com",
     "157164994+sentry-autofix[bot]@users.noreply.github.com",
+    "198982749+Copilot@users.noreply.github.com",
 ]
 BOT_USER_IDS = [
     "49699333",
     "29139614",
     "157164994",
-]  # dependabot[bot], renovate[bot], sentry-autofix[bot]
+    "198982749",
+]  # dependabot[bot], renovate[bot], sentry-autofix[bot], copilot-swe-agent[bot]
 USER_BASIC_LIMIT_UPLOAD = 250
 
 

--- a/apps/worker/services/tests/test_decoration.py
+++ b/apps/worker/services/tests/test_decoration.py
@@ -573,8 +573,10 @@ class TestDecorationServiceTestCase:
             (True, "email", "dependabot[bot]@users.noreply.github.com"),
             (True, "email", "29139614+renovate[bot]@users.noreply.github.com"),
             (True, "email", "157164994+sentry-autofix[bot]@users.noreply.github.com"),
+            (True, "email", "198982749+Copilot@users.noreply.github.com"),
             (True, "service_id", "29139614"),
             (True, "service_id", "157164994"),
+            (True, "service_id", "198982749"),
             (False, None, None),
         ],
     )


### PR DESCRIPTION
Allows for pull requests created by Copilot to be exempt from our seat count checks.