### PR TITLE
chore: Migrations refactor

### DIFF
--- a/apps/codecov-api/api.sh
+++ b/apps/codecov-api/api.sh
@@ -43,7 +43,7 @@ fi
 if [[ "${RUN_ENV:-}" = "ENTERPRISE" ]] || [[ "${RUN_ENV:-}" = "DEV" ]]; then
   echo "Running migrations"
   $pre_migrate $berglas python manage.py migrate $post_migrate
-  $pre_migrate $berglas python manage.py migrate --database "timeseries" $post_migrate
+  $pre_migrate $berglas python migrate_timeseries.py $post_migrate
   $pre_migrate $berglas python manage.py pgpartition --yes --skip-delete $post_migrate
 fi
 

--- a/apps/codecov-api/migrate-timeseries.sh
+++ b/apps/codecov-api/migrate-timeseries.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "Running Timeseries Django migrations"
+prefix=""
+if [ -f "/usr/local/bin/berglas" ]; then
+  prefix="berglas exec --"
+fi
+
+$prefix python migrate_timeseries.py

--- a/apps/codecov-api/migrate_timeseries.py
+++ b/apps/codecov-api/migrate_timeseries.py
@@ -1,0 +1,61 @@
+import logging
+import os
+
+import django
+from django.core.management import call_command
+from django.db import connections
+
+from shared.django_apps.utils.config import get_settings_module
+
+#################################################################
+# Keep in sync between apps/codecov-api/migrate_timeseries.py and
+# apps/worker/migrate_timeseries.py
+
+# Note: this is the only difference from the worker version
+parent_module = "codecov"
+#################################################################
+
+
+# Setup Django environment
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", get_settings_module(parent_module))
+django.setup()
+
+from django.conf import settings  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def run_migrate_commands():
+    for app, setting in [
+        ("timeseries", settings.TIMESERIES_ENABLED),
+        ("ta_timeseries", settings.TA_TIMESERIES_ENABLED),
+    ]:
+        try:
+            if setting and (
+                f"shared.django_apps.{app}" in settings.INSTALLED_APPS
+                or app in settings.INSTALLED_APPS
+            ):
+                logger.info(f"Running {app} migrations")
+                with connections[app].cursor() as cursor:
+                    cursor.execute(
+                        "SELECT _timescaledb_internal.stop_background_workers();"
+                    )
+                call_command(
+                    "migrate",
+                    database=app,
+                    app_label=app,
+                    settings=os.environ["DJANGO_SETTINGS_MODULE"],
+                    verbosity=1,
+                )
+                with connections[app].cursor() as cursor:
+                    cursor.execute(
+                        "SELECT _timescaledb_internal.start_background_workers();"
+                    )
+            else:
+                logger.info(f"Skipping {app} migrations")
+        except Exception as e:
+            logger.error(f"An error occurred: {e}")
+
+
+if __name__ == "__main__":
+    run_migrate_commands()

--- a/apps/worker/migrate_timeseries.py
+++ b/apps/worker/migrate_timeseries.py
@@ -7,8 +7,17 @@ from django.db import connections
 
 from shared.django_apps.utils.config import get_settings_module
 
+#################################################################
+# Keep in sync between apps/codecov-api/migrate_timeseries.py and
+# apps/worker/migrate_timeseries.py
+
+# Note: this is the only difference from the worker version
+parent_module = "django_scaffold"
+#################################################################
+
+
 # Setup Django environment
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", get_settings_module("django_scaffold"))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", get_settings_module(parent_module))
 django.setup()
 
 from django.conf import settings  # noqa: E402
@@ -17,29 +26,35 @@ logger = logging.getLogger(__name__)
 
 
 def run_migrate_commands():
-    try:
-        if settings.TA_TIMESERIES_ENABLED:
-            logger.info("Running ta_timeseries migrations")
-            with connections["ta_timeseries"].cursor() as cursor:
-                cursor.execute(
-                    "SELECT _timescaledb_internal.stop_background_workers();"
+    for app, setting in [
+        ("timeseries", settings.TIMESERIES_ENABLED),
+        ("ta_timeseries", settings.TA_TIMESERIES_ENABLED),
+    ]:
+        try:
+            if setting and (
+                f"shared.django_apps.{app}" in settings.INSTALLED_APPS
+                or app in settings.INSTALLED_APPS
+            ):
+                logger.info(f"Running {app} migrations")
+                with connections[app].cursor() as cursor:
+                    cursor.execute(
+                        "SELECT _timescaledb_internal.stop_background_workers();"
+                    )
+                call_command(
+                    "migrate",
+                    database=app,
+                    app_label=app,
+                    settings=os.environ["DJANGO_SETTINGS_MODULE"],
+                    verbosity=1,
                 )
-            call_command(
-                "migrate",
-                database="ta_timeseries",
-                app_label="ta_timeseries",
-                settings=get_settings_module("django_scaffold"),
-                verbosity=1,
-            )
-            with connections["ta_timeseries"].cursor() as cursor:
-                cursor.execute(
-                    "SELECT _timescaledb_internal.start_background_workers();"
-                )
-        else:
-            logger.info("Skipping ta_timeseries migrations")
-
-    except Exception as e:
-        logger.error(f"An error occurred: {e}")
+                with connections[app].cursor() as cursor:
+                    cursor.execute(
+                        "SELECT _timescaledb_internal.start_background_workers();"
+                    )
+            else:
+                logger.info(f"Skipping {app} migrations")
+        except Exception as e:
+            logger.error(f"An error occurred: {e}")
 
 
 if __name__ == "__main__":

--- a/tools/devenv/Makefile.devenv
+++ b/tools/devenv/Makefile.devenv
@@ -22,14 +22,14 @@ devenv.build: devenv.build.requirements devenv.build.api devenv.build.worker dev
 devenv.start.deps:
 	docker compose up minio redis postgres timescale mailhog --detach
 
-.PHONY: devenv.start.backend
-devenv.start.backend:
+.PHONY: devenv.start.apps
+devenv.start.apps:
 	# No-op if they have not already been started
 	docker compose down worker api
 	docker compose up worker api shared frontend gateway --detach
 
 .PHONY: devenv.start
-devenv.start: devenv.start.deps devenv.start.backend
+devenv.start: devenv.start.deps devenv.start.apps
 
 .PHONY: devenv
 devenv:
@@ -41,12 +41,13 @@ devenv:
 devenv.refresh:
 	$(MAKE) devenv.build
 	$(MAKE) devenv.migrate
-	$(MAKE) devenv.start.backend
+	$(MAKE) devenv.start.apps
 
 .PHONY: devenv.migrate
 devenv.migrate:
 	$(MAKE) devenv.start.deps
 	docker compose run --entrypoint python --rm api manage.py migrate
+	docker compose run --entrypoint python --rm api migrate_timeseries.py
 	docker compose run --entrypoint python --rm api manage.py pgpartition --yes
 	docker compose run --entrypoint python --rm worker manage.py migrate
 	docker compose run --entrypoint python --rm worker migrate_timeseries.py


### PR DESCRIPTION
* Adds the migrate scripts to both worker and API, and keep them in sync
* API runs timeseries migrations via the safer script (versus the unsafe migrate command)
* Rename devenv command for better correctness