### PR TITLE
fix: take flaky_fail_count into account for total tests in new TA impl

### DIFF
--- a/apps/codecov-api/graphql_api/tests/test_test_analytics.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_analytics.py
@@ -846,7 +846,7 @@ class TestAnalyticsTestCase(GraphQLTestHelper):
     @pytest.mark.parametrize("ordering", ["FAILURE_RATE", "TOTAL_DURATION"])
     def test_gql_query_with_new_ta_format(self, mocker, repository, snapshot, ordering):
         # set the feature flag
-        mocker.patch("rollouts.READ_NEW_TA.check_value", return_value=True)
+        mocker.patch("utils.test_results.use_new_impl", return_value=True)
 
         # read file from samples
         storage = get_appropriate_storage_service()
@@ -934,7 +934,7 @@ class TestAnalyticsTestCase(GraphQLTestHelper):
         assert result["owner"]["repository"]["testAnalytics"][
             "testResultsAggregates"
         ] == {
-            "totalDuration": 7500.0,
+            "totalDuration": 8000.0,
             "slowestTestsDuration": 2500.0,
             "totalFails": 50,
             "totalSkips": 25,


### PR DESCRIPTION
in the old TA implementation the possible outcomes were: pass, fail, and skip.
flaky failures were a subset of fails which meant we shouldn't include the
flaky_fail_count in the total tests calculation

In the new implementation that's not the case, flakiness is represented by the
outcome of a testrun, which means that we have to count flaky fails in the total
tests

This commit also does some light refactoring of the polars aggregation
expressions for simplicity, and fixes a bug where we weren't running fill_nan
when it was needed.
