### PR TITLE
feat: fetch TA GQL data directly from Timescale

### DIFF
--- a/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query__0.json
@@ -7,15 +7,13 @@
     "total_flaky_fail_count": 0,
     "total_skip_count": 0,
     "commits_where_fail": 0,
+    "total_count": 1,
     "failure_rate": 0.0,
     "flake_rate": 0.0,
-    "avg_duration": 0.0,
     "total_duration": 0.0,
+    "avg_duration": 0.0,
     "last_duration": 0.0,
-    "flags": [
-      "flag1",
-      "flag2"
-    ],
+    "flags": ["flag1", "flag2"],
     "name": "name0"
   },
   {
@@ -26,14 +24,13 @@
     "total_flaky_fail_count": 0,
     "total_skip_count": 0,
     "commits_where_fail": 1,
+    "total_count": 1,
     "failure_rate": 1.0,
     "flake_rate": 0.0,
-    "avg_duration": 1.0,
     "total_duration": 1.0,
+    "avg_duration": 1.0,
     "last_duration": 1.0,
-    "flags": [
-      "flag3"
-    ],
+    "flags": ["flag3"],
     "name": "name1"
   },
   {
@@ -44,15 +41,13 @@
     "total_flaky_fail_count": 0,
     "total_skip_count": 0,
     "commits_where_fail": 0,
+    "total_count": 1,
     "failure_rate": 0.0,
     "flake_rate": 0.0,
-    "avg_duration": 2.0,
     "total_duration": 2.0,
+    "avg_duration": 2.0,
     "last_duration": 2.0,
-    "flags": [
-      "flag1",
-      "flag2"
-    ],
+    "flags": ["flag1", "flag2"],
     "name": "name2"
   },
   {
@@ -63,14 +58,13 @@
     "total_flaky_fail_count": 0,
     "total_skip_count": 0,
     "commits_where_fail": 1,
+    "total_count": 1,
     "failure_rate": 1.0,
     "flake_rate": 0.0,
-    "avg_duration": 3.0,
     "total_duration": 3.0,
+    "avg_duration": 3.0,
     "last_duration": 3.0,
-    "flags": [
-      "flag3"
-    ],
+    "flags": ["flag3"],
     "name": "name3"
   },
   {
@@ -81,15 +75,13 @@
     "total_flaky_fail_count": 0,
     "total_skip_count": 0,
     "commits_where_fail": 0,
+    "total_count": 1,
     "failure_rate": 0.0,
     "flake_rate": 0.0,
-    "avg_duration": 4.0,
     "total_duration": 4.0,
+    "avg_duration": 4.0,
     "last_duration": 4.0,
-    "flags": [
-      "flag1",
-      "flag2"
-    ],
+    "flags": ["flag1", "flag2"],
     "name": "name4"
   }
 ]

