### PR TITLE
feat: allow filtering TA aggregates by branch

### DIFF
--- a/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_test_results_timescale_non_precomputed_branch_feature_branch__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_test_results_timescale_non_precomputed_branch_feature_branch__0.json
@@ -1,0 +1,80 @@
+[
+  {
+    "computed_name": "name0",
+    "testsuite": "testsuite0",
+    "repo_id": 1,
+    "failing_commits": 0,
+    "avg_duration_seconds": 0.0,
+    "last_duration_seconds": 0.0,
+    "pass_count": 1,
+    "fail_count": 0,
+    "skip_count": 0,
+    "flaky_fail_count": 0,
+    "flags": [
+      "flag1",
+      "flag2"
+    ]
+  },
+  {
+    "computed_name": "name1",
+    "testsuite": "testsuite1",
+    "repo_id": 1,
+    "failing_commits": 1,
+    "avg_duration_seconds": 1.0,
+    "last_duration_seconds": 1.0,
+    "pass_count": 0,
+    "fail_count": 1,
+    "skip_count": 0,
+    "flaky_fail_count": 0,
+    "flags": [
+      "flag3"
+    ]
+  },
+  {
+    "computed_name": "name2",
+    "testsuite": "testsuite2",
+    "repo_id": 1,
+    "failing_commits": 0,
+    "avg_duration_seconds": 2.0,
+    "last_duration_seconds": 2.0,
+    "pass_count": 1,
+    "fail_count": 0,
+    "skip_count": 0,
+    "flaky_fail_count": 0,
+    "flags": [
+      "flag1",
+      "flag2"
+    ]
+  },
+  {
+    "computed_name": "name3",
+    "testsuite": "testsuite3",
+    "repo_id": 1,
+    "failing_commits": 1,
+    "avg_duration_seconds": 3.0,
+    "last_duration_seconds": 3.0,
+    "pass_count": 0,
+    "fail_count": 1,
+    "skip_count": 0,
+    "flaky_fail_count": 0,
+    "flags": [
+      "flag3"
+    ]
+  },
+  {
+    "computed_name": "name4",
+    "testsuite": "testsuite4",
+    "repo_id": 1,
+    "failing_commits": 0,
+    "avg_duration_seconds": 4.0,
+    "last_duration_seconds": 4.0,
+    "pass_count": 1,
+    "fail_count": 0,
+    "skip_count": 0,
+    "flaky_fail_count": 0,
+    "flags": [
+      "flag1",
+      "flag2"
+    ]
+  }
+]

--- a/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__flake_aggregates_timescale_non_precomputed_branch_feature_branch__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__flake_aggregates_timescale_non_precomputed_branch_feature_branch__0.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "flakeAggregates": null
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__gql_query_flake_aggregates_timescale_branch__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__gql_query_flake_aggregates_timescale_branch__0.json
@@ -1,0 +1,14 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "flakeAggregates": {
+          "flakeRate": 0.5,
+          "flakeCount": 1,
+          "flakeRatePercentChange": -0.5,
+          "flakeCountPercentChange": -0.6666666666666666
+        }
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__gql_query_test_results_aggregates_timescale_branch__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__gql_query_test_results_aggregates_timescale_branch__0.json
@@ -1,0 +1,20 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "testResultsAggregates": {
+          "totalDuration": 20.0,
+          "slowestTestsDuration": 10.0,
+          "totalFails": 1,
+          "totalSkips": 0,
+          "totalSlowTests": 1,
+          "totalDurationPercentChange": -0.42857142857142855,
+          "slowestTestsDurationPercentChange": -0.4444444444444444,
+          "totalFailsPercentChange": 0.0,
+          "totalSkipsPercentChange": -1.0,
+          "totalSlowTestsPercentChange": 0.0
+        }
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__results_aggregates_timescale_non_precomputed_branch_feature_branch__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__results_aggregates_timescale_non_precomputed_branch_feature_branch__0.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "testResultsAggregates": null
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
@@ -27,12 +27,11 @@ def new_ta_enabled(mocker):
 
 
 @pytest.fixture
-def populate_timescale_flake_aggregates(repository):
-    # Create testruns with different flaky behavior patterns
+def populate_timescale_flake_aggregates(repository, request):
+    branch = getattr(request, "param", "main")
     today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     thirty_days_ago = today - timedelta(days=30)
 
-    # Recent testruns (today's data) - some flaky tests
     recent_testruns = [
         Testrun(
             repo_id=repository.repoid,
@@ -46,12 +45,11 @@ def populate_timescale_flake_aggregates(repository):
             duration_seconds=10.0,
             commit_sha=f"commit{i + 1}",
             flags=["flag1"],
-            branch="main",
+            branch=branch,
         )
         for i in range(2)
     ]
 
-    # Old testruns (30 days ago data) - different flaky pattern for comparison
     old_testruns = [
         Testrun(
             test_id=calc_test_id(f"flaky_test_{i}", "", f"testsuite{i}"),
@@ -65,7 +63,7 @@ def populate_timescale_flake_aggregates(repository):
             duration_seconds=15.0 + (i),
             commit_sha=f"commit {i}",
             flags=[f"flag{i}"],
-            branch="main",
+            branch=branch,
         )
         for i in range(2, 5)
     ]
@@ -74,13 +72,20 @@ def populate_timescale_flake_aggregates(repository):
 
     Testrun.objects.bulk_create(testruns)
 
