### PR TITLE
fix: get_test_results_queryset expects str for the parameter

### DIFF
--- a/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
+++ b/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
@@ -348,7 +348,7 @@ async def resolve_test_results(
             start_date=start_date,
             end_date=end_date,
             branch=filters.get("branch") if filters else repository.branch,  # type: ignore
-            parameter=filters.get("parameter") if filters else None,  # type: ignore
+            parameter=filters.get("parameter").value if filters else None,  # type: ignore
             testsuites=filters.get("test_suites") if filters else None,
             flags=filters.get("flags") if filters else None,
             term=filters.get("term") if filters else None,


### PR DESCRIPTION
i made this change to avoid some circular imports during testing where the timescale_test_results module wouldn't have to import any GQL types but i forgot to make the matching change in the code that calls get_test_results_queryset so this fixes the parameters being applied
