### PR TITLE
db: remove default continuous aggregate indexes and create new ones

### DIFF
--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0022_remove_default_cagg_indexes.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0022_remove_default_cagg_indexes.py
@@ -1,0 +1,151 @@
+from django.db import migrations
+
+from shared.django_apps.migration_utils import RiskyRunSQL
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("ta_timeseries", "0021_testrun_ta_ts__repo_timestamp_idx_and_more"),
+    ]
+
+    operations = [
+        RiskyRunSQL(
+            """
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_aggregate_hourly';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_repo_id_bucket_hourly_idx');
+                END IF;
+            END $$;
+            """,
+            reverse_sql="""
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_aggregate_hourly';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_repo_id_bucket_hourly_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (repo_id, bucket_hourly)';
+                END IF;
+            END $$;
+            """,
+        ),
+        RiskyRunSQL(
+            """
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_aggregate_daily';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_repo_id_bucket_daily_idx');
+                END IF;
+            END $$;
+            """,
+            reverse_sql="""
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_aggregate_daily';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_repo_id_bucket_daily_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (repo_id, bucket_daily)';
+                END IF;
+            END $$;
+            """,
+        ),
+        RiskyRunSQL(
+            """
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_branch_aggregate_hourly';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_repo_id_bucket_hourly_idx');
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_branch_bucket_hourly_idx');
+                END IF;
+            END $$;
+            """,
+            reverse_sql="""
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_branch_aggregate_hourly';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_repo_id_bucket_hourly_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (repo_id, bucket_hourly)';
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_branch_bucket_hourly_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (branch, bucket_hourly)';
+                END IF;
+            END $$;
+            """,
+        ),
+        RiskyRunSQL(
+            """
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_branch_aggregate_daily';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_repo_id_bucket_daily_idx');
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_branch_bucket_daily_idx');
+                END IF;
+            END $$;
+            """,
+            reverse_sql="""
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_branch_aggregate_daily';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_repo_id_bucket_daily_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (repo_id, bucket_daily)';
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_branch_bucket_daily_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (branch, bucket_daily)';
+                END IF;
+            END $$;
+            """,
+        ),
+    ]

--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0023_create_cagg_indexes.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0023_create_cagg_indexes.py
@@ -1,0 +1,41 @@
+from django.db import migrations
+
+from shared.django_apps.migration_utils import RiskyRunSQL
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("ta_timeseries", "0022_remove_default_cagg_indexes"),
+    ]
+
+    operations = [
+        RiskyRunSQL(
+            """
+            CREATE INDEX IF NOT EXISTS ta_ts_agg_hourly_repo_bucket_idx
+            ON ta_timeseries_aggregate_hourly (repo_id, bucket_hourly DESC);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS ta_ts_agg_hourly_repo_bucket_idx;",
+        ),
+        RiskyRunSQL(
+            """
+            CREATE INDEX IF NOT EXISTS ta_ts_agg_daily_repo_bucket_idx
+            ON ta_timeseries_aggregate_daily (repo_id, bucket_daily DESC);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS ta_ts_agg_daily_repo_bucket_idx;",
+        ),
+        RiskyRunSQL(
+            """
+            CREATE INDEX IF NOT EXISTS ta_ts_branch_agg_hourly_repo_branch_bucket_idx
+            ON ta_timeseries_branch_aggregate_hourly (repo_id, branch, bucket_hourly DESC);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS ta_ts_branch_agg_hourly_repo_branch_bucket_idx;",
+        ),
+        RiskyRunSQL(
+            """
+            CREATE INDEX IF NOT EXISTS ta_ts_branch_agg_daily_repo_branch_bucket_idx
+            ON ta_timeseries_branch_aggregate_daily (repo_id, branch, bucket_daily DESC);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS ta_ts_branch_agg_daily_repo_branch_bucket_idx;",
+        ),
+    ]


### PR DESCRIPTION
add migrations to remove the default group indexes create on the new aggregate CAs and add composite indexes on the fields we end up filtering by.