### PR TITLE
fix: Add username to impersonation request

### DIFF
--- a/apps/codecov-api/codecov_auth/admin.py
+++ b/apps/codecov-api/codecov_auth/admin.py
@@ -85,9 +85,9 @@ def impersonate_owner(self, request, queryset):
         )
         return
 
-    owner = queryset.first()
+    owner: Owner = queryset.first()
     response = redirect(
-        f"{settings.CODECOV_URL}/{get_short_service_name(owner.service)}/"
+        f"{settings.CODECOV_URL}/{get_short_service_name(owner.service)}/{owner.username}"
     )
 
     # this cookie is read by the `ImpersonationMiddleware` and

--- a/apps/codecov-api/codecov_auth/tests/test_admin.py
+++ b/apps/codecov-api/codecov_auth/tests/test_admin.py
@@ -47,10 +47,7 @@ from shared.django_apps.codecov_auth.tests.factories import (
     UserFactory,
 )
 from shared.django_apps.core.tests.factories import PullFactory, RepositoryFactory
-from shared.plan.constants import (
-    DEFAULT_FREE_PLAN,
-    PlanName,
-)
+from shared.plan.constants import DEFAULT_FREE_PLAN, PlanName
 
 
 class OwnerAdminTest(TestCase):
@@ -74,7 +71,11 @@ class OwnerAdminTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_owner_admin_impersonate_owner(self):
-        owner_to_impersonate = OwnerFactory(service="bitbucket", plan=DEFAULT_FREE_PLAN)
+        owner_to_impersonate = OwnerFactory(
+            service="bitbucket",
+            plan=DEFAULT_FREE_PLAN,
+            username="test-owner",
+        )
         other_owner = OwnerFactory(plan=DEFAULT_FREE_PLAN)
 
         with self.subTest("more than one user selected"):
@@ -101,7 +102,7 @@ class OwnerAdminTest(TestCase):
                     ACTION_CHECKBOX_NAME: [owner_to_impersonate.pk],
                 },
             )
-            self.assertIn("/bb/", response.url)
+            self.assertIn("/bb/test-owner", response.url)
             self.assertEqual(
                 response.cookies.get("staff_user").value,
                 str(owner_to_impersonate.pk),


### PR DESCRIPTION
This PR aims to fix an issue where you are already logged into codecov with a provider different than the provider you are requesting to impersonate. Currently we'll just spin trying to find the default username which doesn't exist on the provider we are logged in as prior to impersonating, but now we'll redirect to the impersonated user's account directly.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
