### PR TITLE
fix: TA ordering and filtering bug

### DIFF
--- a/apps/codecov-api/utils/test_results.py
+++ b/apps/codecov-api/utils/test_results.py
@@ -205,9 +205,9 @@ def v1_agg_table(table: pl.LazyFrame) -> pl.LazyFrame:
         .alias("flags"),  # TODO: filter by this before we aggregate
         pl.col("failing_commits").sum().alias("commits_where_fail"),
         pl.col("last_duration").max().alias("last_duration"),
-        failure_rate_expr.alias("failure_rate"),
-        flake_rate_expr.alias("flake_rate"),
-        avg_duration_expr.alias("avg_duration"),
+        failure_rate_expr.fill_nan(0).alias("failure_rate"),
+        flake_rate_expr.fill_nan(0).alias("flake_rate"),
+        avg_duration_expr.fill_nan(0).alias("avg_duration"),
         total_duration_expr.alias("total_duration"),
         pl.col("pass_count").sum().alias("total_pass_count"),
         pl.col("fail_count").sum().alias("total_fail_count"),


### PR DESCRIPTION
divisions by zero, e.g. avg duration calculation where the total tests is 0, are causing NaNs to show up in the polars dataframe

the NaNs are causing errors in the GQL API which leads to the UI not even displaying, this only happens when we try to return values with NaNs 

also this error is isolated to users reading from the new TA rollups which is just us for now