### PR TITLE
feat: Add pytest path variable for running pytest with a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ $ make devenv.test.api
 $ make devenv.test.shared
 ```
 
-These `make` targets capture a few magic incantations involved in running our tests but they don't allow you to specify specific test files you want to run. A shell function or custom script may be nicer.
+Including the extra parameter "EXTRA_PYTEST_ARGS" allows you to add additional options to the pytest run. For example, if you wanted to run tests in the shared foo directory you could
+run the command `make devenv.test.shared EXTRA_PYTEST_ARGS foo`
 
 ### Submitting coverage and test results locally
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ make devenv.test.shared
 ```
 
 Including the extra parameter "EXTRA_PYTEST_ARGS" allows you to add additional options to the pytest run. For example, if you wanted to run tests in the shared foo directory you could
-run the command `make devenv.test.shared EXTRA_PYTEST_ARGS foo`
+run the command `make devenv.test.shared EXTRA_PYTEST_ARGS=foo`
 
 ### Submitting coverage and test results locally
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -58,7 +58,7 @@ make build.base
 make build
 ```
 
-To run this as part of the whole infrasctructure, you will be better served by getting the main codebase and running `docker-compose up` from there
+To run this as part of the whole infrastructure, you will be better served by getting the main codebase and running `docker-compose up` from there
 
 ### Getting into enterprise mode
 
@@ -74,7 +74,7 @@ The source of truth on which version we use is in the file `VERSION`. Every scri
 
 That file is manually updated. We use semantic versioning.
 
-If you are unsure whether you need to change that version at a given moment, the answer is that you probaby don't then. We have multiple deploys on the same version, and only change it when we want to cut a version to enterprise.
+If you are unsure whether you need to change that version at a given moment, the answer is that you probably don't then. We have multiple deploys on the same version, and only change it when we want to cut a version to enterprise.
 
 ## Upgrading Dependencies
 
@@ -100,9 +100,9 @@ As the deployer, it is your responsibility to make sure the system is working as
 
 Before getting into changing the code, try to use the following structure (feel free to suggest changes.Some bits of it are based on our experience)
 
-- `helpers` - Those are the "low" level pieces of code, that don't depend on database models or any other heavy business logic. Those shouldn't depend on anything else on the codebase, preferrably
+- `helpers` - Those are the "low" level pieces of code, that don't depend on database models or any other heavy business logic. Those shouldn't depend on anything else on the codebase, preferably
 - `database` - Those contain database models. They can use logic from `helpers` and other models, but nothing else. Try to avoid any heavy logic in this code.
 - `services` - Those are heavier pieces of logic, that don't talk to the external world. They can use `helpers` and `database` logic, and among themselves. But make sure that if a service _bravo_ depends on service _alpha_, then _alpha_ should not depend on any part of _bravo_
 - `tasks` - Those are the parts of the code that talk to the external world: it has the tasks that are triggered by external containers. They can depend on `helpers`, `models` and `services`, but NEVER depend on another task (except to schedule them). If some code is common to two tasks, try to put it in a `service` or somewhere else.
 
-You will also notice some usage of the package https://github.com/codecov/shared for various things. The logic that is there is used by both here and `codecov/api` codebase. So feel free to make changes there, but dont do anything that will break compatibility too hard.
+You will also notice some usage of the package https://github.com/codecov/shared for various things. The logic that is there is used by both here and `codecov/api` codebase. So feel free to make changes there, but don't do anything that will break compatibility too hard.

--- a/tools/devenv/Makefile.test
+++ b/tools/devenv/Makefile.test
@@ -1,14 +1,14 @@
 TEST_YML := ../../tools/devenv/config/test.yml
 
-# Optional PYTEST_PATH variable to specify pytest path
-PYTEST_PATH ?=
+# Optional EXTRA_PYTEST_ARGS variable to specify pytest path
+EXTRA_PYTEST_ARGS ?=
 
 .PHONY: devenv.test
 devenv.test: devenv.test.worker devenv.test.api devenv.test.shared
 
 .PHONY: devenv.test.worker
 devenv.test.worker:
-	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=django_scaffold.settings_test -it umbrella-worker-1 pytest --cov=./ --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini $(if $(PYTEST_PATH),$(PYTEST_PATH))
+	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=django_scaffold.settings_test -it umbrella-worker-1 pytest --cov=./ --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini $(EXTRA_PYTEST_ARGS)
 
 .PHONY: devenv.upload.worker
 devenv.upload.worker:
@@ -17,7 +17,7 @@ devenv.upload.worker:
 
 .PHONY: devenv.test.api
 devenv.test.api:
-	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=codecov.settings_test -it umbrella-api-1 pytest --cov=./ --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini $(if $(PYTEST_PATH),$(PYTEST_PATH))
+	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=codecov.settings_test -it umbrella-api-1 pytest --cov=./ --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini $(EXTRA_PYTEST_ARGS)
 
 .PHONY: devenv.upload.api
 devenv.upload.api:
@@ -26,7 +26,7 @@ devenv.upload.api:
 
 .PHONY: devenv.test.shared
 devenv.test.shared:
-	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=shared.django_apps.settings_test -it umbrella-shared-1 pytest --cov ./shared --cov-report=xml:tests/coverage.xml --junitxml=tests/junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini $(if $(PYTEST_PATH),$(PYTEST_PATH))
+	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=shared.django_apps.settings_test -it umbrella-shared-1 pytest --cov ./shared --cov-report=xml:tests/coverage.xml --junitxml=tests/junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini $(EXTRA_PYTEST_ARGS)
 
 .PHONY: devenv.upload.shared
 devenv.upload.shared:

--- a/tools/devenv/Makefile.test
+++ b/tools/devenv/Makefile.test
@@ -1,11 +1,14 @@
 TEST_YML := ../../tools/devenv/config/test.yml
 
+# Optional PYTEST_PATH variable to specify pytest path
+PYTEST_PATH ?=
+
 .PHONY: devenv.test
 devenv.test: devenv.test.worker devenv.test.api devenv.test.shared
 
 .PHONY: devenv.test.worker
 devenv.test.worker:
-	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=django_scaffold.settings_test -it umbrella-worker-1 pytest --cov=./ --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini
+	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=django_scaffold.settings_test -it umbrella-worker-1 pytest --cov=./ --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini $(if $(PYTEST_PATH),$(PYTEST_PATH))
 
 .PHONY: devenv.upload.worker
 devenv.upload.worker:
@@ -14,7 +17,7 @@ devenv.upload.worker:
 
 .PHONY: devenv.test.api
 devenv.test.api:
-	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=codecov.settings_test -it umbrella-api-1 pytest --cov=./ --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini
+	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=codecov.settings_test -it umbrella-api-1 pytest --cov=./ --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini $(if $(PYTEST_PATH),$(PYTEST_PATH))
 
 .PHONY: devenv.upload.api
 devenv.upload.api:
@@ -23,7 +26,7 @@ devenv.upload.api:
 
 .PHONY: devenv.test.shared
 devenv.test.shared:
-	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=shared.django_apps.settings_test -it umbrella-shared-1 pytest --cov ./shared --cov-report=xml:tests/coverage.xml --junitxml=tests/junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini
+	docker exec -e COVERAGE_CORE=sysmon -e RUN_ENV=TESTING -e CODECOV_YML=${TEST_YML} -e DJANGO_SETTINGS_MODULE=shared.django_apps.settings_test -it umbrella-shared-1 pytest --cov ./shared --cov-report=xml:tests/coverage.xml --junitxml=tests/junit.xml -o junit_family=legacy --rootdir=/app -c pytest.ini $(if $(PYTEST_PATH),$(PYTEST_PATH))
 
 .PHONY: devenv.upload.shared
 devenv.upload.shared:


### PR DESCRIPTION
Title, adds to API, Shared, and Worker

Closes https://linear.app/getsentry/issue/CCMRG-1055/extra-pytest-args-variable-in-toolsdevenvmakefiletest

![Screenshot 2025-07-08 at 10 10 37 AM](https://github.com/user-attachments/assets/45968c28-14b6-4feb-a243-00f7934f3398)
![Screenshot 2025-07-08 at 10 10 49 AM](https://github.com/user-attachments/assets/b1805b6a-afb6-4e16-ac7a-43fb89650c79)


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