-    # Refresh the continuous aggregate to ensure the repo summary is updated
     min_timestamp = datetime.now(UTC) - timedelta(days=60)
     max_timestamp = datetime.now(UTC)
 
     with connections["ta_timeseries"].cursor() as cursor:
         cursor.execute(
             "CALL refresh_continuous_aggregate('ta_timeseries_testrun_branch_summary_1day', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_branch_aggregate_hourly', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_branch_aggregate_daily', %s, %s)",
             [min_timestamp, max_timestamp],
         )
 
@@ -129,3 +134,19 @@ class TestFlakeAggregatesTimescale(GraphQLTestHelper):
         result = self.gql_request(query, owner=repository.author)
 
         assert snapshot("json") == result
+
+    @pytest.mark.parametrize(
+        "populate_timescale_flake_aggregates", ["feature-branch"], indirect=True
+    )
+    def test_flake_aggregates_timescale_non_precomputed_branch(
+        self, repository, populate_timescale_flake_aggregates, snapshot
+    ):
+        result = get_flake_aggregates_from_timescale(
+            repository.repoid,
+            "feature-branch",
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+            - timedelta(days=30),
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0),
+        )
+
+        assert result is None

--- a/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
@@ -14,7 +14,12 @@ from .helper import GraphQLTestHelper
 @pytest.fixture(autouse=True)
 def repository():
     owner = OwnerFactory(username="codecov-user")
-    repo = RepositoryFactory(author=owner, name="testRepoName", active=True)
+    repo = RepositoryFactory(
+        author=owner,
+        name="testRepoName",
+        active=True,
+        branch="main",
+    )
     return repo
 
 
@@ -141,12 +146,51 @@ class TestFlakeAggregatesTimescale(GraphQLTestHelper):
     def test_flake_aggregates_timescale_non_precomputed_branch(
         self, repository, populate_timescale_flake_aggregates, snapshot
     ):
-        result = get_flake_aggregates_from_timescale(
-            repository.repoid,
-            "feature-branch",
-            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
-            - timedelta(days=30),
-            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0),
-        )
+        query = f"""
+            query {{
+                owner(username: "{repository.author.username}") {{
+                    repository(name: "{repository.name}") {{
+                        ... on Repository {{
+                            testAnalytics {{
+                                flakeAggregates(branch: "feature-branch") {{
+                                    flakeRate
+                                    flakeCount
+                                    flakeRatePercentChange
+                                    flakeCountPercentChange
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        """
 
