### PR TITLE
update test-result-parser to parse evals info out of JUnit

### DIFF
--- a/apps/codecov-api/api/public/v2/evals/views.py
+++ b/apps/codecov-api/api/public/v2/evals/views.py
@@ -177,9 +177,9 @@ class EvalsViewSet(viewsets.GenericViewSet, RepoPropertyMixin):
         testruns = list(queryset)
         try:
             return JsonResponse(self._aggregate_testruns(testruns))
-        except (json.JSONDecodeError, KeyError) as e:
+        except (json.JSONDecodeError, KeyError):
             return JsonResponse(
-                {"error": f"Error aggregating data: {e}"},
+                {"error": "Error aggregating data"},
                 status=500,
             )
 
@@ -220,9 +220,9 @@ class EvalsViewSet(viewsets.GenericViewSet, RepoPropertyMixin):
         try:
             base_data = self._aggregate_testruns(base_testruns)
             head_data = self._aggregate_testruns(head_testruns)
-        except (json.JSONDecodeError, KeyError) as e:
+        except (json.JSONDecodeError, KeyError):
             return JsonResponse(
-                {"error": f"Error aggregating data: {e}"},
+                {"error": "Error aggregating data"},
                 status=500,
             )
 

--- a/apps/codecov-api/api/public/v2/evals/views.py
+++ b/apps/codecov-api/api/public/v2/evals/views.py
@@ -1,3 +1,4 @@
+import json
 from typing import TypedDict
 
 import django_filters
@@ -92,29 +93,45 @@ class EvalsViewSet(viewsets.GenericViewSet, RepoPropertyMixin):
 
         # Calculate score sums and averages for all items with scores
         score_agg_data: dict[str, tuple[float, int]] = {}
-        cost_acc = 0
+        cost_acc = 0.0
         items_with_cost = 0
 
         for testrun in testruns:
-            eval_data = testrun.properties.get("eval", {})
+            # Sadly the exact format of the properties field is not well defined. Ideally we'd use Pydantic to validate
+            # but for now we will try to be flexible and handle the different formats.
+            # Check tests for examples of the different formats.
+            if isinstance(testrun.properties, str):
+                eval_data = json.loads(testrun.properties)
+            else:
+                eval_data = testrun.properties
+            if "eval" in eval_data:
+                eval_data = eval_data["eval"]
+            elif "evals" in eval_data:
+                eval_data = eval_data["evals"]
+
             scores = eval_data.get("scores", [])
             cost = eval_data.get("cost")
             if cost:
-                cost_acc += cost
+                cost_acc += float(cost)
                 items_with_cost += 1
 
+            if isinstance(scores, list):
+                scores = {
+                    score["name"]: {
+                        "value": score.get("value") or score.get("score", 0)
+                    }
+                    for score in scores
+                }
+
             # Consider scores from all items (not just passed ones)
