### PR TITLE
chore(api): Remove old wrapper run scripts

### DIFF
--- a/apps/codecov-api/prod.sh
+++ b/apps/codecov-api/prod.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-bash api.sh

--- a/apps/codecov-api/staging.sh
+++ b/apps/codecov-api/staging.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-bash api.sh


### PR DESCRIPTION
Our Helm charts now directly target `api.sh` so the wrapper scripts are  no longer necessary.
