### PR TITLE
chore: Centralize all Celery task names

### DIFF
--- a/apps/codecov-api/services/task/task.py
+++ b/apps/codecov-api/services/task/task.py
@@ -95,7 +95,7 @@ class TaskService:
 
     def status_set_pending(self, repoid, commitid, branch, on_a_pull_request):
         self._create_signature(
-            "app.tasks.status.SetPending",
+            celery_config.status_set_pending_task_name,
             kwargs={
                 "repoid": repoid,
                 "commitid": commitid,
@@ -115,7 +115,7 @@ class TaskService:
         immutable=False,
     ):
         return self._create_signature(
-            "app.tasks.upload.Upload",
+            celery_config.upload_task_name,
             kwargs={
                 "repoid": repoid,
                 "commitid": commitid,
@@ -148,7 +148,7 @@ class TaskService:
 
     def notify_signature(self, repoid, commitid, current_yaml=None, empty_upload=None):
         return self._create_signature(
-            "app.tasks.notify.Notify",
+            celery_config.notify_task_name,
             kwargs={
                 "repoid": repoid,
                 "commitid": commitid,
@@ -164,7 +164,7 @@ class TaskService:
 
     def pulls_sync(self, repoid, pullid):
         self._create_signature(
-            "app.tasks.pulls.Sync", kwargs={"repoid": repoid, "pullid": pullid}
+            celery_config.pulls_task_name, kwargs={"repoid": repoid, "pullid": pullid}
         ).apply_async()
 
     def refresh(
@@ -187,7 +187,7 @@ class TaskService:
         if sync_teams:
             chain_to_call.append(
                 self._create_signature(
-                    "app.tasks.sync_teams.SyncTeams",
+                    celery_config.sync_teams_task_name,
                     kwargs={
                         "ownerid": ownerid,
                         "username": username,
@@ -199,7 +199,7 @@ class TaskService:
         if sync_repos:
             chain_to_call.append(
                 self._create_signature(
-                    "app.tasks.sync_repos.SyncRepos",
+                    celery_config.sync_repos_task_name,
                     kwargs={
                         "ownerid": ownerid,
                         "username": username,
@@ -221,7 +221,7 @@ class TaskService:
     def delete_owner(self, ownerid):
         log.info(f"Triggering delete_owner task for owner: {ownerid}")
         self._create_signature(
-            "app.tasks.delete_owner.DeleteOwner", kwargs={"ownerid": ownerid}
+            celery_config.delete_owner_task_name, kwargs={"ownerid": ownerid}
         ).apply_async()
 
     def backfill_repo(
@@ -229,7 +229,7 @@ class TaskService:
         repository: Repository,
         start_date: datetime,
         end_date: datetime,
-        dataset_names: Iterable[str] = None,
+        dataset_names: Iterable[str] | None = None,
     ):
         log.info(
             "Triggering timeseries backfill tasks for repo",
@@ -290,7 +290,7 @@ class TaskService:
         )
 
         self._create_signature(
-            "app.tasks.timeseries.backfill_dataset",
+            celery_config.timeseries_backfill_dataset_task_name,
             kwargs={
                 "dataset_id": dataset.pk,
                 "start_date": start_date.isoformat(),
@@ -300,19 +300,19 @@ class TaskService:
 
     def transplant_report(self, repo_id: int, from_sha: str, to_sha: str) -> None:
         self._create_signature(
-            "app.tasks.reports.transplant_report",
+            celery_config.transplant_report_task_name,
             kwargs={"repo_id": repo_id, "from_sha": from_sha, "to_sha": to_sha},
         ).apply_async()
 
     def update_commit(self, commitid, repoid):
         self._create_signature(
-            "app.tasks.commit_update.CommitUpdate",
+            celery_config.commit_update_task_name,
             kwargs={"commitid": commitid, "repoid": repoid},
         ).apply_async()
 
     def http_request(self, url, method="POST", headers=None, data=None, timeout=None):
         self._create_signature(
-            "app.tasks.http_request.HTTPRequest",
+            celery_config.http_request_task_name,
             kwargs={
                 "url": url,
                 "method": method,
@@ -324,13 +324,13 @@ class TaskService:
 
     def flush_repo(self, repository_id: int):
         self._create_signature(
-            "app.tasks.flush_repo.FlushRepo",
+            celery_config.flush_repo_task_name,
             kwargs={"repoid": repository_id},
         ).apply_async()
 
     def manual_upload_completion_trigger(self, repoid, commitid, current_yaml=None):
         self._create_signature(
-            "app.tasks.upload.ManualUploadCompletionTrigger",
+            celery_config.manual_upload_completion_trigger_task_name,
             kwargs={
                 "commitid": commitid,
                 "repoid": repoid,
@@ -340,7 +340,7 @@ class TaskService:
 
     def preprocess_upload(self, repoid, commitid):
         self._create_signature(
-            "app.tasks.upload.PreProcessUpload",
+            celery_config.pre_process_upload_task_name,
             kwargs={"repoid": repoid, "commitid": commitid},
         ).apply_async()
 
@@ -354,7 +354,7 @@ class TaskService:
     ):
         # Templates can be found in worker/templates
         self._create_signature(
-            "app.tasks.send_email.SendEmail",
+            celery_config.send_email_task_name,
             kwargs=dict(
                 to_addr=to_addr,
                 subject=subject,

--- a/apps/worker/tasks/ai_pr_review.py
+++ b/apps/worker/tasks/ai_pr_review.py
@@ -8,12 +8,13 @@ from app import celery_app
 from database.models import Repository
 from helpers.exceptions import RepositoryWithoutValidBotError
 from services.ai_pr_review import perform_review
+from shared.celery_config import ai_pr_review_task_name
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
 
 
-class AiPrReviewTask(BaseCodecovTask, name="app.tasks.ai_pr_review.AiPrReview"):
+class AiPrReviewTask(BaseCodecovTask, name=ai_pr_review_task_name):
     throws = (SoftTimeLimitExceeded,)
 
     def run_impl(

--- a/apps/worker/tasks/bundle_analysis_notify.py
+++ b/apps/worker/tasks/bundle_analysis_notify.py
@@ -10,12 +10,11 @@ from helpers.github_installation import get_installation_name_for_owner_for_task
 from services.bundle_analysis.notify import BundleAnalysisNotifyService
 from services.bundle_analysis.notify.types import NotificationSuccess
 from services.lock_manager import LockManager, LockRetry, LockType
+from shared.celery_config import bundle_analysis_notify_task_name
 from shared.yaml import UserYaml
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
-
-bundle_analysis_notify_task_name = "app.tasks.bundle_analysis.BundleAnalysisNotify"
 
 
 class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task_name):

--- a/apps/worker/tasks/bundle_analysis_processor.py
+++ b/apps/worker/tasks/bundle_analysis_processor.py
@@ -12,6 +12,7 @@ from services.bundle_analysis.report import (
 )
 from services.lock_manager import LockManager, LockRetry, LockType
 from services.processing.types import UploadArguments
+from shared.celery_config import bundle_analysis_processor_task_name
 from shared.reports.enums import UploadState
 from shared.yaml import UserYaml
 from tasks.base import BaseCodecovTask
@@ -20,10 +21,6 @@ from tasks.bundle_analysis_save_measurements import (
 )
 
 log = logging.getLogger(__name__)
-
-bundle_analysis_processor_task_name = (
-    "app.tasks.bundle_analysis.BundleAnalysisProcessor"
-)
 
 
 class BundleAnalysisProcessorTask(

--- a/apps/worker/tasks/bundle_analysis_save_measurements.py
+++ b/apps/worker/tasks/bundle_analysis_save_measurements.py
@@ -9,14 +9,11 @@ from services.bundle_analysis.report import (
     BundleAnalysisReportService,
     ProcessingResult,
 )
+from shared.celery_config import bundle_analysis_save_measurements_task_name
 from shared.yaml import UserYaml
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
-
-bundle_analysis_save_measurements_task_name = (
-    "app.tasks.bundle_analysis.BundleAnalysisSaveMeasurements"
-)
 
 
 class BundleAnalysisSaveMeasurementsTask(

--- a/apps/worker/tasks/compute_component_comparison.py
+++ b/apps/worker/tasks/compute_component_comparison.py
@@ -10,16 +10,12 @@ from services.comparison import ComparisonProxy, FilteredComparison
 from services.comparison_utils import get_comparison_proxy
 from services.report import ReportService
 from services.yaml import get_current_yaml, get_repo_yaml
+from shared.celery_config import compute_component_comparison_task_name
 from shared.components import Component
-from shared.utils.enums import TaskConfigGroup
 from shared.yaml import UserYaml
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
-
-task_name = (
-    f"app.tasks.{TaskConfigGroup.compute_comparison.value}.ComputeComponentComparison"
-)
 
 
 def compute_component_comparison(
@@ -64,7 +60,9 @@ def compute_component_comparison(
     db_session.flush()
 
 
-class ComputeComponentComparisonTask(BaseCodecovTask, name=task_name):
+class ComputeComponentComparisonTask(
+    BaseCodecovTask, name=compute_component_comparison_task_name
+):
     def run_impl(
         self,
         db_session: Session,

--- a/apps/worker/tasks/flush_repo.py
+++ b/apps/worker/tasks/flush_repo.py
@@ -5,12 +5,13 @@ from celery.exceptions import SoftTimeLimitExceeded
 from app import celery_app
 from services.cleanup.repository import cleanup_repo
 from services.cleanup.utils import CleanupSummary
+from shared.celery_config import flush_repo_task_name
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
 
 
-class FlushRepoTask(BaseCodecovTask, name="app.tasks.flush_repo.FlushRepo"):
+class FlushRepoTask(BaseCodecovTask, name=flush_repo_task_name):
     acks_late = True  # retry the task when the worker dies for whatever reason
     max_retries = None  # aka, no limit on retries
 

--- a/apps/worker/tasks/http_request.py
+++ b/apps/worker/tasks/http_request.py
@@ -3,13 +3,14 @@ import logging
 import httpx
 
 from app import celery_app
+from shared.celery_config import http_request_task_name
 from shared.config import get_config
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
 
 
-class HTTPRequestTask(BaseCodecovTask, name="app.tasks.http_request.HTTPRequest"):
+class HTTPRequestTask(BaseCodecovTask, name=http_request_task_name):
     """
     Task for making generic HTTP requests.
     """

--- a/apps/worker/tasks/preprocess_upload.py
+++ b/apps/worker/tasks/preprocess_upload.py
@@ -14,6 +14,7 @@ from services.repository import (
     get_repo_provider_service,
     possibly_update_commit_from_provider_info,
 )
+from shared.celery_config import pre_process_upload_task_name
 from shared.helpers.redis import get_redis_connection
 from shared.torngit.base import TorngitBaseAdapter
 from tasks.base import BaseCodecovTask
@@ -21,7 +22,7 @@ from tasks.base import BaseCodecovTask
 log = logging.getLogger(__name__)
 
 
-class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"):
+class PreProcessUpload(BaseCodecovTask, name=pre_process_upload_task_name):
     """
     The main goal for this task is to carry forward flags from previous uploads
     and save the new carry-forwarded upload in the db, as a pre-step for

--- a/apps/worker/tasks/sync_pull.py
+++ b/apps/worker/tasks/sync_pull.py
@@ -26,7 +26,11 @@ from services.repository import (
 )
 from services.test_results import should_do_flaky_detection
 from services.yaml.reader import read_yaml_field
-from shared.celery_config import notify_task_name, pulls_task_name
+from shared.celery_config import (
+    ai_pr_review_task_name,
+    notify_task_name,
+    pulls_task_name,
+)
 from shared.helpers.redis import get_redis_connection
 from shared.metrics import Counter, inc_counter
 from shared.reports.types import Change
@@ -573,7 +577,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                         "pull_labels": pull_labels,
                     },
                 )
-                self.app.tasks["app.tasks.ai_pr_review.AiPrReview"].apply_async(
+                self.app.tasks[ai_pr_review_task_name].apply_async(
                     kwargs={"repoid": pull.repoid, "pullid": pull.pullid}
                 )
 

--- a/apps/worker/tasks/test_results_finisher.py
+++ b/apps/worker/tasks/test_results_finisher.py
@@ -42,6 +42,7 @@ from services.test_results import (
     latest_failures_for_commit,
     should_do_flaky_detection,
 )
+from shared.celery_config import test_results_finisher_task_name
 from shared.helpers.redis import get_redis_connection
 from shared.reports.types import UploadType
 from shared.typings.torngit import AdditionalData
@@ -52,8 +53,6 @@ from tasks.notify import notify_task_name
 from tasks.process_flakes import NEW_KEY, process_flakes_task_name
 
 log = logging.getLogger(__name__)
-
-test_results_finisher_task_name = "app.tasks.test_results.TestResultsFinisherTask"
 
 ESCAPE_FAILURE_MESSAGE_DEFN = [
     Replacement(["\r"], "", EscapeEnum.REPLACE),

--- a/apps/worker/tasks/transplant_report.py
+++ b/apps/worker/tasks/transplant_report.py
@@ -1,9 +1,10 @@
 from app import celery_app
 from services.report.transplant import transplant_commit_report
+from shared.celery_config import transplant_report_task_name
 from tasks.base import BaseCodecovTask
 
 
-class TransplantReportTask(BaseCodecovTask, name="app.tasks.reports.transplant_report"):
+class TransplantReportTask(BaseCodecovTask, name=transplant_report_task_name):
     def run_impl(self, db_session, repo_id: int, from_sha: str, to_sha: str):
         transplant_commit_report(repo_id, from_sha, to_sha)
 

--- a/apps/worker/tasks/upsert_component.py
+++ b/apps/worker/tasks/upsert_component.py
@@ -7,16 +7,14 @@ from database.models import Commit
 from services.report import ReportService
 from services.timeseries import ComponentForMeasurement, upsert_components_measurements
 from services.yaml import get_repo_yaml
+from shared.celery_config import timeseries_upsert_component_task_name
 from shared.reports.readonly import ReadOnlyReport
-from shared.utils.enums import TaskConfigGroup
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
 
-task_name = f"app.tasks.{TaskConfigGroup.timeseries.value}.UpsertComponentTask"
 
-
-class UpsertComponentTask(BaseCodecovTask, name=task_name):
+class UpsertComponentTask(BaseCodecovTask, name=timeseries_upsert_component_task_name):
     def run_impl(
         self,
         db_session: Session,

--- a/libs/shared/shared/celery_config.py
+++ b/libs/shared/shared/celery_config.py
@@ -8,6 +8,26 @@ from shared.utils.enums import TaskConfigGroup
 # <type> can be "tasks" or "cron"
 # <config_group> is the task's TaskConfigGroup
 # <identifier> is the task name (usually same as task class)
+
+# Miscellaneous tasks
+http_request_task_name = f"app.tasks.{TaskConfigGroup.http_request.value}.HTTPRequest"
+ai_pr_review_task_name = f"app.tasks.{TaskConfigGroup.ai_pr_review.value}.AiPrReview"
+transplant_report_task_name = (
+    f"app.tasks.{TaskConfigGroup.reports.value}.transplant_report"
+)
+
+# Bundle analysis tasks
+bundle_analysis_notify_task_name = (
+    f"app.tasks.{TaskConfigGroup.bundle_analysis.value}.BundleAnalysisNotify"
+)
+bundle_analysis_processor_task_name = (
+    f"app.tasks.{TaskConfigGroup.bundle_analysis.value}.BundleAnalysisProcessor"
+)
+bundle_analysis_save_measurements_task_name = (
+    f"app.tasks.{TaskConfigGroup.bundle_analysis.value}.BundleAnalysisSaveMeasurements"
+)
+
+# Sync tasks
 sync_teams_task_name = f"app.tasks.{TaskConfigGroup.sync_teams.value}.SyncTeams"
 sync_repos_task_name = f"app.tasks.{TaskConfigGroup.sync_repos.value}.SyncRepos"
 sync_repo_languages_task_name = (
@@ -16,6 +36,7 @@ sync_repo_languages_task_name = (
 sync_repo_languages_gql_task_name = (
     f"app.tasks.{TaskConfigGroup.sync_repo_languages_gql.value}.SyncLanguagesGQL"
 )
+
 delete_owner_task_name = f"app.tasks.{TaskConfigGroup.delete_owner.value}.DeleteOwner"
 activate_account_user_task_name = (
     f"app.tasks.{TaskConfigGroup.sync_account.value}.ActivateAccountUser"
@@ -38,6 +59,8 @@ upload_finisher_task_name = f"app.tasks.{TaskConfigGroup.upload.value}.UploadFin
 parallel_verification_task_name = (
     f"app.tasks.{TaskConfigGroup.upload.value}.ParallelVerification"
 )
+
+# Test results tasks
 test_results_processor_task_name = (
     f"app.tasks.{TaskConfigGroup.test_results.value}.TestResultsProcessor"
 )
@@ -50,6 +73,7 @@ sync_test_results_task_name = (
     f"app.tasks.{TaskConfigGroup.test_results.value}.SyncTestResultsTask"
 )
 
+# Cache rollup tasks
 cache_test_rollups_task_name = (
     f"app.tasks.{TaskConfigGroup.cache_rollup.value}.CacheTestRollupsTask"
 )
@@ -70,13 +94,20 @@ send_email_task_name = f"app.tasks.{TaskConfigGroup.send_email.value}.SendEmail"
 new_user_activated_task_name = (
     f"app.tasks.{TaskConfigGroup.new_user_activated.value}.NewUserActivated"
 )
+
+# Compute comparison tasks
 compute_comparison_task_name = (
     f"app.tasks.{TaskConfigGroup.compute_comparison.value}.ComputeComparison"
 )
+compute_component_comparison_task_name = (
+    f"app.tasks.{TaskConfigGroup.compute_comparison.value}.ComputeComponentComparison"
+)
+
 commit_update_task_name = (
     f"app.tasks.{TaskConfigGroup.commit_update.value}.CommitUpdate"
 )
 
+# Profiling tasks
 profiling_finding_task_name = (
     f"app.cron.{TaskConfigGroup.profiling.value}.findinguncollected"
 )
@@ -101,6 +132,9 @@ timeseries_backfill_commits_task_name = (
 timeseries_delete_task_name = f"app.tasks.{TaskConfigGroup.timeseries.value}.delete"
 timeseries_save_commit_measurements_task_name = (
     f"app.tasks.{TaskConfigGroup.timeseries.value}.save_commit_measurements"
+)
+timeseries_upsert_component_task_name = (
+    f"app.tasks.{TaskConfigGroup.timeseries.value}.UpsertComponentTask"
 )
 
 health_check_task_name = f"app.cron.{TaskConfigGroup.healthcheck.value}.HealthCheckTask"

--- a/libs/shared/shared/utils/enums.py
+++ b/libs/shared/shared/utils/enums.py
@@ -20,7 +20,9 @@ class TaskConfigGroup(Enum):
     Marks the config key in the install yaml that affects a given task.
     """
 
+    ai_pr_review = "ai_pr_review"
     archive = "archive"
+    bundle_analysis = "bundle_analysis"
     cache_rollup = "cache_rollup"
     comment = "comment"
     commit_update = "commit_update"
@@ -30,10 +32,12 @@ class TaskConfigGroup(Enum):
     flakes = "flakes"
     flush_repo = "flush_repo"
     healthcheck = "healthcheck"
+    http_request = "http_request"
     new_user_activated = "new_user_activated"
     notify = "notify"
     profiling = "profiling"
     pulls = "pulls"
+    reports = "reports"
     send_email = "send_email"
     status = "status"
     sync_account = "sync_account"


### PR DESCRIPTION
Moves all Celery task names into `shared` to deduplicate manually defining the names in multiple places