### PR TITLE
feat: add new continuous aggregates to compute repo wide aggregates

### DIFF
--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0018_create_repo_summary_caggs.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0018_create_repo_summary_caggs.py
@@ -1,0 +1,132 @@
+from django.db import migrations
+
+from shared.django_apps.migration_utils import RiskyRunSQL
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("ta_timeseries", "0017_enable_real_time_aggregates"),
+    ]
+
+    operations = [
+        RiskyRunSQL(
+            """
+            CREATE MATERIALIZED VIEW ta_timeseries_aggregate_hourly
+            WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
+            SELECT
+                repo_id,
+                time_bucket(interval '1 hour', timestamp) as bucket_hourly,
+                
+                SUM(CASE WHEN duration_seconds IS NOT NULL THEN duration_seconds ELSE 0 END) as total_duration_seconds,
+                COUNT(*) FILTER (WHERE outcome = 'pass') AS pass_count,
+                COUNT(*) FILTER (WHERE outcome = 'failure') AS fail_count,
+                COUNT(*) FILTER (WHERE outcome = 'skip') AS skip_count,
+                COUNT(*) FILTER (WHERE outcome = 'flaky_fail') AS flaky_fail_count
+            FROM ta_timeseries_testrun
+            GROUP BY repo_id, bucket_hourly;
+            """,
+            reverse_sql="DROP MATERIALIZED VIEW ta_timeseries_aggregate_hourly;",
+        ),
+        RiskyRunSQL(
+            """
+            CREATE MATERIALIZED VIEW ta_timeseries_aggregate_daily
+            WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
+            SELECT
+                repo_id,
+                time_bucket(interval '1 day', bucket_hourly) as bucket_daily,
+                SUM(total_duration_seconds) as total_duration_seconds,
+                SUM(pass_count) AS pass_count,
+                SUM(fail_count) AS fail_count,
+                SUM(skip_count) AS skip_count,
+                SUM(flaky_fail_count) AS flaky_fail_count
+            FROM ta_timeseries_aggregate_hourly
+            GROUP BY repo_id, bucket_daily;
+            """,
+            reverse_sql="DROP MATERIALIZED VIEW ta_timeseries_aggregate_daily;",
+        ),
+        # Create hourly branch repo summary continuous aggregate
+        RiskyRunSQL(
+            """
+            CREATE MATERIALIZED VIEW ta_timeseries_branch_aggregate_hourly
+            WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
+            SELECT
+                repo_id,
+                branch,
+                time_bucket(interval '1 hour', timestamp) as bucket_hourly,
+                
+                SUM(CASE WHEN duration_seconds IS NOT NULL THEN duration_seconds ELSE 0 END) as total_duration_seconds,
+                COUNT(*) FILTER (WHERE outcome = 'pass') AS pass_count,
+                COUNT(*) FILTER (WHERE outcome = 'failure') AS fail_count,
+                COUNT(*) FILTER (WHERE outcome = 'skip') AS skip_count,
+                COUNT(*) FILTER (WHERE outcome = 'flaky_fail') AS flaky_fail_count
+            FROM ta_timeseries_testrun
+            WHERE branch IN ('main', 'master', 'develop')
+            GROUP BY repo_id, branch, bucket_hourly;
+            """,
+            reverse_sql="DROP MATERIALIZED VIEW ta_timeseries_branch_aggregate_hourly;",
+        ),
+        RiskyRunSQL(
+            """
+            CREATE MATERIALIZED VIEW ta_timeseries_branch_aggregate_daily
+            WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
+            SELECT
+                repo_id,
+                branch,
+                time_bucket(interval '1 day', bucket_hourly) as bucket_daily,
+                
+                SUM(total_duration_seconds) as total_duration_seconds,
+                SUM(pass_count) AS pass_count,
+                SUM(fail_count) AS fail_count,
+                SUM(skip_count) AS skip_count,
+                SUM(flaky_fail_count) AS flaky_fail_count
+            FROM ta_timeseries_branch_aggregate_hourly
+            GROUP BY repo_id, branch, bucket_daily;
+            """,
+            reverse_sql="DROP MATERIALIZED VIEW ta_timeseries_branch_aggregate_daily;",
+        ),
+        RiskyRunSQL(
+            """
+            SELECT add_continuous_aggregate_policy(
+                'ta_timeseries_aggregate_hourly',
+                start_offset => '2 hours',
+                end_offset => NULL,
+                schedule_interval => INTERVAL '1 hour'
+            );
+            """,
+            reverse_sql="SELECT remove_continuous_aggregate_policy('ta_timeseries_aggregate_hourly');",
+        ),
+        RiskyRunSQL(
+            """
+            SELECT add_continuous_aggregate_policy(
+                'ta_timeseries_aggregate_daily',
+                start_offset => '2 days',
+                end_offset => NULL,
+                schedule_interval => INTERVAL '1 day'
+            );
+            """,
+            reverse_sql="SELECT remove_continuous_aggregate_policy('ta_timeseries_aggregate_daily');",
+        ),
+        RiskyRunSQL(
+            """
+            SELECT add_continuous_aggregate_policy(
+                'ta_timeseries_branch_aggregate_hourly',
+                start_offset => '2 hours',
+                end_offset => NULL,
+                schedule_interval => INTERVAL '1 hour'
+            );
+            """,
+            reverse_sql="SELECT remove_continuous_aggregate_policy('ta_timeseries_branch_aggregate_hourly');",
+        ),
+        RiskyRunSQL(
+            """
+            SELECT add_continuous_aggregate_policy(
+                'ta_timeseries_branch_aggregate_daily',
+                start_offset => '2 days',
+                end_offset => NULL,
+                schedule_interval => INTERVAL '1 day'
+            );
+            """,
+            reverse_sql="SELECT remove_continuous_aggregate_policy('ta_timeseries_branch_aggregate_daily');",
+        ),
+    ]