--- a/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query__0.json
@@ -1,0 +1,95 @@
+[
+  {
+    "computed_name": "name0",
+    "testsuite": "testsuite0",
+    "total_pass_count": 1,
+    "total_fail_count": 0,
+    "total_flaky_fail_count": 0,
+    "total_skip_count": 0,
+    "commits_where_fail": 0,
+    "failure_rate": 0.0,
+    "flake_rate": 0.0,
+    "avg_duration": 0.0,
+    "total_duration": 0.0,
+    "last_duration": 0.0,
+    "flags": [
+      "flag1",
+      "flag2"
+    ],
+    "name": "name0"
+  },
+  {
+    "computed_name": "name1",
+    "testsuite": "testsuite1",
+    "total_pass_count": 0,
+    "total_fail_count": 1,
+    "total_flaky_fail_count": 0,
+    "total_skip_count": 0,
+    "commits_where_fail": 1,
+    "failure_rate": 1.0,
+    "flake_rate": 0.0,
+    "avg_duration": 1.0,
+    "total_duration": 1.0,
+    "last_duration": 1.0,
+    "flags": [
+      "flag3"
+    ],
+    "name": "name1"
+  },
+  {
+    "computed_name": "name2",
+    "testsuite": "testsuite2",
+    "total_pass_count": 1,
+    "total_fail_count": 0,
+    "total_flaky_fail_count": 0,
+    "total_skip_count": 0,
+    "commits_where_fail": 0,
+    "failure_rate": 0.0,
+    "flake_rate": 0.0,
+    "avg_duration": 2.0,
+    "total_duration": 2.0,
+    "last_duration": 2.0,
+    "flags": [
+      "flag1",
+      "flag2"
+    ],
+    "name": "name2"
+  },
+  {
+    "computed_name": "name3",
+    "testsuite": "testsuite3",
+    "total_pass_count": 0,
+    "total_fail_count": 1,
+    "total_flaky_fail_count": 0,
+    "total_skip_count": 0,
+    "commits_where_fail": 1,
+    "failure_rate": 1.0,
+    "flake_rate": 0.0,
+    "avg_duration": 3.0,
+    "total_duration": 3.0,
+    "last_duration": 3.0,
+    "flags": [
+      "flag3"
+    ],
+    "name": "name3"
+  },
+  {
+    "computed_name": "name4",
+    "testsuite": "testsuite4",
+    "total_pass_count": 1,
+    "total_fail_count": 0,
+    "total_flaky_fail_count": 0,
+    "total_skip_count": 0,
+    "commits_where_fail": 0,
+    "failure_rate": 0.0,
+    "flake_rate": 0.0,
+    "avg_duration": 4.0,
+    "total_duration": 4.0,
+    "last_duration": 4.0,
+    "flags": [
+      "flag1",
+      "flag2"
+    ],
+    "name": "name4"
+  }
+]

--- a/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
@@ -1,0 +1,105 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from django.db import connections
+
+from shared.django_apps.codecov_auth.tests.factories import OwnerFactory
+from shared.django_apps.core.tests.factories import RepositoryFactory
+from shared.django_apps.ta_timeseries.models import Testrun, calc_test_id
+from utils.timescale_test_results import get_flake_aggregates_from_timescale
+
+from .helper import GraphQLTestHelper
+
+
+@pytest.fixture(autouse=True)
+def repository():
+    owner = OwnerFactory(username="codecov-user")
+    repo = RepositoryFactory(author=owner, name="testRepoName", active=True)
+    return repo
+
+
+@pytest.fixture
+def new_ta_enabled(mocker):
+    mocker.patch(
+        "graphql_api.types.test_analytics.test_analytics.READ_NEW_TA.check_value",
+        return_value=True,
+    )
+
+
+@pytest.fixture
+def populate_timescale_flake_aggregates(repository):
+    # Create testruns with different flaky behavior patterns
+    today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    thirty_days_ago = today - timedelta(days=30)
+
+    # Recent testruns (today's data) - some flaky tests
+    recent_testruns = [
+        Testrun(
+            repo_id=repository.repoid,
+            test_id=calc_test_id(f"flaky_test_{i}", "", f"testsuite{i}"),
+            timestamp=today - timedelta(days=1) + timedelta(minutes=i * 60),
+            testsuite="testsuite1",
+            classname="",
+            name=f"flaky_test_{i}",
+            computed_name=f"flaky_test_{i}",
+            outcome="flaky_fail" if i == 0 else "pass",
+            duration_seconds=10.0,
+            commit_sha=f"commit{i + 1}",
+            flags=["flag1"],
+            branch="main",
+        )
+        for i in range(2)
+    ]
+
+    # Old testruns (30 days ago data) - different flaky pattern for comparison
+    old_testruns = [
+        Testrun(
+            test_id=calc_test_id(f"flaky_test_{i}", "", f"testsuite{i}"),
+            repo_id=repository.repoid,
+            timestamp=thirty_days_ago - timedelta(days=1) + timedelta(minutes=i * 60),
+            testsuite=f"testsuite{i}",
+            classname="",
+            name=f"flaky_test_{i}",
+            computed_name=f"flaky_test_{i}",
+            outcome="flaky_fail",
+            duration_seconds=15.0 + (i),
+            commit_sha=f"commit {i}",
+            flags=[f"flag{i}"],
+            branch="main",
+        )
+        for i in range(2, 5)
+    ]
+
+    testruns = recent_testruns + old_testruns
+
+    Testrun.objects.bulk_create(testruns)
+
+    # Refresh the continuous aggregate to ensure the repo summary is updated
+    min_timestamp = datetime.now(UTC) - timedelta(days=60)
+    max_timestamp = datetime.now(UTC)
+
+    with connections["ta_timeseries"].cursor() as cursor:
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_testrun_branch_summary_1day', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
+
+
+@pytest.mark.usefixtures("new_ta_enabled")
+@pytest.mark.django_db(databases=["default", "ta_timeseries"], transaction=True)
+class TestFlakeAggregatesTimescale(GraphQLTestHelper):
+    def test_gql_query_flake_aggregates(
+        self, repository, populate_timescale_flake_aggregates, snapshot
+    ):
+        result = get_flake_aggregates_from_timescale(
+            repository.repoid,
+            "main",
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+            - timedelta(days=30),
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0),
+        )
+        assert result is not None
+        assert result.flake_rate == 0.5
+        assert result.flake_count == 1
+        assert result.flake_rate_percent_change == -0.5
+        assert result.flake_count_percent_change == -0.6666666666666666

