### PR TITLE
chore: Documentation and misc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,7 @@ git update-index --assume-unchanged docker-compose.yml
 - You can browse your local Redis by pointing the [Redis CLI](https://redis.io/docs/latest/develop/tools/cli/) or [Redis Insight GUI](https://redis.io/insight/) at 127.0.0.1:6380
 - You can browse your local Postgres database with the connection string `postgres://postgres@localhost:5434/postgres` in your preferred database browser
 - You can browse your local Timescale database with the connection string `postgres://postgres@localhost:5433/postgres` in your preferred database browser
+
+## Contributing
+
+This repository, like all of Codecov's repositories, strives to follow our general [Contributing guidlines](https://github.com/codecov/contributing). If you're considering making a contribution to this repository, we encourage review of our Contributing guidelines first.

--- a/apps/codecov-api/README.md
+++ b/apps/codecov-api/README.md
@@ -75,7 +75,3 @@ You can run the linter using the command `make lint_local`.
 ### Migrations
 
 We leverage Django's migration system to keep the state of our models in sync with the state of our database. You can read more about how we work with migrations at https://codecovio.atlassian.net/wiki/spaces/ENG/pages/1696530442/Migrations
-
-## Contributing
-
-This repository, like all of Codecov's repositories, strives to follow our general [Contributing guidlines](https://github.com/codecov/contributing). If you're considering making a contribution to this repository, we encourage review of our Contributing guidelines first.

--- a/apps/worker/.envrc
+++ b/apps/worker/.envrc
@@ -1,2 +1,0 @@
-uv sync
-source .venv/bin/activate

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -106,7 +106,3 @@ Before getting into changing the code, try to use the following structure (feel 
 - `tasks` - Those are the parts of the code that talk to the external world: it has the tasks that are triggered by external containers. They can depend on `helpers`, `models` and `services`, but NEVER depend on another task (except to schedule them). If some code is common to two tasks, try to put it in a `service` or somewhere else.
 
 You will also notice some usage of the package https://github.com/codecov/shared for various things. The logic that is there is used by both here and `codecov/api` codebase. So feel free to make changes there, but dont do anything that will break compatibility too hard.
-
-## Contributing
-
-This repository, like all of Codecov's repositories, strives to follow our general [Contributing guidlines](https://github.com/codecov/contributing). If you're considering making a contribution to this repository, we encourage review of our Contributing guidelines first.

--- a/apps/worker/tasks/base.py
+++ b/apps/worker/tasks/base.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime
 
-import psycopg2
 import sentry_sdk
 from celery._state import get_current_task
 from celery.exceptions import MaxRetriesExceededError, SoftTimeLimitExceeded
@@ -192,6 +191,8 @@ class BaseCodecovTask(celery_app.Task):
 
     def _analyse_error(self, exception: SQLAlchemyError, *args, **kwargs):
         try:
+            import psycopg2  # noqa: PLC0415
+
             if hasattr(exception, "orig") and isinstance(
                 exception.orig, psycopg2.errors.DeadlockDetected
             ):

--- a/libs/shared/README.md
+++ b/libs/shared/README.md
@@ -1,14 +1,12 @@
 # shared
 
-Shared is a place for code that is common to multiple python repositories on `codecov`.
+Shared is a place for code that is common to multiple python services within `codecov`.
 
 ## How does shared get into production
 
-`shared` is a repository of its own, so it needs to be installed as a dependency on the repositories that might use it.
+`shared` is a package of its own, so it needs to be installed as a dependency on the services that might use it.
 
-The current repositories using `shared` are `codecov/worker` and `codecov/codecov-api`.
-
-Whenever getting new code into `shared`, one needs to wait for a new version to be released (or release it themselves, see below), and update the `requirements.in` file in `codecov/worker` and `codecov/codecov-api` to use the newly released version of `shared`.
+The current services using `shared` are `worker` and `codecov-api`.
 
 ## Getting started
 
@@ -19,19 +17,6 @@ To get started, ensure that you have:
 ```
 docker compose up
 ```
-
-## Releasing a new version on shared
-
-To release a new version, you need to:
-
-1) Check what the next version should be.
-    - You can check the latest version on https://github.com/codecov/shared/releases
-    - As a rule of thumb, just add one to the micro version (number most to the right)
-2) Create a new PR:
-- Changing the `version` field on https://github.com/codecov/shared/blob/main/setup.py#L12 to that new version
-- Change https://github.com/codecov/shared/blob/main/CHANGELOG.md  unreleased header name to that version, and create a new _unreleased_ section with the same subsections.
-3) Merge that PR
-4) Create a new release on https://github.com/codecov/shared/releases/new
 
 ## Running tests
 
@@ -60,7 +45,7 @@ Now you can create a migration (from within the container)
 
 ```bash
 $ cd shared/django_apps/
-$ python manage.py makemigrations
+$ python manage.py pgmakemigrations
 ```
 
 To learn more about migrations visit [Django Docs](https://docs.djangoproject.com/en/5.0/topics/migrations/)
@@ -69,12 +54,8 @@ To learn more about migrations visit [Django Docs](https://docs.djangoproject.co
 
 As a normal python package, `shared` can include dependencies of its own.
 
-Updating them should be done at the `setup.py` file.
+Updating them should be done in the `pyproject.toml` file.
 
 Remember to add dependencies as loosely as possible. Only make sure to include what the minimum version is, and only include a maximum version if you do know that higher versions will break.
 
 Remember that multiple packages, on different contexts of their own requirements, will have to install this. So keeping the requirements loose allow them to avoid version clashes and eases upgrades whenever they need to.
-
-## Contributing
-
-This repository, like all of Codecov's repositories, strives to follow our general [Contributing guidlines](https://github.com/codecov/contributing). If you're considering making a contribution to this repository, we encourage review of our Contributing guidelines first.

--- a/tools/devenv/Makefile.test
+++ b/tools/devenv/Makefile.test
@@ -29,4 +29,3 @@ devenv.test.shared:
 devenv.upload.shared:
 	./tools/devenv/scripts/codecovcli-helper.sh upload-process -f libs/shared/tests/coverage.xml --disable-search -F sharedunit --recurse-submodules --plugin noop
 	./tools/devenv/scripts/codecovcli-helper.sh upload-process --report-type test_results -f libs/shared/tests/junit.xml --disable-search -F sharedunit --recurse-submodules --plugin noop
-


### PR DESCRIPTION
* Remove extra `Makefile` newline
* Remove old `.envrc` file
* Move the `psycopg2` import back into the `try...except` out of caution (was originally moved in #249)
* Move the contributors section to the main read
* Update `shared` module instructions for the monorepo setup