### PR TITLE
feat: Update available plans to add Team Plan if not purchased 10 seats

### DIFF
--- a/libs/shared/shared/plan/service.py
+++ b/libs/shared/shared/plan/service.py
@@ -111,6 +111,13 @@ class PlanService:
         return self.current_org.total_seat_count
 
     @property
+    def free_seat_count(self) -> int:
+        """Returns the number of free seats for the organization."""
+        if self.has_account:
+            return self.current_org.account.free_seat_count
+        return self.current_org.free
+
+    @property
     def plan_activated_users(self) -> list[int] | None:
         """Returns the list of activated users for the plan."""
         return self.current_org.plan_activated_users
@@ -172,7 +179,9 @@ class PlanService:
 
         if (
             not self.plan_activated_users
-            or len(self.plan_activated_users) <= TEAM_PLAN_MAX_USERS
+            or len(self.plan_activated_users)
+            # Add the free seats if user has any because we want to allow them to purchase up to TEAM_PLAN_MAX_USERS regardless
+            <= (TEAM_PLAN_MAX_USERS + self.free_seat_count)
         ):
             available_tiers.append(TierName.TEAM.value)
 

--- a/libs/shared/tests/unit/plan/test_plan.py
+++ b/libs/shared/tests/unit/plan/test_plan.py
@@ -423,6 +423,21 @@ class PlanServiceTests(TestCase):
                 plan_service = PlanService(current_org=current_org)
                 assert plan_service.plan_user_count == 20
 
+    def test_plan_service_free_seat_count_with_no_account(self):
+        """Test plan_user_count when owner has an account"""
+        current_org = OwnerFactory(plan=DEFAULT_FREE_PLAN, free=5)
+        plan_service = PlanService(current_org=current_org)
+        assert plan_service.free_seat_count == 5
+
+    def test_plan_service_free_seat_count_with_account(self):
+        """Test plan_user_count when owner has an account"""
+        account = AccountFactory(
+            plan=DEFAULT_FREE_PLAN, plan_seat_count=10, free_seat_count=5
+        )
+        current_org = OwnerFactory(plan=DEFAULT_FREE_PLAN, account=account)
+        plan_service = PlanService(current_org=current_org)
+        assert plan_service.free_seat_count == 5
+
 
 class AvailablePlansBeforeTrial(TestCase):
     """


### PR DESCRIPTION
This PR fixes a bug where the available plans for a user wouldn't include the team plan if they had more than 10 seats including seats which we gave for free.

This exposes a new "free_user_count" property on plan service which we use in availablePlans when checking to see if we should include the team plans in that list.


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
