### PR TITLE
feat: use new repo wide CAs in GQL API

### DIFF
--- a/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
@@ -83,6 +83,14 @@ def populate_timescale_flake_aggregates(repository):
             "CALL refresh_continuous_aggregate('ta_timeseries_testrun_branch_summary_1day', %s, %s)",
             [min_timestamp, max_timestamp],
         )
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_branch_aggregate_hourly', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_branch_aggregate_daily', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
 
 
 @pytest.mark.usefixtures("new_ta_enabled")

--- a/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
@@ -83,6 +83,14 @@ def populate_timescale_test_results_aggregates(repository):
             "CALL refresh_continuous_aggregate('ta_timeseries_testrun_branch_summary_1day', %s, %s)",
             [min_timestamp, max_timestamp],
         )
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_branch_aggregate_hourly', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_branch_aggregate_daily', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
 
 
 @pytest.mark.usefixtures("new_ta_enabled")


### PR DESCRIPTION
Fixes CCMRG-1377

Depends on:
https://github.com/codecov/umbrella/pull/335

see:
https://github.com/codecov/umbrella/pull/311
https://github.com/codecov/umbrella/pull/317
https://github.com/codecov/umbrella/pull/319

we're going to use the repo wide CAs to populate some of the data here. We can't
use them for all of the data we want to return in the API so we'll have to fall
back to the testrun branch summaries for those ones: flake_count and
unique_test_count which is subsequently used in the calculation of slow tests
duration.

the continuous aggregates only rollup raw testrun data at a branch level
granularity for certain branches. For branches that aren't being rolled up we
can't fetch the data from CAs, instead we have to aggrgate directly from the
testrun hypertable.

We don't have to compute test results aggregates or flake aggregates for
non-precomputed yet, as that adds too much complexity for now, and we'll
probably test out a new CA where we compute rollups for all branches before we
build that.