### PR TITLE
Skip migrating risky plans change

### DIFF
--- a/libs/shared/shared/django_apps/codecov_auth/migrations/0070_add_sentry_merge_plan.py
+++ b/libs/shared/shared/django_apps/codecov_auth/migrations/0070_add_sentry_merge_plan.py
@@ -2,6 +2,8 @@
 
 from django.db import migrations
 
+from shared.django_apps.migration_utils import RiskyRunSQL
+
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -9,7 +11,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL(
+        RiskyRunSQL(
             "ALTER TYPE plans ADD VALUE 'sentry-merge';",
             reverse_sql=migrations.RunSQL.noop,
         ),


### PR DESCRIPTION
Production migration does not have the correct permissions to do the plan migration. Turning this migration into a risky one to skip the migration. We would need to run this migration seperately.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
