### PR TITLE
fix: Add caps to celery work

### DIFF
--- a/apps/worker/services/cleanup/pulls.py
+++ b/apps/worker/services/cleanup/pulls.py
@@ -1,8 +1,8 @@
 import logging
+import time
 
 import sentry_sdk
 from django.db.models.aggregates import Max
-
 from services.cleanup.models import DELETE_FILES_BATCHSIZE
 from services.cleanup.utils import CleanupContext
 from shared.django_apps.core.models import Pull, PullStates
@@ -14,6 +14,11 @@ log = logging.getLogger(__name__)
 @sentry_sdk.trace
 def cleanup_flare(
     context: CleanupContext,
+    start_id: int = 1,
+    max_id: int = None,
+    db_batch_size: int = 500,
+    file_batch_size: int = DELETE_FILES_BATCHSIZE,
+    max_total_batches: int = 200,  # Cap work per run
 ):
     """
     Flare is a field on a Pull object.
@@ -34,28 +39,31 @@ def cleanup_flare(
 
     try:
         log.info("Flare cleanup: starting task")
+
         # id is indexed, so this should be a fast call
-        max_id = Pull.objects.aggregate(max_id=Max("id"))["max_id"] or 0
-        start_id = 1
+        actual_max_id = Pull.objects.aggregate(max_id=Max("id"))["max_id"] or 0
+        max_id = max_id or actual_max_id
+        max_id = min(max_id, start_id + (max_total_batches * db_batch_size))
 
         # Clear in db, batch size is 500
         cleaned_db_flares = 0
-        for id_start in range(start_id, max_id, 500):
-            id_end = id_start + 500
+        for id_start in range(start_id, max_id, db_batch_size):
+            id_end = id_start + db_batch_size
 
-            non_open_pulls_with_flare_in_db = Pull.objects.filter(
-                id__gt=id_start, id__lte=id_end, _flare__isnull=False
-            ).exclude(state=PullStates.OPEN.value)
-
-            batch_ids = list(
-                non_open_pulls_with_flare_in_db.values_list("id", flat=True)
+            non_open_pulls_with_flare_in_db = (
+                Pull.objects.filter(
+                    id__gt=id_start,
+                    id__lte=id_end,
+                    _flare__isnull=False,
+                )
+                .exclude(state=PullStates.OPEN.value)
+                .iterator(chunk_size=100)  # Use iterator to avoid holding DB cursors
             )
 
-            # Update directly with ID list
-            if batch_ids:
-                cleaned_db_flares += Pull.objects.filter(id__in=batch_ids).update(
-                    _flare=None
-                )
+            for pull in non_open_pulls_with_flare_in_db:
+                pull._flare = None
+                pull.save(update_fields=["_flare"])
+                cleaned_db_flares += 1
 
         if cleaned_db_flares:
             log.info(f"Flare cleanup: cleared {cleaned_db_flares} database flares")
@@ -63,18 +71,22 @@ def cleanup_flare(
         # Clear in Archive, batch size is DELETE_FILES_BATCHSIZE
         # keep small batch_size here since files are deleted 1 by 1
         cleaned_file_flares = 0
-        for id_start in range(start_id, max_id, DELETE_FILES_BATCHSIZE):
-            id_end = id_start + DELETE_FILES_BATCHSIZE
+        for id_start in range(start_id, max_id, file_batch_size):
+            id_end = id_start + file_batch_size
 
-            non_open_pulls_with_flare_in_archive = Pull.objects.filter(
-                id__gt=id_start, id__lte=id_end, _flare_storage_path__isnull=False
-            ).exclude(state=PullStates.OPEN.value)
-
-            batch_of_id_path_pairs = list(
-                non_open_pulls_with_flare_in_archive.values_list(
-                    "id", "_flare_storage_path"
+            non_open_pulls_with_flare_in_archive = (
+                Pull.objects.filter(
+                    id__gt=id_start,
+                    id__lte=id_end,
+                    _flare_storage_path__isnull=False,
                 )
+                .exclude(state=PullStates.OPEN.value)
+                .values_list("id", "_flare_storage_path")
             )
+
+            batch_of_id_path_pairs = list(non_open_pulls_with_flare_in_archive)
+            if not batch_of_id_path_pairs:
+                continue
 
             # Track which pulls had successful deletions
             successful_deletions = []
@@ -83,9 +95,13 @@ def cleanup_flare(
                 try:
                     if context.storage.delete_file(context.default_bucket, path):
                         successful_deletions.append(pull_id)
+                        cleaned_file_flares += 1
+                    time.sleep(0.005)  # Throttle to avoid socket bursts
                 except FileNotInStorageError:
                     # If file isn't in storage, still mark as successful
                     successful_deletions.append(pull_id)
+                    cleaned_file_flares += 1
+                    time.sleep(0.005)  # Throttle to avoid socket bursts
                 except Exception as e:
                     log.error(f"Flare cleanup: error deleting file {path}: {e}")
                     sentry_sdk.capture_exception(e)
@@ -96,7 +112,6 @@ def cleanup_flare(
                     _flare_storage_path=None
                 )
 
-            cleaned_file_flares += len(successful_deletions)
             context.add_progress(cleaned_files=len(successful_deletions), model=Pull)
 
         if cleaned_file_flares:

--- a/apps/worker/services/cleanup/tests/test_pulls.py
+++ b/apps/worker/services/cleanup/tests/test_pulls.py
@@ -1,12 +1,8 @@
 import pytest
-
 from services.cleanup.pulls import cleanup_flare
 from services.cleanup.utils import CleanupContext
 from shared.django_apps.core.models import Pull, PullStates
-from shared.django_apps.core.tests.factories import (
-    PullFactory,
-    RepositoryFactory,
-)
+from shared.django_apps.core.tests.factories import PullFactory, RepositoryFactory
 from shared.storage.exceptions import FileNotInStorageError
 
 
@@ -78,7 +74,7 @@ def test_flare_cleanup_in_regular_cleanup(
 
     # Run flare cleanup
     context = CleanupContext()
-    cleanup_flare(context=context)
+    cleanup_flare(context=context, start_id=1, max_id=1000)
 
     # Check that the non-open pulls have had their flare data cleaned
     # Note: there is a cache for flare on the object (all ArchiveFields have this),
@@ -112,7 +108,7 @@ def test_flare_cleanup_in_regular_cleanup(
     # Verify that running cleanup again doesn't process the already cleaned pulls
     mock_delete.reset_mock()
     context = CleanupContext()
-    cleanup_flare(context=context)
+    cleanup_flare(context=context, start_id=1, max_id=1000)
 
     # Verify no delete calls were made for already processed pulls
     mock_delete.assert_not_called()
@@ -146,7 +142,7 @@ def test_flare_cleanup_failed_deletion(transactional_db, mocker, mock_archive_st
 
     # Run cleanup
     context = CleanupContext()
-    cleanup_flare(context=context)
+    cleanup_flare(context=context, start_id=1, max_id=1000)
 
     # Verify the delete_file was called
     storage_path = failed_deletion_pull._flare_storage_path
@@ -188,7 +184,7 @@ def test_flare_cleanup_file_not_in_storage(
 
     # Run cleanup
     context = CleanupContext()
-    cleanup_flare(context=context)
+    cleanup_flare(context=context, start_id=1, max_id=1000)
 
     # Verify the delete_file was called
     storage_path = file_not_in_storage_pull._flare_storage_path
@@ -234,7 +230,7 @@ def test_flare_cleanup_general_exception(
 
     # Run cleanup
     context = CleanupContext()
-    cleanup_flare(context=context)
+    cleanup_flare(context=context, start_id=1, max_id=1000)
 
     # Verify the delete_file was called
     storage_path = exception_pull._flare_storage_path


### PR DESCRIPTION
[UPDATE - this PR as is won't work unless I keep track of the start somewhere durable.. thinking.. tbd]

[This PR](https://github.com/codecov/umbrella/pull/232) removed bounds from cleanup_flare() function, causing it to process potentially millions of records instead of limited batches. This created too many concurrent file/socket connections (redis, postgres, GCS), exceeding the system's file descriptor limit (ulimit), resulting in "Error 24: Too many open files" in Celery.

Fix: Added back bounded processing (max 200 batches per run), used .iterator() for memory efficiency, and added throttling (time.sleep(0.005)) between file deletions to prevent connection spikes. Note that this means it will take more daily jobs to pay down the rows needing cleanup, but we'll do it in more manageable batches.

Also note this PR retains the changes that the original above PR was meant to solve (i.e., look at everything instead of just ids # 5000-500000, so we correctly process 1-4999 and 500001+).

Closes https://linear.app/getsentry/issue/CCMRG-1352/fix-ongoing-intermittent-celery-task-failures-reported-issue