### PR TITLE
chore: Change partition management cron job name

### DIFF
--- a/libs/shared/shared/celery_config.py
+++ b/libs/shared/shared/celery_config.py
@@ -53,10 +53,6 @@ cache_test_rollups_redis_task_name = (
     f"app.tasks.{TaskConfigGroup.cache_rollup.value}.CacheTestRollupsRedisTask"
 )
 
-partition_management_task_name = (
-    f"app.tasks.{TaskConfigGroup.partition_management.value}.PartitionManagementTask"
-)
-
 process_flakes_task_name = f"app.tasks.{TaskConfigGroup.flakes.value}.ProcessFlakesTask"
 
 manual_upload_completion_trigger_task_name = (
@@ -103,11 +99,16 @@ timeseries_save_commit_measurements_task_name = (
 )
 
 health_check_task_name = f"app.cron.{TaskConfigGroup.healthcheck.value}.HealthCheckTask"
+
+# Daily cron tasks
 gh_app_webhook_check_task_name = (
     f"app.cron.{TaskConfigGroup.daily.value}.GitHubAppWebhooksCheckTask"
 )
 brolly_stats_rollup_task_name = (
     f"app.cron.{TaskConfigGroup.daily.value}.BrollyStatsRollupTask"
+)
+partition_management_task_name = (
+    f"app.cron.{TaskConfigGroup.daily.value}.PartitionManagementTask"
 )
 
 

--- a/libs/shared/shared/utils/enums.py
+++ b/libs/shared/shared/utils/enums.py
@@ -32,7 +32,6 @@ class TaskConfigGroup(Enum):
     healthcheck = "healthcheck"
     new_user_activated = "new_user_activated"
     notify = "notify"
-    partition_management = "partition_management"
     profiling = "profiling"
     pulls = "pulls"
     send_email = "send_email"

--- a/libs/shared/tests/unit/test_celery_config.py
+++ b/libs/shared/tests/unit/test_celery_config.py
@@ -7,7 +7,7 @@ from shared.utils.enums import TaskConfigGroup
 def test_celery_config():
     # NOTE: This test is fairly limited
     # Since all the fields get determined at import time (because they are class attributes),
-    # it's not possibe to mock `get_config` in order to see their results here.
+    # it's not possible to mock `get_config` in order to see their results here.
     # The only way to do so would to be to make each field a @classmethod
     # and hold the logic inside it.
     # It's not a terrible idea, but I am not sure of the impact of reloading those things every time
@@ -82,8 +82,8 @@ def test_celery_config():
         ),
         ("app.tasks.notify.Notify", TaskConfigGroup.notify.value),
         (
-            "app.tasks.partition_management.PartitionManagementTask",
-            TaskConfigGroup.partition_management.value,
+            "app.cron.daily.PartitionManagementTask",
+            TaskConfigGroup.daily.value,
         ),
         ("app.tasks.profiling.collection", TaskConfigGroup.profiling.value),
         ("app.tasks.profiling.normalizer", TaskConfigGroup.profiling.value),


### PR DESCRIPTION
Put the job under cron instead of tasks for proper organization