--- a/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
@@ -19,14 +19,6 @@ def repository():
 
 
 @pytest.fixture
-def new_ta_enabled(mocker):
-    mocker.patch(
-        "graphql_api.types.test_analytics.test_analytics.READ_NEW_TA.check_value",
-        return_value=True,
-    )
-
-
-@pytest.fixture
 def populate_timescale_flake_aggregates(repository):
     # Create testruns with different flaky behavior patterns
     today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
@@ -85,7 +77,6 @@ def populate_timescale_flake_aggregates(repository):
         )
 
 
-@pytest.mark.usefixtures("new_ta_enabled")
 @pytest.mark.django_db(databases=["default", "ta_timeseries"], transaction=True)
 class TestFlakeAggregatesTimescale(GraphQLTestHelper):
     def test_gql_query_flake_aggregates(

--- a/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
@@ -1,0 +1,67 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from django.db import connections
+
+from shared.django_apps.codecov_auth.tests.factories import OwnerFactory
+from shared.django_apps.core.tests.factories import RepositoryFactory
+from shared.django_apps.ta_timeseries.models import Testrun
+from utils.timescale_test_results import get_test_results_queryset
+
+from .helper import GraphQLTestHelper
+
+
+@pytest.fixture(autouse=True)
+def repository():
+    owner = OwnerFactory(username="codecov-user")
+    repo = RepositoryFactory(author=owner, name="testRepoName", active=True)
+
+    return repo
+
+
+@pytest.fixture
+def populate_timescale(repository):
+    Testrun.objects.bulk_create(
+        [
+            Testrun(
+                repo_id=repository.repoid,
+                timestamp=datetime.now(UTC) - timedelta(days=5 - i),
+                testsuite=f"testsuite{i}",
+                classname="",
+                name=f"name{i}",
+                computed_name=f"name{i}",
+                outcome="pass" if i % 2 == 0 else "failure",
+                duration_seconds=i,
+                commit_sha=f"test_commit {i}",
+                flags=["flag1", "flag2"] if i % 2 == 0 else ["flag3"],
+                branch="main",
+            )
+            for i in range(5)
+        ]
+    )
+
+    with connections["ta_timeseries"].cursor() as cursor:
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_testrun_branch_summary_1day', %s, %s)",
+            [
+                (datetime.now(UTC) - timedelta(days=10)),
+                datetime.now(UTC),
+            ],
+        )
+
+
+class TestAnalyticsTestCaseNew(GraphQLTestHelper):
+    @pytest.mark.django_db(databases=["default", "ta_timeseries"], transaction=True)
+    def test_gql_query(self, repository, populate_timescale, snapshot):
+        result = get_test_results_queryset(
+            repository.repoid,
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+            - timedelta(days=30),
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0),
+            "main",
+        )
+
+        assert result.count() == 5
+        assert snapshot("json") == [
+            {k: v for k, v in row.items() if k != "updated_at"} for row in result
+        ]

