### PR TITLE
fix(api): Proper typing for mixins

### DIFF
--- a/apps/codecov-api/upload/views/bundle_analysis.py
+++ b/apps/codecov-api/upload/views/bundle_analysis.py
@@ -74,7 +74,7 @@ class UploadSerializer(serializers.Serializer):
     upload_external_id = serializers.CharField(required=False, allow_null=True)
 
 
-class BundleAnalysisView(APIView, ShelterMixin):
+class BundleAnalysisView(ShelterMixin, APIView):
     permission_classes = [UploadBundleAnalysisPermission]
     authentication_classes = [
         UploadTokenRequiredGetFromBodyAuthenticationCheck,

--- a/apps/codecov-api/upload/views/commits.py
+++ b/apps/codecov-api/upload/views/commits.py
@@ -54,7 +54,7 @@ def create_commit(
     return serializer.save(repository=repository)
 
 
-class CommitViews(ListCreateAPIView, GetterMixin):
+class CommitViews(GetterMixin, ListCreateAPIView):
     serializer_class = CommitSerializer
     permission_classes = [CanDoCoverageUploadsPermission]
     authentication_classes = [

--- a/apps/codecov-api/upload/views/empty_upload.py
+++ b/apps/codecov-api/upload/views/empty_upload.py
@@ -75,7 +75,7 @@ class EmptyUploadSerializer(serializers.Serializer):
     should_force = serializers.BooleanField(required=False)
 
 
-class EmptyUploadView(CreateAPIView, GetterMixin):
+class EmptyUploadView(GetterMixin, CreateAPIView):
     permission_classes = [CanDoCoverageUploadsPermission]
     authentication_classes = [
         UploadTokenRequiredAuthenticationCheck,

--- a/apps/codecov-api/upload/views/legacy.py
+++ b/apps/codecov-api/upload/views/legacy.py
@@ -59,7 +59,7 @@ class PlainTextRenderer(renderers.BaseRenderer):
         return smart_str(data, encoding=self.charset)
 
 
-class UploadHandler(APIView, ShelterMixin):
+class UploadHandler(ShelterMixin, APIView):
     permission_classes = [AllowAny]
     renderer_classes = [PlainTextRenderer, renderers.JSONRenderer]
 

--- a/apps/codecov-api/upload/views/test_results.py
+++ b/apps/codecov-api/upload/views/test_results.py
@@ -56,8 +56,8 @@ class UploadSerializer(serializers.Serializer):
 
 
 class TestResultsView(
-    APIView,
     ShelterMixin,
+    APIView,
 ):
     permission_classes = [UploadTestResultsPermission]
     authentication_classes = [

--- a/apps/codecov-api/upload/views/transplant_report.py
+++ b/apps/codecov-api/upload/views/transplant_report.py
@@ -30,7 +30,7 @@ class TransplantReportSerializer(serializers.Serializer):
     to_sha = serializers.CharField(required=True)
 
 
-class TransplantReportView(CreateAPIView, GetterMixin):
+class TransplantReportView(GetterMixin, CreateAPIView):
     permission_classes = [CanDoCoverageUploadsPermission]
     authentication_classes = [
         UploadTokenRequiredAuthenticationCheck,

--- a/apps/codecov-api/upload/views/upload_completion.py
+++ b/apps/codecov-api/upload/views/upload_completion.py
@@ -26,7 +26,7 @@ from upload.views.uploads import CanDoCoverageUploadsPermission
 log = logging.getLogger(__name__)
 
 
-class UploadCompletionView(CreateAPIView, GetterMixin):
+class UploadCompletionView(GetterMixin, CreateAPIView):
     permission_classes = [CanDoCoverageUploadsPermission]
     authentication_classes = [
         UploadTokenRequiredAuthenticationCheck,

--- a/apps/codecov-api/upload/views/upload_coverage.py
+++ b/apps/codecov-api/upload/views/upload_coverage.py
@@ -38,7 +38,7 @@ from upload.views.uploads import (
 log = logging.getLogger(__name__)
 
 
-class UploadCoverageView(APIView, GetterMixin):
+class UploadCoverageView(GetterMixin, APIView):
     permission_classes = [CanDoCoverageUploadsPermission]
     authentication_classes = [
         UploadTokenRequiredAuthenticationCheck,


### PR DESCRIPTION
Reverts a [change I made a while ago](https://github.com/codecov/umbrella/commit/4ba094771448c393f44104673e65372880d7e6c4) to make `ShelterMixin` inherit from `View` and replaces it with proper mixin typing using protocols as suggested by `mypy`.