### PR TITLE
fix: always set testrun outcome to flaky_failure in process flakes

### DIFF
--- a/apps/worker/services/test_analytics/ta_process_flakes.py
+++ b/apps/worker/services/test_analytics/ta_process_flakes.py
@@ -60,13 +60,12 @@ def handle_failure(
     curr_flakes: dict[bytes, Flake], test_id: bytes, testrun: Testrun, repo_id: int
 ):
     existing_flake = curr_flakes.get(test_id)
+
     if existing_flake:
         existing_flake.fail_count += 1
         existing_flake.count += 1
         existing_flake.recent_passes_count = 0
     else:
-        if testrun.outcome != "flaky_failure":
-            testrun.outcome = "flaky_failure"
         new_flake = Flake(
             repoid=repo_id,
             test_id=test_id,
@@ -76,6 +75,9 @@ def handle_failure(
             start_date=datetime.now(),
         )
         curr_flakes[test_id] = new_flake
+
+    if testrun.outcome != "flaky_failure":
+        testrun.outcome = "flaky_failure"
 
 
 def process_flakes_for_commit(repo_id: int, commit_id: str):


### PR DESCRIPTION
we were only setting this outcome to flaky failure if we were creating a new flake, but any failure on the main branch should be considered a flaky failure (by our heuristic) so to be _correct_ we should be setting the outcome to flaky no matter if it 's for an existing flake or a new flake

a scenario where this would have been broken is if we had 2 uploads in quick succession and the flake weren't created by the first upload by the time we were processing the tests in the second, in this case we'd be missing a flaky test outcome on the second testrun