--- a/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
@@ -1,0 +1,103 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from django.db import connections
+
+from shared.django_apps.codecov_auth.tests.factories import OwnerFactory
+from shared.django_apps.core.tests.factories import RepositoryFactory
+from shared.django_apps.ta_timeseries.models import Testrun, calc_test_id
+from utils.timescale_test_results import get_test_results_aggregates_from_timescale
+
+from .helper import GraphQLTestHelper
+
+
+@pytest.fixture(autouse=True)
+def repository():
+    owner = OwnerFactory(username="codecov-user")
+    repo = RepositoryFactory(author=owner, name="testRepoName", active=True)
+    return repo
+
+
+@pytest.fixture
+def populate_timescale_test_results_aggregates(repository):
+    # Create testruns with different flaky behavior patterns
+    now_utc = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    thirty_days_ago = now_utc - timedelta(days=30)
+
+    # Recent testruns (today's data) - some flaky tests
+    recent_testruns = [
+        Testrun(
+            repo_id=repository.repoid,
+            test_id=calc_test_id(f"test_{i}", "", f"testsuite{i}"),
+            timestamp=now_utc - timedelta(days=1) + timedelta(minutes=i * 60),
+            testsuite="testsuite1",
+            classname="",
+            name=f"test_{i}",
+            computed_name=f"test_{i}",
+            outcome="pass" if i % 2 == 0 else "failure",
+            duration_seconds=10.0,
+            commit_sha=f"commit{i + 1}",
+            flags=["flag1"],
+            branch="main",
+        )
+        for i in range(2)
+    ]
+
+    # Old testruns (30 days ago data) - different flaky pattern for comparison
+    old_testruns = [
+        Testrun(
+            test_id=calc_test_id(f"test_{i}", "", f"testsuite{i}"),
+            repo_id=repository.repoid,
+            timestamp=thirty_days_ago - timedelta(days=1) + timedelta(minutes=i * 60),
+            testsuite=f"testsuite{i}",
+            classname="",
+            name=f"test_{i}",
+            computed_name=f"test_{i}",
+            outcome="pass" if i == 2 else "failure" if i == 3 else "skip",
+            duration_seconds=15.0 + (i) if i != 4 else 0.0,
+            commit_sha=f"commit {i}",
+            flags=[f"flag{i}"],
+            branch="main",
+        )
+        for i in range(2, 5)
+    ]
+
+    testruns = recent_testruns + old_testruns
+
+    Testrun.objects.bulk_create(testruns)
+
+    # Refresh the continuous aggregate to ensure the repo summary is updated
+    min_timestamp = datetime.now(UTC) - timedelta(days=60)
+    max_timestamp = datetime.now(UTC)
+
+    with connections["ta_timeseries"].cursor() as cursor:
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_testrun_branch_summary_1day', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
+
+
+@pytest.mark.django_db(databases=["default", "ta_timeseries"], transaction=True)
+class TestTestResultsAggregatesTimescale(GraphQLTestHelper):
+    def test_test_results_aggregates_timescale(
+        self, repository, populate_timescale_test_results_aggregates
+    ):
+        result = get_test_results_aggregates_from_timescale(
+            repository.repoid,
+            "main",
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+            - timedelta(days=30),
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0),
+        )
+
+        assert result is not None
+        assert result.total_duration == 20.0
+        assert result.fails == 1
+        assert result.skips == 0
+        assert result.slowest_tests_duration == 10.0
+        assert result.total_slow_tests == 1
+        assert result.slowest_tests_duration_percent_change == (10.0 - 18.0) / 18.0
+        assert result.total_duration_percent_change == (20.0 - 35.0) / 35.0
+        assert result.fails_percent_change == 0.0
+        assert result.skips_percent_change == -1.0
+        assert result.total_slow_tests_percent_change == 0.0

