### PR TITLE
feat: use direct from Timescale TA GQL aggregates behind feature flag

### DIFF
--- a/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_test_results_timescale__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_test_results_timescale__0.json
@@ -1,0 +1,93 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "testResults": {
+          "totalCount": 5,
+          "edges": [
+            {
+              "cursor": "NC4wfG5hbWU0",
+              "node": {
+                "name": "name4",
+                "failureRate": 0.0,
+                "flakeRate": 0.0,
+                "avgDuration": 4.0,
+                "totalDuration": 4.0,
+                "totalFailCount": 0,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 1,
+                "totalSkipCount": 0,
+                "commitsFailed": 0,
+                "lastDuration": 4.0
+              }
+            },
+            {
+              "cursor": "My4wfG5hbWUz",
+              "node": {
+                "name": "name3",
+                "failureRate": 1.0,
+                "flakeRate": 0.0,
+                "avgDuration": 3.0,
+                "totalDuration": 3.0,
+                "totalFailCount": 1,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 0,
+                "totalSkipCount": 0,
+                "commitsFailed": 1,
+                "lastDuration": 3.0
+              }
+            },
+            {
+              "cursor": "Mi4wfG5hbWUy",
+              "node": {
+                "name": "name2",
+                "failureRate": 0.0,
+                "flakeRate": 0.0,
+                "avgDuration": 2.0,
+                "totalDuration": 2.0,
+                "totalFailCount": 0,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 1,
+                "totalSkipCount": 0,
+                "commitsFailed": 0,
+                "lastDuration": 2.0
+              }
+            },
+            {
+              "cursor": "MS4wfG5hbWUx",
+              "node": {
+                "name": "name1",
+                "failureRate": 1.0,
+                "flakeRate": 0.0,
+                "avgDuration": 1.0,
+                "totalDuration": 1.0,
+                "totalFailCount": 1,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 0,
+                "totalSkipCount": 0,
+                "commitsFailed": 1,
+                "lastDuration": 1.0
+              }
+            },
+            {
+              "cursor": "MC4wfG5hbWUw",
+              "node": {
+                "name": "name0",
+                "failureRate": 0.0,
+                "flakeRate": 0.0,
+                "avgDuration": 0.0,
+                "totalDuration": 0.0,
+                "totalFailCount": 0,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 1,
+                "totalSkipCount": 0,
+                "commitsFailed": 0,
+                "lastDuration": 0.0
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__gql_query_flake_aggregates_timescale__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__gql_query_flake_aggregates_timescale__0.json
@@ -1,0 +1,14 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "flakeAggregates": {
+          "flakeRate": 0.5,
+          "flakeCount": 1,
+          "flakeRatePercentChange": -0.5,
+          "flakeCountPercentChange": -0.6666666666666666
+        }
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__gql_query_test_results_aggregates_timescale__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__gql_query_test_results_aggregates_timescale__0.json
@@ -1,0 +1,20 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "testResultsAggregates": {
+          "totalDuration": 20.0,
+          "slowestTestsDuration": 10.0,
+          "totalFails": 1,
+          "totalSkips": 0,
+          "totalSlowTests": 1,
+          "totalDurationPercentChange": -0.42857142857142855,
+          "slowestTestsDurationPercentChange": -0.4444444444444444,
+          "totalFailsPercentChange": 0.0,
+          "totalSkipsPercentChange": -1.0,
+          "totalSlowTestsPercentChange": 0.0
+        }
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
@@ -19,6 +19,14 @@ def repository():
 
 
 @pytest.fixture
+def new_ta_enabled(mocker):
+    mocker.patch(
+        "graphql_api.types.test_analytics.test_analytics.READ_NEW_TA.check_value",
+        return_value=True,
+    )
+
+
+@pytest.fixture
 def populate_timescale_flake_aggregates(repository):
     # Create testruns with different flaky behavior patterns
     today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
@@ -77,6 +85,7 @@ def populate_timescale_flake_aggregates(repository):
         )
 
 
+@pytest.mark.usefixtures("new_ta_enabled")
 @pytest.mark.django_db(databases=["default", "ta_timeseries"], transaction=True)
 class TestFlakeAggregatesTimescale(GraphQLTestHelper):
     def test_gql_query_flake_aggregates(

--- a/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
@@ -94,3 +94,29 @@ class TestFlakeAggregatesTimescale(GraphQLTestHelper):
         assert result.flake_count == 1
         assert result.flake_rate_percent_change == -0.5
         assert result.flake_count_percent_change == -0.6666666666666666
+
+    def test_gql_query_flake_aggregates_timescale(
+        self, repository, populate_timescale_flake_aggregates, snapshot
+    ):
+        query = f"""
+            query {{
+                owner(username: "{repository.author.username}") {{
+                    repository(name: "{repository.name}") {{
+                        ... on Repository {{
+                            testAnalytics {{
+                                flakeAggregates {{
+                                    flakeRate
+                                    flakeCount
+                                    flakeRatePercentChange
+                                    flakeCountPercentChange
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        result = self.gql_request(query, owner=repository.author)
+
+        assert snapshot("json") == result

--- a/apps/codecov-api/graphql_api/tests/test_test_analytics.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_analytics.py
@@ -227,7 +227,11 @@ def repository_with_new_commit(db):
 def store_in_redis(repository_with_old_commit, mocker):
     """Store data in Redis and ensure old implementation is used"""
     # Mock the rollout to return False to ensure old implementation
-    mocker.patch("utils.test_results.READ_NEW_TA.check_value", return_value=False)
+    mocker.patch("utils.test_results.use_new_impl", return_value=False)
+    mocker.patch(
+        "graphql_api.types.test_analytics.test_analytics.READ_NEW_TA.check_value",
+        return_value=False,
+    )
 
     redis = get_redis_connection()
     redis.set(
@@ -246,7 +250,11 @@ def store_in_redis(repository_with_old_commit, mocker):
 def store_in_storage(repository_with_old_commit, mocker):
     """Store data in storage and ensure old implementation is used"""
     # Mock the rollout to return False to ensure old implementation
-    mocker.patch("utils.test_results.READ_NEW_TA.check_value", return_value=False)
+    mocker.patch("utils.test_results.use_new_impl", return_value=False)
+    mocker.patch(
+        "graphql_api.types.test_analytics.test_analytics.READ_NEW_TA.check_value",
+        return_value=False,
+    )
 
     storage = get_appropriate_storage_service()
 
@@ -273,7 +281,11 @@ def store_in_storage(repository_with_old_commit, mocker):
 def store_in_redis_with_duplicate_names(repository_with_old_commit, mocker):
     """Store duplicate names data in Redis and ensure old implementation is used"""
     # Mock the rollout to return False to ensure old implementation
-    mocker.patch("utils.test_results.READ_NEW_TA.check_value", return_value=False)
+    mocker.patch("utils.test_results.use_new_impl", return_value=False)
+    mocker.patch(
+        "graphql_api.types.test_analytics.test_analytics.READ_NEW_TA.check_value",
+        return_value=False,
+    )
 
     redis = get_redis_connection()
     redis.set(

--- a/apps/codecov-api/graphql_api/types/test_results/test_results.py
+++ b/apps/codecov-api/graphql_api/types/test_results/test_results.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any
 
 from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
@@ -9,60 +10,106 @@ test_result_bindable = ObjectType("TestResult")
 
 
 @test_result_bindable.field("name")
-def resolve_name(test: TestResultsRow, _: GraphQLResolveInfo) -> str:
+def resolve_name(test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo) -> str:
+    if isinstance(test, dict):
+        return test["computed_name"].replace("\x1f", " ")
     return test.name.replace("\x1f", " ")
 
 
 @test_result_bindable.field("updatedAt")
-def resolve_updated_at(test: TestResultsRow, _: GraphQLResolveInfo) -> datetime:
+def resolve_updated_at(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> datetime:
+    if isinstance(test, dict):
+        return test["updated_at"]
     return test.updated_at
 
 
 @test_result_bindable.field("commitsFailed")
-def resolve_commits_failed(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+def resolve_commits_failed(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> int:
+    if isinstance(test, dict):
+        return test["commits_where_fail"]
     return test.commits_where_fail
 
 
 @test_result_bindable.field("failureRate")
-def resolve_failure_rate(test: TestResultsRow, _: GraphQLResolveInfo) -> float:
+def resolve_failure_rate(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> float:
+    if isinstance(test, dict):
+        return test["failure_rate"]
     return test.failure_rate
 
 
 @test_result_bindable.field("flakeRate")
-def resolve_flake_rate(test: TestResultsRow, _: GraphQLResolveInfo) -> float:
+def resolve_flake_rate(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> float:
+    if isinstance(test, dict):
+        return test["flake_rate"]
     return test.flake_rate
 
 
 @test_result_bindable.field("avgDuration")
-def resolve_avg_duration(test: TestResultsRow, _: GraphQLResolveInfo) -> float:
+def resolve_avg_duration(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> float:
+    if isinstance(test, dict):
+        return test["avg_duration"]
     return test.avg_duration
 
 
 @test_result_bindable.field("totalDuration")
-def resolve_total_duration(test: TestResultsRow, _: GraphQLResolveInfo) -> float:
+def resolve_total_duration(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> float:
+    if isinstance(test, dict):
+        return test["total_duration"]
     return test.total_duration
 
 
 @test_result_bindable.field("lastDuration")
-def resolve_last_duration(test: TestResultsRow, _: GraphQLResolveInfo) -> float:
+def resolve_last_duration(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> float:
+    if isinstance(test, dict):
+        return test["last_duration"]
     return test.last_duration
 
 
 @test_result_bindable.field("totalFailCount")
-def resolve_total_fail_count(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+def resolve_total_fail_count(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> int:
+    if isinstance(test, dict):
+        return test["total_fail_count"]
     return test.total_fail_count
 
 
 @test_result_bindable.field("totalFlakyFailCount")
-def resolve_total_flaky_fail_count(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+def resolve_total_flaky_fail_count(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> int:
+    if isinstance(test, dict):
+        return test["total_flaky_fail_count"]
     return test.total_flaky_fail_count
 
 
 @test_result_bindable.field("totalSkipCount")
-def resolve_total_skip_count(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+def resolve_total_skip_count(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> int:
+    if isinstance(test, dict):
+        return test["total_skip_count"]
     return test.total_skip_count
 
 
 @test_result_bindable.field("totalPassCount")
-def resolve_total_pass_count(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+def resolve_total_pass_count(
+    test: TestResultsRow | dict[str, Any], _: GraphQLResolveInfo
+) -> int:
+    if isinstance(test, dict):
+        return test["total_pass_count"]
     return test.total_pass_count

--- a/apps/codecov-api/utils/test_results.py
+++ b/apps/codecov-api/utils/test_results.py
@@ -6,7 +6,6 @@ import polars as pl
 from django.conf import settings
 
 from core.models import Commit
-from rollouts import READ_NEW_TA
 from services.task import TaskService
 from shared.helpers.redis import get_redis_connection
 from shared.metrics import Summary
@@ -98,11 +97,9 @@ def _has_commits_before_cutoff(repoid: int) -> bool:
 def use_new_impl(repoid: int) -> bool:
     """
     Check if we should use the new implementation
-    Use new implementation if:
-    1. READ_NEW_TA rollout is enabled for this repo, OR
-    2. The repo has no commits before the cutoff date
+    Use new implementation if the repo has no commits before the cutoff date
     """
-    return READ_NEW_TA.check_value(repoid) or not _has_commits_before_cutoff(repoid)
+    return not _has_commits_before_cutoff(repoid)
 
 
 def get_results(
@@ -121,7 +118,6 @@ def get_results(
             cache to redis
     deserialize
     """
-
     if use_new_impl(repoid):
         func = new_get_results
         label = "new"


### PR DESCRIPTION
See https://github.com/codecov/umbrella/pull/311 for more context

Adding code here to use the new code that fetches TA data directly from
timescale rather than the cache files in GCS. I'm putting it behind the feature
flag because we want to start by rolling this out to ourselves only. We still
want newer users to use Timescale through the cache files though so that's why
I made the changes to `use_new_impl`.

There's also some changes with regards to
the start date and end date, this is for our own sake, since there was some
confusion about what range of days we're getting data for. This is a product
related decision, not a technical decision and has to do with the fact that the
"last day" interval should really mean the last 24 hours, but we don't support