--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0019_refresh_repo_summary_caggs.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0019_refresh_repo_summary_caggs.py
@@ -1,0 +1,53 @@
+from django.db import migrations
+
+from shared.django_apps.migration_utils import RiskyRunSQL
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("ta_timeseries", "0018_create_repo_summary_caggs"),
+    ]
+
+    operations = [
+        RiskyRunSQL(
+            """
+            CALL refresh_continuous_aggregate(
+                'ta_timeseries_aggregate_hourly',
+                NOW() - INTERVAL '60 days',
+                NULL
+            );
+            """,
+            reverse_sql="",
+        ),
+        RiskyRunSQL(
+            """
+            CALL refresh_continuous_aggregate(
+                'ta_timeseries_aggregate_daily',
+                NOW() - INTERVAL '60 days',
+                NULL
+            );
+            """,
+            reverse_sql="",
+        ),
+        RiskyRunSQL(
+            """
+            CALL refresh_continuous_aggregate(
+                'ta_timeseries_branch_aggregate_hourly',
+                NOW() - INTERVAL '60 days',
+                NOW()
+            );
+            """,
+            reverse_sql="-- No reverse operation needed for refresh",
+        ),
+        RiskyRunSQL(
+            """
+            CALL refresh_continuous_aggregate(
+                'ta_timeseries_branch_aggregate_daily',
+                NOW() - INTERVAL '60 days',
+                NOW()
+            );
+            """,
+            reverse_sql="-- No reverse operation needed for refresh",
+        ),
+    ]