--- a/apps/codecov-api/utils/timescale_test_results.py
+++ b/apps/codecov-api/utils/timescale_test_results.py
@@ -1,0 +1,298 @@
+from datetime import datetime
+from typing import Literal
+
+from django.db import connections
+from django.db.models import (
+    Aggregate,
+    Case,
+    Count,
+    F,
+    FloatField,
+    Max,
+    Q,
+    Sum,
+    Value,
+    When,
+)
+from django.db.models.functions import Coalesce
+
+from shared.django_apps.ta_timeseries.models import (
+    TestrunBranchSummary,
+)
+from shared.metrics import Histogram
+from utils.ta_types import (
+    FlakeAggregates,
+    TestResultsAggregates,
+)
+
+get_test_result_aggregates_histogram = Histogram(
+    "get_test_result_aggregates_timescale",
+    "Time it takes to get the test result aggregates from the database",
+)
+
+get_flake_aggregates_histogram = Histogram(
+    "get_flake_aggregates_timescale",
+    "Time it takes to get the flake aggregates from the database",
+)
+
+
+class ArrayMergeDedupe(Aggregate):
+    function = "array_merge_dedup_agg"
+    template = "%(function)s(%(expressions)s)"
+
+
+def get_test_results_queryset(
+    repoid: int,
+    start_date: datetime,
+    end_date: datetime,
+    branch: str,
+    parameter: Literal["flaky_tests", "failed_tests", "slowest_tests", "skipped_tests"]
+    | None = None,
+    testsuites: list[str] | None = None,
+    flags: list[str] | None = None,
+    term: str | None = None,
+):
+    base_queryset = TestrunBranchSummary.objects.filter(
+        repo_id=repoid,
+        branch=branch,
+        timestamp_bin__gte=start_date,
+        timestamp_bin__lt=end_date,
+    )
+
+    aggregated_queryset = base_queryset.values("computed_name", "testsuite").annotate(
+        total_pass_count=Sum("pass_count"),
+        total_fail_count=Sum("fail_count"),
+        total_flaky_fail_count=Sum("flaky_fail_count"),
+        total_skip_count=Sum("skip_count"),
+        commits_where_fail=Sum("failing_commits"),
+        failure_rate=Coalesce(
+            (
+                Sum("fail_count", output_field=FloatField())
+                + Sum("flaky_fail_count", output_field=FloatField())
+            )
+            / (
+                Sum("pass_count", output_field=FloatField())
+                + Sum("fail_count", output_field=FloatField())
+                + Sum("flaky_fail_count", output_field=FloatField())
+            ),
+            Value(0.0),
+        ),
+        flake_rate=Coalesce(
+            Sum("flaky_fail_count", output_field=FloatField())
+            / (
+                Sum("pass_count", output_field=FloatField())
+                + Sum("fail_count", output_field=FloatField())
+                + Sum("flaky_fail_count", output_field=FloatField())
+            ),
+            Value(0.0),
+        ),
+        avg_duration=Coalesce(
+            Sum(
+                F("avg_duration_seconds")
+                * (F("pass_count") + F("fail_count") + F("flaky_fail_count")),
+                output_field=FloatField(),
+            )
+            / Sum(
+                F("pass_count") + F("fail_count") + F("flaky_fail_count"),
+                output_field=FloatField(),
+            ),
+            Value(0.0),
+        ),
+        total_duration=Sum(
+            F("avg_duration_seconds")
+            * (F("pass_count") + F("fail_count") + F("flaky_fail_count")),
+            output_field=FloatField(),
+        ),
+        last_duration=Max("last_duration_seconds"),
+        updated_at=Max("updated_at"),
+        flags=ArrayMergeDedupe("flags"),
+        name=F("computed_name"),
+    )
+
+    match parameter:
+        case "failed_tests":
+            aggregated_queryset = aggregated_queryset.filter(total_fail_count__gt=0)
+        case "flaky_tests":
+            aggregated_queryset = aggregated_queryset.filter(
+                total_flaky_fail_count__gt=0
+            )
+        case "skipped_tests":
+            aggregated_queryset = aggregated_queryset.filter(
+                total_skip_count__gt=0, total_pass_count__eq=0
+            )
+
+    if term:
+        aggregated_queryset = aggregated_queryset.filter(computed_name__icontains=term)
+    if testsuites:
+        aggregated_queryset = aggregated_queryset.filter(testsuite__in=testsuites)
+    if flags:
+        aggregated_queryset = aggregated_queryset.filter(flags__overlap=flags)
+
+    return aggregated_queryset
+
+
+def _pct_change(current: int | float | None, past: int | float | None) -> float:
+    if past is None or past == 0:
+        return 0.0
+    if current is None:
+        current = 0
+
+    return (current - past) / past
+
+
+def get_slowest_tests_duration(
+    repoid: int,
+    branch: str,
+    start_date: datetime,
+    end_date: datetime,
+    unique_test_count: int,
+) -> tuple[float, int]:
+    slow_test_num = min(100, max(unique_test_count // 20, 1))
+
+    with connections["ta_timeseries"].cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT SUM(total_duration) as slowest_tests_duration FROM (
+                SELECT SUM(avg_duration_seconds * (pass_count + fail_count + flaky_fail_count)) as total_duration
+                FROM ta_timeseries_testrun_branch_summary_1day
+                WHERE repo_id = %s
+                    AND branch = %s
+                    AND timestamp_bin >= %s
+                    AND timestamp_bin < %s
+                GROUP BY computed_name, testsuite
+                ORDER BY total_duration DESC
+                LIMIT %s
+            ) as slow_tests
+            """,
+            (repoid, branch, start_date, end_date, slow_test_num),
+        )
+        if result := cursor.fetchone():
+            return result[0], slow_test_num
+        else:
+            return 0.0, 0
+
+
+def get_aggregates(repoid: int, branch: str, start_date: datetime, end_date: datetime):
+    return TestrunBranchSummary.objects.filter(
+        repo_id=repoid,
+        branch=branch,
+        timestamp_bin__gte=start_date,
+        timestamp_bin__lt=end_date,
+    ).aggregate(
+        total_duration=Sum(
+            F("avg_duration_seconds")
+            * (F("pass_count") + F("fail_count") + F("flaky_fail_count")),
+            output_field=FloatField(),
+        ),
+        fails=Sum(F("fail_count") + F("flaky_fail_count")),
+        skips=Sum("skip_count"),
+        unique_test_count=Count("computed_name", distinct=True),
+    )
+
+
+@get_test_result_aggregates_histogram.time()
+def get_test_results_aggregates_from_timescale(
+    repoid: int, branch: str, start_date: datetime, end_date: datetime
+) -> TestResultsAggregates | None:
+    interval_duration = end_date - start_date
+    comparison_start_date = start_date - interval_duration
+    comparison_end_date = start_date
+
+    curr_aggregates = get_aggregates(repoid, branch, start_date, end_date)
+
+    if curr_aggregates["total_duration"] is None:
+        return None
+
+    curr_slow_test_duration, curr_slow_test_num = get_slowest_tests_duration(
+        repoid, branch, start_date, end_date, curr_aggregates["unique_test_count"]
+    )
+
+    past_aggregates = get_aggregates(
+        repoid, branch, comparison_start_date, comparison_end_date
+    )
+
+    past_slow_test_duration, past_slow_test_num = get_slowest_tests_duration(
+        repoid,
+        branch,
+        comparison_start_date,
+        comparison_end_date,
+        past_aggregates["unique_test_count"],
+    )
+
+    return TestResultsAggregates(
+        total_duration=curr_aggregates["total_duration"] or 0,
+        fails=curr_aggregates["fails"] or 0,
+        skips=curr_aggregates["skips"] or 0,
+        total_slow_tests=curr_slow_test_num,
+        slowest_tests_duration=curr_slow_test_duration or 0.0,
+        total_duration_percent_change=_pct_change(
+            curr_aggregates["total_duration"], past_aggregates["total_duration"]
+        ),
+        fails_percent_change=_pct_change(
+            curr_aggregates["fails"], past_aggregates["fails"]
+        ),
+        skips_percent_change=_pct_change(
+            curr_aggregates["skips"], past_aggregates["skips"]
+        ),
+        slowest_tests_duration_percent_change=_pct_change(
+            curr_slow_test_duration, past_slow_test_duration
+        ),
+        total_slow_tests_percent_change=_pct_change(
+            curr_slow_test_num, past_slow_test_num
+        ),
+    )
+
+
+@get_flake_aggregates_histogram.time()
+def get_flake_aggregates_from_timescale(
+    repoid: int, branch: str, start_date: datetime, end_date: datetime
+) -> FlakeAggregates | None:
+    interval_duration = end_date - start_date
+    comparison_start_date = start_date - interval_duration
+    comparison_end_date = start_date
+
+    def get_aggregates(
+        start: datetime,
+        end: datetime,
+    ):
+        return TestrunBranchSummary.objects.filter(
+            repo_id=repoid,
+            branch=branch,
+            timestamp_bin__gte=start,
+            timestamp_bin__lt=end,
+        ).aggregate(
+            total_count=Sum(
+                "pass_count",
+                output_field=FloatField(),
+            )
+            + Sum("fail_count", output_field=FloatField())
+            + Sum("flaky_fail_count", output_field=FloatField()),
+            flake_count=Count(
+                "computed_name", distinct=True, filter=Q(flaky_fail_count__gt=0)
+            ),
+            flake_rate=Case(
+                When(
+                    total_count=0,
+                    then=Value(0.0),
+                ),
+                default=Sum("flaky_fail_count", output_field=FloatField())
+                / F("total_count"),
+            ),
+        )
+
+    curr_aggregates = get_aggregates(start_date, end_date)
+    if curr_aggregates["flake_count"] is None:
+        return None
+
+    past_aggregates = get_aggregates(comparison_start_date, comparison_end_date)
+
+    return FlakeAggregates(
+        flake_count=curr_aggregates["flake_count"] or 0,
+        flake_rate=curr_aggregates["flake_rate"] or 0,
+        flake_count_percent_change=_pct_change(
+            curr_aggregates["flake_count"], past_aggregates["flake_count"]
+        ),
+        flake_rate_percent_change=_pct_change(
+            curr_aggregates["flake_rate"], past_aggregates["flake_rate"]
+        ),
+    )


### PR DESCRIPTION
the previous implementation of calculating TA aggregates relied on a polars
file stored in GCS that contained all the testrun data for a branch in a repo
grouped by test and day. We would aggregate that data further according to the
user's desired time interval and group by test only. We would also calculate
aggregates on all of the data grouped only by repo.

grouped by repo, test, day -> filter by interval -> group by repo, test -> table
                           -> filter by interval -> group by repo -> aggregates

generating this cache file meant that we'd have to scan all rows in Timescale
related to the (branch, repo) combination in the relevant table. These queries
take long and the bottleneck is in reading all the rows from disk, especially if
the data is cold.

What if we could avoid these expensive queries that scan all these rows?

We could fetch only the page of data we need from Timescale to populate the
results in the table, and we could create other continuous aggregates to make it
quick to compute the aggregates we display at the top of the page in the UI.

This commit makes the first step towards the above, by adding code that directly
fetches the relevant GQL fields from Timescale.

The next steps will be to optimize the calculation of the top of the page
aggregates by creating a CAgg that caches the incremental results of that
calculation by day.

I expect that this code might make Timescale performance worse as we'll still
be reading all the rows from the DB to calculate the top of the page aggregates,
but we'll solve this by creating a new CAgg that rolls up the data by day for
the branch and repo, allowing us to only have to read 60 rows per repo in order
to calculate the top of the page aggregates.