### PR TITLE
ci(overwatch): Only upload to Overwatch once

### DIFF
--- a/.github/workflows/upload-overwatch.yml
+++ b/.github/workflows/upload-overwatch.yml
@@ -12,18 +12,12 @@ permissions:
 jobs:
   upload-overwatch:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        project: [apps/worker, apps/codecov-api, libs/shared]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
 
       - uses: astral-sh/setup-uv@v5
       - run: uv sync
-        working-directory: ${{ matrix.project }}
-      - run: uv pip install mypy==1.15.0 ruff==0.11.8
-        working-directory: ${{ matrix.project }}
 
       - name: Install Overwatch CLI
         run: |
@@ -33,10 +27,9 @@ jobs:
           mv overwatch-cli /usr/local/bin/overwatch-cli
 
       - name: Run Overwatch CLI
-        working-directory: ${{ matrix.project }}
         run: |
           overwatch-cli \
             --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} \
             --organization-slug codecov \
             python \
-            --python-path "${{ github.workspace }}/.venv/bin/python"
+            --python-path ".venv/bin/python"


### PR DESCRIPTION
Uploads previously occurred three times and with the latest Seer changes that means repeated comments which is unwanted. This change removes the  matrix and uploads to Overwatch once.