-            for score in scores:
-                name = score.get("name")
-                if name:
-                    score_value = score.get("value") or score.get("score")
-                    if isinstance(score_value, int | float):
-                        if name not in score_agg_data:
-                            score_agg_data[name] = (0, 0)
-                        score_agg_data[name] = (
-                            score_agg_data[name][0] + score_value,
-                            score_agg_data[name][1] + 1,
-                        )
+            for score_name, score in scores.items():
+                if score_name not in score_agg_data:
+                    score_agg_data[score_name] = (0, 0)
+                score_agg_data[score_name] = (
+                    score_agg_data[score_name][0]
+                    + float(score.get("value") or score.get("score", 0)),
+                    score_agg_data[score_name][1] + 1,
+                )
 
         # Create score aggregation dicts with both sum and avg
         scores = {
@@ -158,7 +175,13 @@ class EvalsViewSet(viewsets.GenericViewSet, RepoPropertyMixin):
         """
         queryset = self.filter_queryset(self.get_queryset())
         testruns = list(queryset)
-        return JsonResponse(self._aggregate_testruns(testruns))
+        try:
+            return JsonResponse(self._aggregate_testruns(testruns))
+        except (json.JSONDecodeError, KeyError) as e:
+            return JsonResponse(
+                {"error": f"Error aggregating data: {e}"},
+                status=500,
+            )
 
     @extend_schema(
         summary="Evaluation compare",
@@ -194,8 +217,14 @@ class EvalsViewSet(viewsets.GenericViewSet, RepoPropertyMixin):
         base_testruns = list(self.get_queryset().filter(commit_sha=base_sha))
         head_testruns = list(self.get_queryset().filter(commit_sha=head_sha))
 
-        base_data = self._aggregate_testruns(base_testruns)
-        head_data = self._aggregate_testruns(head_testruns)
+        try:
+            base_data = self._aggregate_testruns(base_testruns)
+            head_data = self._aggregate_testruns(head_testruns)
+        except (json.JSONDecodeError, KeyError) as e:
+            return JsonResponse(
+                {"error": f"Error aggregating data: {e}"},
+                status=500,
+            )
 
         # Calculate differences
         def calculate_diff(base, head):

--- a/apps/codecov-api/api/public/v2/tests/test_api_evals_viewset.py
+++ b/apps/codecov-api/api/public/v2/tests/test_api_evals_viewset.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
@@ -148,13 +149,8 @@ class EvalsViewSetTestCase(APITestCase):
             repo_id=self.repo.repoid,
             commit_sha="abc123",
             properties={
-                "eval": {
-                    "cost": 5.0,
-                    "scores": [
-                        {"name": "accuracy", "score": 0.9},
-                        {"name": "f1", "score": 0.8},
-                    ],
-                }
+                "cost": 5.0,
+                "scores": {"accuracy": {"value": 0.9}, "f1": {"value": 0.8}},
             },
         )
         Testrun.objects.using("ta_timeseries").create(
@@ -166,15 +162,17 @@ class EvalsViewSetTestCase(APITestCase):
             duration_seconds=20.0,
             repo_id=self.repo.repoid,
             commit_sha="abc123",
-            properties={
-                "eval": {
-                    "cost": 7.0,
-                    "scores": [
-                        {"name": "accuracy", "score": 0.7},
-                        {"name": "f1", "score": 0.6},
-                    ],
+            properties=json.dumps(
+                {
+                    "eval": {
+                        "cost": 7.0,
+                        "scores": [
+                            {"name": "accuracy", "score": 0.7},
+                            {"name": "f1", "score": 0.6},
+                        ],
+                    }
                 }
-            },
+            ),
         )
         Testrun.objects.using("ta_timeseries").create(
             timestamp=base_time + timedelta(seconds=2),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ required-version = ">=0.7.5"
 
 [tool.uv.sources]
 timestring = { git = "https://github.com/codecov/timestring", rev = "d37ceacc5954dff3b5bd2f887936a98a668dda42" }
-test-results-parser = { git = "https://github.com/codecov/test-results-parser", rev = "f4f44a3a144471c2b304ed1a6d03945a6d00bd84" }
+test-results-parser = { git = "https://github.com/codecov/test-results-parser", rev = "accbb7f63cc973ee9809b181a5cf67f1f8f13ecd" }
 shared = { workspace = true }                                                                                                      # TODO remove after repo-root migration
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -2351,7 +2351,7 @@ wheels = [
 [[package]]
 name = "test-results-parser"
 version = "0.5.4"
-source = { git = "https://github.com/codecov/test-results-parser?rev=f4f44a3a144471c2b304ed1a6d03945a6d00bd84#f4f44a3a144471c2b304ed1a6d03945a6d00bd84" }
+source = { git = "https://github.com/codecov/test-results-parser?rev=accbb7f63cc973ee9809b181a5cf67f1f8f13ecd#accbb7f63cc973ee9809b181a5cf67f1f8f13ecd" }
 
 [[package]]
 name = "timestring"
@@ -2849,7 +2849,7 @@ prod = [
     { name = "starlette", specifier = ">=0.40.0" },
     { name = "statsd", specifier = ">=3.3.0" },
     { name = "stripe", specifier = ">=11.4.1" },
-    { name = "test-results-parser", git = "https://github.com/codecov/test-results-parser?rev=f4f44a3a144471c2b304ed1a6d03945a6d00bd84" },
+    { name = "test-results-parser", git = "https://github.com/codecov/test-results-parser?rev=accbb7f63cc973ee9809b181a5cf67f1f8f13ecd" },
     { name = "timestring", git = "https://github.com/codecov/timestring?rev=d37ceacc5954dff3b5bd2f887936a98a668dda42" },
     { name = "urllib3", specifier = "==1.26.20" },
     { name = "whitenoise", specifier = ">=5.2.0" },
@@ -2945,7 +2945,7 @@ worker = [
     { name = "sqlparse", specifier = ">=0.5.0" },
     { name = "statsd", specifier = ">=3.3.0" },
     { name = "stripe", specifier = ">=11.4.1" },
-    { name = "test-results-parser", git = "https://github.com/codecov/test-results-parser?rev=f4f44a3a144471c2b304ed1a6d03945a6d00bd84" },
+    { name = "test-results-parser", git = "https://github.com/codecov/test-results-parser?rev=accbb7f63cc973ee9809b181a5cf67f1f8f13ecd" },
     { name = "timestring", git = "https://github.com/codecov/timestring?rev=d37ceacc5954dff3b5bd2f887936a98a668dda42" },
     { name = "urllib3", specifier = "==1.26.20" },
     { name = "zstandard", specifier = ">=0.23.0" },


### PR DESCRIPTION
and make the aggregation endpoint a bit more flexible in terms of what `Testrun.properties` can be