### PR TITLE
chore: Allow `None` inputs for `BreadcrumbData`

### DIFF
--- a/libs/shared/shared/django_apps/upload_breadcrumbs/models.py
+++ b/libs/shared/shared/django_apps/upload_breadcrumbs/models.py
@@ -80,7 +80,8 @@ class BreadcrumbData(
     Represents the data structure for the `breadcrumb_data` field which contains
     information about the milestone, endpoint, error, and error text.
 
-    Each field is optional and cannot be set to `None` or an empty string.
+    Each field is optional and cannot be set to an empty string. Note that any
+    field not set or set to `None` will be excluded from the model dump.
     Additionally, if `error_text` is provided, `error` must also be provided.
 
     :param milestone: The milestone of the upload process.
@@ -92,7 +93,8 @@ class BreadcrumbData(
     :param error_text: Additional text describing the error.
     :type error_text: str, optional
 
-    :raises ValidationError: If any field is explicitly set to None or empty.
+    :raises ValidationError: If no non-empty fields are provided.
+    :raises ValidationError: If any field is explicitly set to an empty string.
     :raises ValidationError: If `error_text` is provided without an `error`.
     :raises ValidationError: If `error` is set to UNKNOWN without an `error_text`.
     """
@@ -105,8 +107,8 @@ class BreadcrumbData(
     @field_validator("*", mode="after")
     @classmethod
     def validate_initialized(cls, value):
-        if value is None or value == "":
-            raise ValueError("field must not be None or empty.")
+        if value == "":
+            raise ValueError("field must not be empty.")
         return value
 
     @model_validator(mode="after")

--- a/libs/shared/shared/django_apps/upload_breadcrumbs/tests/test_models.py
+++ b/libs/shared/shared/django_apps/upload_breadcrumbs/tests/test_models.py
@@ -31,6 +31,7 @@ class TestBreadcrumbData:
     def test_valid_some_fields(self):
         data = BreadcrumbData(
             milestone=Milestones.FETCHING_COMMIT_DETAILS,
+            error=None,
         )
         assert data.milestone == Milestones.FETCHING_COMMIT_DETAILS
         assert data.endpoint is None
@@ -49,7 +50,7 @@ class TestBreadcrumbData:
                 {
                     "milestone": None,
                 },
-                "field must not be None or empty.",
+                "at least one field must be provided.",
             ),
             (
                 {
@@ -60,37 +61,16 @@ class TestBreadcrumbData:
             ),
             (
                 {
-                    "milestone": Milestones.UPLOAD_COMPLETE,
-                    "endpoint": None,
-                },
-                "field must not be None or empty.",
-            ),
-            (
-                {
-                    "milestone": Milestones.PREPARING_FOR_REPORT,
-                    "endpoint": Endpoints.CREATE_REPORT,
-                    "error": None,
-                },
-                "field must not be None or empty.",
-            ),
-            (
-                {
-                    "error": Errors.UNRECOGNIZED_FORMAT,
-                    "error_text": None,
-                },
-                "field must not be None or empty.",
-            ),
-            (
-                {
                     "error": Errors.MISSING_TOKEN,
                     "error_text": "",
                 },
-                "field must not be None or empty.",
+                "field must not be empty.",
             ),
             (
                 {
                     "milestone": Milestones.FETCHING_COMMIT_DETAILS,
                     "endpoint": Endpoints.CREATE_COMMIT,
+                    "error": None,
                     "error_text": "Error text without an error",
                 },
                 "'error_text' is provided, but 'error' is missing.",
@@ -138,6 +118,7 @@ class TestBreadcrumbData:
     def test_some_fields_dump(self):
         data = BreadcrumbData(
             milestone=Milestones.FETCHING_COMMIT_DETAILS,
+            endpoint=None,
         )
         dumped_data = data.model_dump()
         expected_data = {


### PR DESCRIPTION
Simplifies class usages elsewhere without changing the data that is  saved to the database.