--- a/libs/shared/shared/django_apps/ta_timeseries/models.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/models.py
@@ -154,3 +154,131 @@ class TestrunSummary(
         app_label = TA_TIMESERIES_APP_LABEL
         db_table = "ta_timeseries_testrun_summary_1day"
         managed = False
+
+
+class AggregateHourly(
+    ExportModelOperationsMixin("ta_timeseries.aggregate_hourly"),
+    models.Model,
+):
+    __test__ = False
+
+    bucket_hourly = models.DateTimeField(primary_key=True)
+    repo_id = models.IntegerField()
+
+    total_duration_seconds = models.FloatField()
+    pass_count = models.IntegerField()
+    fail_count = models.IntegerField()
+    skip_count = models.IntegerField()
+    flaky_fail_count = models.IntegerField()
+
+    __repr__ = sane_repr(
+        "bucket_hourly",
+        "repo_id",
+        "total_duration_seconds",
+        "pass_count",
+        "fail_count",
+        "skip_count",
+        "flaky_fail_count",
+    )  # type: ignore
+
+    class Meta:
+        app_label = TA_TIMESERIES_APP_LABEL
+        db_table = "ta_timeseries_aggregate_hourly"
+        managed = False
+
+
+class AggregateDaily(
+    ExportModelOperationsMixin("ta_timeseries.aggregate_daily"),
+    models.Model,
+):
+    __test__ = False
+
+    bucket_daily = models.DateTimeField(primary_key=True)
+    repo_id = models.IntegerField()
+
+    total_duration_seconds = models.FloatField()
+    pass_count = models.IntegerField()
+    fail_count = models.IntegerField()
+    skip_count = models.IntegerField()
+    flaky_fail_count = models.IntegerField()
+
+    __repr__ = sane_repr(
+        "bucket_daily",
+        "repo_id",
+        "total_duration_seconds",
+        "pass_count",
+        "fail_count",
+        "skip_count",
+        "flaky_fail_count",
+    )  # type: ignore
+
+    class Meta:
+        app_label = TA_TIMESERIES_APP_LABEL
+        db_table = "ta_timeseries_aggregate_daily"
+        managed = False
+
+
+class BranchAggregateHourly(
+    ExportModelOperationsMixin("ta_timeseries.branch_aggregate_hourly"),
+    models.Model,
+):
+    __test__ = False
+
+    bucket_hourly = models.DateTimeField(primary_key=True)
+    repo_id = models.IntegerField()
+    branch = models.TextField()
+
+    total_duration_seconds = models.FloatField()
+    pass_count = models.IntegerField()
+    fail_count = models.IntegerField()
+    skip_count = models.IntegerField()
+    flaky_fail_count = models.IntegerField()
+
+    __repr__ = sane_repr(
+        "bucket_hourly",
+        "repo_id",
+        "branch",
+        "total_duration_seconds",
+        "pass_count",
+        "fail_count",
+        "skip_count",
+        "flaky_fail_count",
+    )  # type: ignore
+
+    class Meta:
+        app_label = TA_TIMESERIES_APP_LABEL
+        db_table = "ta_timeseries_branch_aggregate_hourly"
+        managed = False
+
+
+class BranchAggregateDaily(
+    ExportModelOperationsMixin("ta_timeseries.branch_aggregate_daily"),
+    models.Model,
+):
+    __test__ = False
+
+    bucket_daily = models.DateTimeField(primary_key=True)
+    repo_id = models.IntegerField()
+    branch = models.TextField()
+
+    total_duration_seconds = models.FloatField()
+    pass_count = models.IntegerField()
+    fail_count = models.IntegerField()
+    skip_count = models.IntegerField()
+    flaky_fail_count = models.IntegerField()
+
+    __repr__ = sane_repr(
+        "bucket_daily",
+        "repo_id",
+        "branch",
+        "total_duration_seconds",
+        "pass_count",
+        "fail_count",
+        "skip_count",
+        "flaky_fail_count",
+    )  # type: ignore
+
+    class Meta:
+        app_label = TA_TIMESERIES_APP_LABEL
+        db_table = "ta_timeseries_branch_aggregate_daily"
+        managed = False


### PR DESCRIPTION
Fixes CCMRG-1376

The 2 PRs below have more context
https://github.com/codecov/umbrella/pull/311
https://github.com/codecov/umbrella/pull/317

With this change we're trying to avoid recomputing the repo-wide top of the page
aggregates. By using continuous aggregates here we can reduce the number of rows
we have to read to finalize the computation of the aggregates by a factor of the
number of tests in the repo, of course at the cost of some more intermediate
storage and asynchronous compute. By doing this we'll reduce the load we're
putting on the database every time a user goes to the dashboard.

We're choosing to use hierarchical continuous aggregates:
https://docs.tigerdata.com/use-timescale/latest/continuous-aggregates/hierarchical-continuous-aggregates/

This is so materializing the daily aggregates is not as expensive, by breaking
down the computation into hourly chunks first, then materializing the daily
aggregates from the hourly aggregates. The goal is to not spend too much time
materializing the daily aggregates. We can gradually do work over the course of
the day to make that faster.