### PR TITLE
clean READ_EVALS feature flag

### DIFF
--- a/apps/codecov-api/api/public/v2/evals/views.py
+++ b/apps/codecov-api/api/public/v2/evals/views.py
@@ -12,7 +12,6 @@ from rest_framework.decorators import action
 from api.public.v2.schema import repo_parameters
 from api.shared.mixins import RepoPropertyMixin
 from api.shared.permissions import RepositoryArtifactPermissions
-from rollouts import READ_NEW_EVALS
 from shared.django_apps.db_settings import TA_TIMESERIES_ENABLED
 from shared.django_apps.ta_timeseries.models import Testrun
 
@@ -38,17 +37,13 @@ class EvalsFilters(django_filters.FilterSet):
 class EvalsPermissions(RepositoryArtifactPermissions):
     """
     Permissions class for evals endpoints. Extends RepositoryArtifactPermissions
-    to add a check for the READ_NEW_EVALS feature flag.
+    to add a check for the TA_TIMESERIES_ENABLED setting.
     """
 
     def has_permission(self, request, view):
         # First check if the user has basic repository access
         has_basic_permission = super().has_permission(request, view)
         if not has_basic_permission:
-            return False
-
-        # Then check if the repository has the feature flag enabled
-        if not READ_NEW_EVALS.check_value(identifier=str(view.repo.repoid)):
             return False
 
         # Finally, check if the environment has TA_TIMESERIES_ENABLED

--- a/apps/codecov-api/rollouts/__init__.py
+++ b/apps/codecov-api/rollouts/__init__.py
@@ -6,5 +6,3 @@ __all__ = ["Feature"]
 #    { "enabled": FeatureVariant(True, 1.0) }
 
 READ_NEW_TA = Feature("read_new_ta")
-
-READ_NEW_EVALS = Feature("read_new_evals")


### PR DESCRIPTION
With a blog post about to be publish, and the test-processor technically being able to process the evals info I guess it makes sense to remove the FF.

Also I had many problems with it 😅

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