-        assert result is None
+        result = self.gql_request(query, owner=repository.author)
+
+        assert snapshot("json") == result
+
+    def test_gql_query_flake_aggregates_timescale_branch(
+        self, repository, populate_timescale_flake_aggregates, snapshot
+    ):
+        query = f"""
+            query {{
+                owner(username: "{repository.author.username}") {{
+                    repository(name: "{repository.name}") {{
+                        ... on Repository {{
+                            testAnalytics {{
+                                flakeAggregates(branch: "main") {{
+                                    flakeRate
+                                    flakeCount
+                                    flakeRatePercentChange
+                                    flakeCountPercentChange
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        result = self.gql_request(query, owner=repository.author)
+
+        assert snapshot("json") == result

--- a/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
@@ -14,7 +14,9 @@ from .helper import GraphQLTestHelper
 @pytest.fixture(autouse=True)
 def repository():
     owner = OwnerFactory(username="codecov-user")
-    repo = RepositoryFactory(author=owner, name="testRepoName", active=True)
+    repo = RepositoryFactory(
+        repoid=1, author=owner, name="testRepoName", active=True, branch="main"
+    )
 
     return repo
 
@@ -28,7 +30,8 @@ def new_ta_enabled(mocker):
 
 
 @pytest.fixture
-def populate_timescale(repository):
+def populate_timescale(repository, request):
+    branch = getattr(request, "param", "main")
     Testrun.objects.bulk_create(
         [
             Testrun(
@@ -42,7 +45,7 @@ def populate_timescale(repository):
                 duration_seconds=i,
                 commit_sha=f"test_commit {i}",
                 flags=["flag1", "flag2"] if i % 2 == 0 else ["flag3"],
-                branch="main",
+                branch=branch,
             )
             for i in range(5)
         ]
@@ -114,41 +117,19 @@ class TestAnalyticsTestCaseNew(GraphQLTestHelper):
 
         assert snapshot("json") == result
 
-    def test_gql_query_test_results_timescale_empty_parameter(
+    @pytest.mark.parametrize("populate_timescale", ["feature-branch"], indirect=True)
+    def test_gql_query_test_results_timescale_non_precomputed_branch(
         self, repository, populate_timescale, snapshot
     ):
-        query = f"""
-            query {{
-                owner(username: "{repository.author.username}") {{
-                    repository(name: "{repository.name}") {{
-                        ... on Repository {{
-                            testAnalytics {{
-                                testResults(filters: {{branch: "main"}}) {{
-                                    totalCount
-                                    edges {{
-                                        cursor
-                                        node {{
-                                            name
-                                            failureRate
-                                            flakeRate
-                                            avgDuration
-                                            totalDuration
-                                            totalFailCount
-                                            totalFlakyFailCount
-                                            totalPassCount
-                                            totalSkipCount
-                                            commitsFailed
-                                            lastDuration
-                                        }}
-                                    }}
-                                }}
-                            }}
-                        }}
-                    }}
-                }}
-            }}
-        """
+        result = get_test_results_queryset(
+            repository.repoid,
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+            - timedelta(days=30),
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0),
+            "feature-branch",
+        )
 
-        result = self.gql_request(query, owner=repository.author)
-
-        assert snapshot("json") == result
+        assert result.count() == 5
+        assert snapshot("json") == [
+            {k: v for k, v in row.items() if k != "updated_at"} for row in result
+        ]

--- a/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
@@ -14,7 +14,9 @@ from .helper import GraphQLTestHelper
 @pytest.fixture(autouse=True)
 def repository():
     owner = OwnerFactory(username="codecov-user")
-    repo = RepositoryFactory(author=owner, name="testRepoName", active=True)
+    repo = RepositoryFactory(
+        author=owner, name="testRepoName", active=True, branch="main"
+    )
     return repo
 
 
@@ -154,12 +156,63 @@ class TestTestResultsAggregatesTimescale(GraphQLTestHelper):
     def test_test_results_aggregates_timescale_non_precomputed_branch(
         self, repository, populate_timescale_test_results_aggregates, snapshot
     ):
-        result = get_test_results_aggregates_from_timescale(
-            repository.repoid,
-            "feature-branch",
-            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
-            - timedelta(days=30),
-            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0),
-        )
+        query = f"""
+            query {{
+                owner(username: "{repository.author.username}") {{
+                    repository(name: "{repository.name}") {{
+                        ... on Repository {{
+                            testAnalytics {{
+                                testResultsAggregates(branch: "feature-branch") {{
+                                    totalDuration
+                                    slowestTestsDuration
+                                    totalFails
+                                    totalSkips
+                                    totalSlowTests
+                                    totalDurationPercentChange
+                                    slowestTestsDurationPercentChange
+                                    totalFailsPercentChange
+                                    totalSkipsPercentChange
+                                    totalSlowTestsPercentChange
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        """
 
-        assert result is None
+        result = self.gql_request(query, owner=repository.author)
+
+        assert snapshot("json") == result
+
+    def test_gql_query_test_results_aggregates_timescale_branch(
+        self, repository, populate_timescale_test_results_aggregates, snapshot
+    ):
+        query = f"""
+            query {{
+                owner(username: "{repository.author.username}") {{
+                    repository(name: "{repository.name}") {{
+                        ... on Repository {{
+                            testAnalytics {{
+                                testResultsAggregates(branch: "main") {{
+                                    totalDuration
+                                    slowestTestsDuration
+                                    totalFails
+                                    totalSkips
+                                    totalSlowTests
+                                    totalDurationPercentChange
+                                    slowestTestsDurationPercentChange
+                                    totalFailsPercentChange
+                                    totalSkipsPercentChange
+                                    totalSlowTestsPercentChange
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        result = self.gql_request(query, owner=repository.author)
+
+        assert snapshot("json") == result

--- a/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
@@ -27,12 +27,11 @@ def new_ta_enabled(mocker):
 
 
 @pytest.fixture
-def populate_timescale_test_results_aggregates(repository):
-    # Create testruns with different flaky behavior patterns
+def populate_timescale_test_results_aggregates(repository, request):
+    branch = getattr(request, "param", "main")
     now_utc = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     thirty_days_ago = now_utc - timedelta(days=30)
 
-    # Recent testruns (today's data) - some flaky tests
     recent_testruns = [
         Testrun(
             repo_id=repository.repoid,
@@ -46,12 +45,11 @@ def populate_timescale_test_results_aggregates(repository):
             duration_seconds=10.0,
             commit_sha=f"commit{i + 1}",
             flags=["flag1"],
-            branch="main",
+            branch=branch,
         )
         for i in range(2)
     ]
 
-    # Old testruns (30 days ago data) - different flaky pattern for comparison
     old_testruns = [
         Testrun(
             test_id=calc_test_id(f"test_{i}", "", f"testsuite{i}"),
@@ -65,7 +63,7 @@ def populate_timescale_test_results_aggregates(repository):
             duration_seconds=15.0 + (i) if i != 4 else 0.0,
             commit_sha=f"commit {i}",
             flags=[f"flag{i}"],
-            branch="main",
+            branch=branch,
         )
         for i in range(2, 5)
     ]
@@ -74,13 +72,20 @@ def populate_timescale_test_results_aggregates(repository):
 
     Testrun.objects.bulk_create(testruns)
 
-    # Refresh the continuous aggregate to ensure the repo summary is updated
     min_timestamp = datetime.now(UTC) - timedelta(days=60)
     max_timestamp = datetime.now(UTC)
 
     with connections["ta_timeseries"].cursor() as cursor:
         cursor.execute(
             "CALL refresh_continuous_aggregate('ta_timeseries_testrun_branch_summary_1day', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_branch_aggregate_hourly', %s, %s)",
+            [min_timestamp, max_timestamp],
+        )
+        cursor.execute(
+            "CALL refresh_continuous_aggregate('ta_timeseries_branch_aggregate_daily', %s, %s)",
             [min_timestamp, max_timestamp],
         )
 
@@ -142,3 +147,19 @@ class TestTestResultsAggregatesTimescale(GraphQLTestHelper):
         result = self.gql_request(query, owner=repository.author)
 
         assert snapshot("json") == result
+
+    @pytest.mark.parametrize(
+        "populate_timescale_test_results_aggregates", ["feature-branch"], indirect=True
+    )
+    def test_test_results_aggregates_timescale_non_precomputed_branch(
+        self, repository, populate_timescale_test_results_aggregates, snapshot
+    ):
+        result = get_test_results_aggregates_from_timescale(
+            repository.repoid,
+            "feature-branch",
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+            - timedelta(days=30),
+            datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0),
+        )
+
+        assert result is None

--- a/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.graphql
+++ b/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.graphql
@@ -13,10 +13,16 @@ type TestAnalytics {
   ): TestResultConnection! @cost(complexity: 10, multipliers: ["first", "last"])
 
   "Test results aggregates are analytics data totals across all tests"
-  testResultsAggregates(interval: MeasurementInterval): TestResultsAggregates
+  testResultsAggregates(
+    branch: String
+    interval: MeasurementInterval
+  ): TestResultsAggregates
 
   "Flake aggregates are flake totals across all tests"
-  flakeAggregates(interval: MeasurementInterval): FlakeAggregates
+  flakeAggregates(
+    branch: String
+    interval: MeasurementInterval
+  ): FlakeAggregates
 
   testSuites(term: String): [String!]!
 

--- a/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
+++ b/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
@@ -403,6 +403,7 @@ async def resolve_test_results(
 async def resolve_test_results_aggregates(
     repository: Repository,
     info: GraphQLResolveInfo,
+    branch: str | None = None,
     interval: MeasurementInterval | None = None,
     **_: Any,
 ) -> TestResultsAggregates | None:
@@ -414,13 +415,13 @@ async def resolve_test_results_aggregates(
         start_date = end_date - timedelta(days=measurement_interval.value)
         return await sync_to_async(get_test_results_aggregates_from_timescale)(
             repoid=repository.repoid,
-            branch=repository.branch,
+            branch=branch if branch else repository.branch,
             start_date=start_date,
             end_date=end_date,
         )
     return await sync_to_async(generate_test_results_aggregates)(
         repoid=repository.repoid,
-        branch=repository.branch,
+        branch=branch if branch else repository.branch,
         interval=interval if interval else MeasurementInterval.INTERVAL_30_DAY,
     )
 
@@ -429,6 +430,7 @@ async def resolve_test_results_aggregates(
 async def resolve_flake_aggregates(
     repository: Repository,
     info: GraphQLResolveInfo,
+    branch: str | None = None,
     interval: MeasurementInterval | None = None,
     **_: Any,
 ) -> FlakeAggregates | None:
@@ -440,13 +442,14 @@ async def resolve_flake_aggregates(
         start_date = end_date - timedelta(days=measurement_interval.value)
         return await sync_to_async(get_flake_aggregates_from_timescale)(
             repoid=repository.repoid,
-            branch=repository.branch,
+            branch=branch if branch else repository.branch,
             start_date=start_date,
             end_date=end_date,
         )
+
     return await sync_to_async(generate_flake_aggregates)(
         repoid=repository.repoid,
-        branch=repository.branch,
+        branch=branch if branch else repository.branch,
         interval=interval if interval else MeasurementInterval.INTERVAL_30_DAY,
     )
 

--- a/apps/codecov-api/utils/timescale_test_results.py
+++ b/apps/codecov-api/utils/timescale_test_results.py
@@ -9,15 +9,18 @@ from django.db.models import (
     FloatField,
     Max,
     Q,
+    QuerySet,
     Sum,
     Value,
     When,
 )
 
 from shared.django_apps.ta_timeseries.models import (
+    AggregateDaily,
     BranchAggregateDaily,
     Testrun,
     TestrunBranchSummary,
+    TestrunSummary,
 )
 from shared.metrics import Histogram
 from utils.ta_types import (
@@ -43,18 +46,55 @@ class ArrayMergeDedupe(Aggregate):
     template = "%(function)s(%(expressions)s)"
 
 
+def _get_test_summary_queryset(
+    repoid: int,
+    start_date: datetime,
+    end_date: datetime,
+    branch: Literal["main", "master", "develop"] | None,
+):
+    if branch is None:
+        return TestrunSummary.objects.filter(
+            repo_id=repoid,
+            timestamp_bin__gte=start_date,
+            timestamp_bin__lt=end_date,
+        )
+    else:
+        return TestrunBranchSummary.objects.filter(
+            repo_id=repoid,
+            branch=branch,
+            timestamp_bin__gte=start_date,
+            timestamp_bin__lt=end_date,
+        )
+
+
+def _get_aggregate_daily_queryset(
+    repoid: int,
+    start_date: datetime,
+    end_date: datetime,
+    branch: Literal["main", "master", "develop"] | None,
+):
+    if branch is None:
+        return AggregateDaily.objects.filter(
+            repo_id=repoid,
+            bucket_daily__gte=start_date,
+            bucket_daily__lt=end_date,
+        )
+    else:
+        return BranchAggregateDaily.objects.filter(
+            repo_id=repoid,
+            branch=branch,
+            bucket_daily__gte=start_date,
+            bucket_daily__lt=end_date,
+        )
+
+
 def get_test_data_queryset_via_ca(
     repoid: int,
     start_date: datetime,
     end_date: datetime,
-    branch: Literal["main", "master", "develop"],
-):
-    test_data = TestrunBranchSummary.objects.filter(
-        repo_id=repoid,
-        branch=branch,
-        timestamp_bin__gte=start_date,
-        timestamp_bin__lt=end_date,
-    )
+    branch: Literal["main", "master", "develop"] | None,
+) -> QuerySet:
+    test_data = _get_test_summary_queryset(repoid, start_date, end_date, branch)
 
     return test_data.values("computed_name", "testsuite").annotate(
         total_pass_count=Sum("pass_count"),
@@ -191,20 +231,10 @@ def get_repo_aggregates_via_ca(
     repoid: int,
     start_date: datetime,
     end_date: datetime,
-    branch: Literal["main", "master", "develop"],
+    branch: Literal["main", "master", "develop"] | None,
 ):
-    test_data = TestrunBranchSummary.objects.filter(
-        repo_id=repoid,
-        branch=branch,
-        timestamp_bin__gte=start_date,
-        timestamp_bin__lt=end_date,
-    )
-    repo_data = BranchAggregateDaily.objects.filter(
-        repo_id=repoid,
-        branch=branch,
-        bucket_daily__gte=start_date,
-        bucket_daily__lt=end_date,
-    )
+    test_data = _get_test_summary_queryset(repoid, start_date, end_date, branch)
+    repo_data = _get_aggregate_daily_queryset(repoid, start_date, end_date, branch)
 
     daily_aggregates = repo_data.aggregate(
         total_duration=Sum("total_duration_seconds", output_field=FloatField()),
@@ -242,9 +272,9 @@ def get_repo_aggregates_via_ca(
 
 @get_test_result_aggregates_histogram.time()
 def get_test_results_aggregates_from_timescale(
-    repoid: int, branch: str, start_date: datetime, end_date: datetime
+    repoid: int, branch: str | None, start_date: datetime, end_date: datetime
 ) -> TestResultsAggregates | None:
-    if branch not in PRECOMPUTED_BRANCHES:
+    if branch is not None and branch not in PRECOMPUTED_BRANCHES:
         return None
 
     interval_duration = end_date - start_date
@@ -259,6 +289,7 @@ def get_test_results_aggregates_from_timescale(
             repoid, comparison_start_date, comparison_end_date, branch
         )
     )
+
     return TestResultsAggregates(
         total_duration=curr_aggregates["total_duration"] or 0,
         fails=curr_aggregates["fails"] or 0,
@@ -287,20 +318,10 @@ def get_flake_aggregates_via_ca(
     repoid: int,
     start_date: datetime,
     end_date: datetime,
-    branch: Literal["main", "master", "develop"],
-):
-    test_data = TestrunBranchSummary.objects.filter(
-        repo_id=repoid,
-        branch=branch,
-        timestamp_bin__gte=start_date,
-        timestamp_bin__lt=end_date,
-    )
-    repo_data = BranchAggregateDaily.objects.filter(
-        repo_id=repoid,
-        branch=branch,
-        bucket_daily__gte=start_date,
-        bucket_daily__lt=end_date,
-    )
+    branch: Literal["main", "master", "develop"] | None,
+) -> dict:
+    test_data = _get_test_summary_queryset(repoid, start_date, end_date, branch)
+    repo_data = _get_aggregate_daily_queryset(repoid, start_date, end_date, branch)
 
     daily_aggregates = repo_data.aggregate(
         total_count=Sum(
@@ -329,7 +350,7 @@ def get_flake_aggregates_via_ca(
 
 @get_flake_aggregates_histogram.time()
 def get_flake_aggregates_from_timescale(
-    repoid: int, branch: str, start_date: datetime, end_date: datetime
+    repoid: int, branch: str | None, start_date: datetime, end_date: datetime
 ) -> FlakeAggregates | None:
     if branch not in PRECOMPUTED_BRANCHES:
         return None

--- a/apps/codecov-api/utils/timescale_test_results.py
+++ b/apps/codecov-api/utils/timescale_test_results.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import Literal
 
-from django.db import connections
 from django.db.models import (
     Aggregate,
     Case,
@@ -16,6 +15,8 @@ from django.db.models import (
 )
 
 from shared.django_apps.ta_timeseries.models import (
+    BranchAggregateDaily,
+    Testrun,
     TestrunBranchSummary,
 )
 from shared.metrics import Histogram
@@ -23,6 +24,8 @@ from utils.ta_types import (
     FlakeAggregates,
     TestResultsAggregates,
 )
+
+PRECOMPUTED_BRANCHES = ("main", "master", "develop")
 
 get_test_result_aggregates_histogram = Histogram(
     "get_test_result_aggregates_timescale",
@@ -40,25 +43,20 @@ class ArrayMergeDedupe(Aggregate):
     template = "%(function)s(%(expressions)s)"
 
 
-def get_test_results_queryset(
+def get_test_data_queryset_via_ca(
     repoid: int,
     start_date: datetime,
     end_date: datetime,
-    branch: str,
-    parameter: Literal["flaky_tests", "failed_tests", "slowest_tests", "skipped_tests"]
-    | None = None,
-    testsuites: list[str] | None = None,
-    flags: list[str] | None = None,
-    term: str | None = None,
+    branch: Literal["main", "master", "develop"],
 ):
-    base_queryset = TestrunBranchSummary.objects.filter(
+    test_data = TestrunBranchSummary.objects.filter(
         repo_id=repoid,
         branch=branch,
         timestamp_bin__gte=start_date,
         timestamp_bin__lt=end_date,
     )
 
-    aggregated_queryset = base_queryset.values("computed_name", "testsuite").annotate(
+    return test_data.values("computed_name", "testsuite").annotate(
         total_pass_count=Sum("pass_count"),
         total_fail_count=Sum("fail_count"),
         total_flaky_fail_count=Sum("flaky_fail_count"),
@@ -103,26 +101,81 @@ def get_test_results_queryset(
         name=F("computed_name"),
     )
 
+
+def get_test_data_queryset_via_testrun(
+    repoid: int,
+    start_date: datetime,
+    end_date: datetime,
+    branch: str,
+):
+    raw_queryset = Testrun.objects.filter(
+        repo_id=repoid,
+        branch=branch,
+        timestamp__gte=start_date,
+        timestamp__lt=end_date,
+    )
+
+    return raw_queryset.values("computed_name", "testsuite").annotate(
+        repo_id=Value(repoid),
+        failing_commits=Count(
+            "commit_sha",
+            filter=Q(outcome__in=["failure", "flaky_fail"]),
+            distinct=True,
+        ),
+        avg_duration_seconds=Case(
+            When(
+                Q(duration_seconds__isnull=False),
+                then=Sum("duration_seconds") / Count("duration_seconds"),
+            ),
+            default=Value(0.0),
+            output_field=FloatField(),
+        ),
+        last_duration_seconds=Max("duration_seconds"),
+        pass_count=Sum(Case(When(outcome="pass", then=Value(1)), default=Value(0))),
+        fail_count=Sum(Case(When(outcome="failure", then=Value(1)), default=Value(0))),
+        skip_count=Sum(Case(When(outcome="skip", then=Value(1)), default=Value(0))),
+        flaky_fail_count=Sum(
+            Case(When(outcome="flaky_fail", then=Value(1)), default=Value(0))
+        ),
+        updated_at=Max("timestamp"),
+        flags=ArrayMergeDedupe("flags"),
+    )
+
+
+def get_test_results_queryset(
+    repoid: int,
+    start_date: datetime,
+    end_date: datetime,
+    branch: str | None,
+    parameter: Literal["flaky_tests", "failed_tests", "slowest_tests", "skipped_tests"]
+    | None = None,
+    testsuites: list[str] | None = None,
+    flags: list[str] | None = None,
+    term: str | None = None,
+):
+    if branch is None or branch in PRECOMPUTED_BRANCHES:
+        test_data = get_test_data_queryset_via_ca(repoid, start_date, end_date, branch)
+    else:
+        test_data = get_test_data_queryset_via_testrun(
+            repoid, start_date, end_date, branch
+        )
+
     match parameter:
         case "failed_tests":
-            aggregated_queryset = aggregated_queryset.filter(total_fail_count__gt=0)
+            test_data = test_data.filter(total_fail_count__gt=0)
         case "flaky_tests":
-            aggregated_queryset = aggregated_queryset.filter(
-                total_flaky_fail_count__gt=0
-            )
+            test_data = test_data.filter(total_flaky_fail_count__gt=0)
         case "skipped_tests":
-            aggregated_queryset = aggregated_queryset.filter(
-                total_skip_count__gt=0, total_pass_count=0
-            )
+            test_data = test_data.filter(total_skip_count__gt=0, total_pass_count=0)
 
     if term:
-        aggregated_queryset = aggregated_queryset.filter(computed_name__icontains=term)
+        test_data = test_data.filter(computed_name__icontains=term)
     if testsuites:
-        aggregated_queryset = aggregated_queryset.filter(testsuite__in=testsuites)
+        test_data = test_data.filter(testsuite__in=testsuites)
     if flags:
-        aggregated_queryset = aggregated_queryset.filter(flags__overlap=flags)
+        test_data = test_data.filter(flags__overlap=flags)
 
-    return aggregated_queryset
+    return test_data
 
 
 def _pct_change(current: int | float | None, past: int | float | None) -> float:
@@ -134,86 +187,78 @@ def _pct_change(current: int | float | None, past: int | float | None) -> float:
     return (current - past) / past
 
 
-def get_slowest_tests_duration(
+def get_repo_aggregates_via_ca(
     repoid: int,
-    branch: str,
     start_date: datetime,
     end_date: datetime,
-    unique_test_count: int,
-) -> tuple[float, int]:
+    branch: Literal["main", "master", "develop"],
+):
+    test_data = TestrunBranchSummary.objects.filter(
+        repo_id=repoid,
+        branch=branch,
+        timestamp_bin__gte=start_date,
+        timestamp_bin__lt=end_date,
+    )
+    repo_data = BranchAggregateDaily.objects.filter(
+        repo_id=repoid,
+        branch=branch,
+        bucket_daily__gte=start_date,
+        bucket_daily__lt=end_date,
+    )
+
+    daily_aggregates = repo_data.aggregate(
+        total_duration=Sum("total_duration_seconds", output_field=FloatField()),
+        fails=Sum(F("fail_count") + F("flaky_fail_count")),
+        skips=Sum("skip_count"),
+    )
+
+    unique_test_count = (
+        test_data.aggregate(unique_test_count=Count("computed_name", distinct=True))[
+            "unique_test_count"
+        ]
+        or 0
+    )
+
     slow_test_num = min(100, max(unique_test_count // 20, 1))
 
-    with connections["ta_timeseries"].cursor() as cursor:
-        cursor.execute(
-            """
-            SELECT SUM(total_duration) as slowest_tests_duration FROM (
-                SELECT SUM(avg_duration_seconds * (pass_count + fail_count + flaky_fail_count)) as total_duration
-                FROM ta_timeseries_testrun_branch_summary_1day
-                WHERE repo_id = %s
-                    AND branch = %s
-                    AND timestamp_bin >= %s
-                    AND timestamp_bin < %s
-                GROUP BY computed_name, testsuite
-                ORDER BY total_duration DESC
-                LIMIT %s
-            ) as slow_tests
-            """,
-            (repoid, branch, start_date, end_date, slow_test_num),
+    slow_tests = (
+        test_data.values("computed_name", "testsuite")
+        .annotate(
+            total_duration=Sum(
+                F("avg_duration_seconds")
+                * (F("pass_count") + F("fail_count") + F("flaky_fail_count")),
+                output_field=FloatField(),
+            )
         )
-        if result := cursor.fetchone():
-            return result[0] or 0.0, slow_test_num
-        else:
-            return 0.0, 0
+        .order_by("-total_duration")[:slow_test_num]
+    )
+
+    result = slow_tests.aggregate(slowest_tests_duration=Sum("total_duration"))
+
+    slowest_tests_duration = result["slowest_tests_duration"] or 0.0
+
+    return daily_aggregates, slowest_tests_duration, slow_test_num
 
 
 @get_test_result_aggregates_histogram.time()
 def get_test_results_aggregates_from_timescale(
     repoid: int, branch: str, start_date: datetime, end_date: datetime
 ) -> TestResultsAggregates | None:
+    if branch not in PRECOMPUTED_BRANCHES:
+        return None
+
     interval_duration = end_date - start_date
     comparison_start_date = start_date - interval_duration
     comparison_end_date = start_date
 
-    def get_aggregates(
-        repoid: int, branch: str, start_date: datetime, end_date: datetime
-    ):
-        return TestrunBranchSummary.objects.filter(
-            repo_id=repoid,
-            branch=branch,
-            timestamp_bin__gte=start_date,
-            timestamp_bin__lt=end_date,
-        ).aggregate(
-            total_duration=Sum(
-                F("avg_duration_seconds")
-                * (F("pass_count") + F("fail_count") + F("flaky_fail_count")),
-                output_field=FloatField(),
-            ),
-            fails=Sum(F("fail_count") + F("flaky_fail_count")),
-            skips=Sum("skip_count"),
-            unique_test_count=Count("computed_name", distinct=True),
+    curr_aggregates, curr_slow_test_duration, curr_slow_test_num = (
+        get_repo_aggregates_via_ca(repoid, start_date, end_date, branch)
+    )
+    past_aggregates, past_slow_test_duration, past_slow_test_num = (
+        get_repo_aggregates_via_ca(
+            repoid, comparison_start_date, comparison_end_date, branch
         )
-
-    curr_aggregates = get_aggregates(repoid, branch, start_date, end_date)
-
-    if curr_aggregates["total_duration"] is None:
-        return None
-
-    curr_slow_test_duration, curr_slow_test_num = get_slowest_tests_duration(
-        repoid, branch, start_date, end_date, curr_aggregates["unique_test_count"]
     )
-
-    past_aggregates = get_aggregates(
-        repoid, branch, comparison_start_date, comparison_end_date
-    )
-
-    past_slow_test_duration, past_slow_test_num = get_slowest_tests_duration(
-        repoid,
-        branch,
-        comparison_start_date,
-        comparison_end_date,
-        past_aggregates["unique_test_count"],
-    )
-
     return TestResultsAggregates(
         total_duration=curr_aggregates["total_duration"] or 0,
         fails=curr_aggregates["fails"] or 0,
@@ -238,48 +283,69 @@ def get_test_results_aggregates_from_timescale(
     )
 
 
+def get_flake_aggregates_via_ca(
+    repoid: int,
+    start_date: datetime,
+    end_date: datetime,
+    branch: Literal["main", "master", "develop"],
+):
+    test_data = TestrunBranchSummary.objects.filter(
+        repo_id=repoid,
+        branch=branch,
+        timestamp_bin__gte=start_date,
+        timestamp_bin__lt=end_date,
+    )
+    repo_data = BranchAggregateDaily.objects.filter(
+        repo_id=repoid,
+        branch=branch,
+        bucket_daily__gte=start_date,
+        bucket_daily__lt=end_date,
+    )
+
+    daily_aggregates = repo_data.aggregate(
+        total_count=Sum(
+            F("pass_count") + F("fail_count") + F("flaky_fail_count"),
+            output_field=FloatField(),
+        ),
+        flake_rate=Case(
+            When(
+                total_count=0,
+                then=Value(0.0),
+            ),
+            default=Sum("flaky_fail_count", output_field=FloatField())
+            / F("total_count"),
+        ),
+    )
+
+    flake_count = test_data.filter(flaky_fail_count__gt=0).aggregate(
+        flake_count=Count("computed_name", distinct=True),
+    )
+
+    return {
+        **daily_aggregates,
+        "flake_count": flake_count["flake_count"] or 0,
+    }
+
+
 @get_flake_aggregates_histogram.time()
 def get_flake_aggregates_from_timescale(
     repoid: int, branch: str, start_date: datetime, end_date: datetime
 ) -> FlakeAggregates | None:
+    if branch not in PRECOMPUTED_BRANCHES:
+        return None
+
     interval_duration = end_date - start_date
     comparison_start_date = start_date - interval_duration
     comparison_end_date = start_date
 
-    def get_branch_aggregates(
-        start: datetime,
-        end: datetime,
-    ):
-        return TestrunBranchSummary.objects.filter(
-            repo_id=repoid,
-            branch=branch,
-            timestamp_bin__gte=start,
-            timestamp_bin__lt=end,
-        ).aggregate(
-            total_count=Sum(
-                "pass_count",
-                output_field=FloatField(),
-            )
-            + Sum("fail_count", output_field=FloatField())
-            + Sum("flaky_fail_count", output_field=FloatField()),
-            flake_count=Count(
-                "computed_name", distinct=True, filter=Q(flaky_fail_count__gt=0)
-            ),
-            flake_rate=Case(
-                When(
-                    total_count=0,
-                    then=Value(0.0),
-                ),
-                default=Sum("flaky_fail_count", output_field=FloatField())
-                / F("total_count"),
-            ),
-        )
+    curr_aggregates = get_flake_aggregates_via_ca(repoid, start_date, end_date, branch)
 
-    curr_aggregates = get_branch_aggregates(start_date, end_date)
     if curr_aggregates["flake_count"] is None:
         return None
 
-    past_aggregates = get_branch_aggregates(comparison_start_date, comparison_end_date)
+    past_aggregates = get_flake_aggregates_via_ca(
+        repoid, comparison_start_date, comparison_end_date, branch
+    )
 
     return FlakeAggregates(
         flake_count=curr_aggregates["flake_count"] or 0,

--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0022_remove_default_cagg_indexes.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0022_remove_default_cagg_indexes.py
@@ -1,0 +1,151 @@
+from django.db import migrations
+
+from shared.django_apps.migration_utils import RiskyRunSQL
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("ta_timeseries", "0021_testrun_ta_ts__repo_timestamp_idx_and_more"),
+    ]
+
+    operations = [
+        RiskyRunSQL(
+            """
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_aggregate_hourly';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_repo_id_bucket_hourly_idx');
+                END IF;
+            END $$;
+            """,
+            reverse_sql="""
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_aggregate_hourly';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_repo_id_bucket_hourly_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (repo_id, bucket_hourly)';
+                END IF;
+            END $$;
+            """,
+        ),
+        RiskyRunSQL(
+            """
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_aggregate_daily';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_repo_id_bucket_daily_idx');
+                END IF;
+            END $$;
+            """,
+            reverse_sql="""
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_aggregate_daily';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_repo_id_bucket_daily_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (repo_id, bucket_daily)';
+                END IF;
+            END $$;
+            """,
+        ),
+        RiskyRunSQL(
+            """
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_branch_aggregate_hourly';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_repo_id_bucket_hourly_idx');
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_branch_bucket_hourly_idx');
+                END IF;
+            END $$;
+            """,
+            reverse_sql="""
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_branch_aggregate_hourly';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_repo_id_bucket_hourly_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (repo_id, bucket_hourly)';
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_branch_bucket_hourly_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (branch, bucket_hourly)';
+                END IF;
+            END $$;
+            """,
+        ),
+        RiskyRunSQL(
+            """
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_branch_aggregate_daily';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_repo_id_bucket_daily_idx');
+                    EXECUTE 'DROP INDEX IF EXISTS _timescaledb_internal.' || quote_ident(mat_hypertable_name || '_branch_bucket_daily_idx');
+                END IF;
+            END $$;
+            """,
+            reverse_sql="""
+            DO $$
+            DECLARE
+                mat_hypertable_name text;
+            BEGIN
+                SELECT materialization_hypertable_name
+                INTO mat_hypertable_name
+                FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = 'ta_timeseries_branch_aggregate_daily';
+
+                IF mat_hypertable_name IS NOT NULL THEN
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_repo_id_bucket_daily_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (repo_id, bucket_daily)';
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(mat_hypertable_name || '_branch_bucket_daily_idx') || 
+                            ' ON _timescaledb_internal.' || quote_ident(mat_hypertable_name) || ' (branch, bucket_daily)';
+                END IF;
+            END $$;
+            """,
+        ),
+    ]

--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0023_create_cagg_indexes.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0023_create_cagg_indexes.py
@@ -1,0 +1,41 @@
+from django.db import migrations
+
+from shared.django_apps.migration_utils import RiskyRunSQL
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("ta_timeseries", "0022_remove_default_cagg_indexes"),
+    ]
+
+    operations = [
+        RiskyRunSQL(
+            """
+            CREATE INDEX IF NOT EXISTS ta_ts_agg_hourly_repo_bucket_idx
+            ON ta_timeseries_aggregate_hourly (repo_id, bucket_hourly DESC);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS ta_ts_agg_hourly_repo_bucket_idx;",
+        ),
+        RiskyRunSQL(
+            """
+            CREATE INDEX IF NOT EXISTS ta_ts_agg_daily_repo_bucket_idx
+            ON ta_timeseries_aggregate_daily (repo_id, bucket_daily DESC);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS ta_ts_agg_daily_repo_bucket_idx;",
+        ),
+        RiskyRunSQL(
+            """
+            CREATE INDEX IF NOT EXISTS ta_ts_branch_agg_hourly_repo_branch_bucket_idx
+            ON ta_timeseries_branch_aggregate_hourly (repo_id, branch, bucket_hourly DESC);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS ta_ts_branch_agg_hourly_repo_branch_bucket_idx;",
+        ),
+        RiskyRunSQL(
+            """
+            CREATE INDEX IF NOT EXISTS ta_ts_branch_agg_daily_repo_branch_bucket_idx
+            ON ta_timeseries_branch_aggregate_daily (repo_id, branch, bucket_daily DESC);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS ta_ts_branch_agg_daily_repo_branch_bucket_idx;",
+        ),
+    ]


### PR DESCRIPTION
I'm choosing to change the default behaviour when the branch filter is not
specified, even though this will mean that the frontend will inconsistently show
results for all branches on any branch because this code is only deployed to
ourselves for now.

The code change is adding a branch argument to the TestResultsAggregates and
FlakeAggregates GQL types and fetching the data from the correct continuous
aggregates depending on the value of the argument.