### PR TITLE
feat: Upload breadcrumbs for create report

### DIFF
--- a/apps/codecov-api/upload/tests/test_upload.py
+++ b/apps/codecov-api/upload/tests/test_upload.py
@@ -65,6 +65,16 @@ COMMIT_PROCESSED_BREADCRUMB_DATA = BreadcrumbData(
     endpoint=Endpoints.LEGACY_UPLOAD_COVERAGE,
 )
 
+PREPARING_FOR_REPORT_BREADCRUMB_DATA = BreadcrumbData(
+    milestone=Milestones.PREPARING_FOR_REPORT,
+    endpoint=Endpoints.LEGACY_UPLOAD_COVERAGE,
+)
+
+READY_FOR_REPORT_BREADCRUMB_DATA = BreadcrumbData(
+    milestone=Milestones.READY_FOR_REPORT,
+    endpoint=Endpoints.LEGACY_UPLOAD_COVERAGE,
+)
+
 
 def mock_get_config_global_upload_tokens(*args):
     if args == ("github", "global_upload_token"):
@@ -1090,14 +1100,7 @@ class UploadHandlerRouteTest(APITestCase):
         response = self._options(kwargs={"version": "v2"})
 
         headers = response.headers
-
-        assert headers["accept"] == "text/*"
-        assert headers["access-control-allow-origin"] == "*"
-        assert headers["access-control-allow-method"] == "POST"
-        assert (
-            headers["access-control-allow-headers"]
-            == "Origin, Content-Type, Accept, X-User-Agent"
-        )
+        assert headers["allow"] == "POST, OPTIONS"
 
     def test_invalid_request_params(self):
         query_params = {"pr": 9838, "flags": "flags!!!", "package": "codecov-cli/0.0.0"}
@@ -1163,12 +1166,6 @@ class UploadHandlerRouteTest(APITestCase):
         assert response.status_code == 200
 
         headers = response.headers
-
-        assert headers["access-control-allow-origin"] == "*"
-        assert (
-            headers["access-control-allow-headers"]
-            == "Origin, Content-Type, Accept, X-User-Agent"
-        )
         assert headers["content-type"] != "text/plain"
 
         archive_service = ArchiveService(self.repo)
@@ -1215,6 +1212,16 @@ class UploadHandlerRouteTest(APITestCase):
                     commit_sha=query_params["commit"],
                     repo_id=self.repo.repoid,
                     breadcrumb_data=COMMIT_PROCESSED_BREADCRUMB_DATA,
+                ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=PREPARING_FOR_REPORT_BREADCRUMB_DATA,
+                ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=READY_FOR_REPORT_BREADCRUMB_DATA,
                 ),
             ]
         )
@@ -1262,12 +1269,6 @@ class UploadHandlerRouteTest(APITestCase):
         assert response.status_code == 200
 
         headers = response.headers
-
-        assert headers["access-control-allow-origin"] == "*"
-        assert (
-            headers["access-control-allow-headers"]
-            == "Origin, Content-Type, Accept, X-User-Agent"
-        )
         assert headers["content-type"] != "text/plain"
 
         archive_service = ArchiveService(self.repo)
@@ -1314,6 +1315,16 @@ class UploadHandlerRouteTest(APITestCase):
                     commit_sha=query_params["commit"],
                     repo_id=self.repo.repoid,
                     breadcrumb_data=COMMIT_PROCESSED_BREADCRUMB_DATA,
+                ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=PREPARING_FOR_REPORT_BREADCRUMB_DATA,
+                ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=READY_FOR_REPORT_BREADCRUMB_DATA,
                 ),
             ]
         )
@@ -1362,12 +1373,6 @@ class UploadHandlerRouteTest(APITestCase):
         assert response.status_code == 400
 
         headers = response.headers
-
-        assert headers["access-control-allow-origin"] == "*"
-        assert (
-            headers["access-control-allow-headers"]
-            == "Origin, Content-Type, Accept, X-User-Agent"
-        )
         assert headers["content-type"] != "text/plain"
 
         assert response.content == b"Could not determine repo and owner"
@@ -1418,12 +1423,6 @@ class UploadHandlerRouteTest(APITestCase):
         assert response.status_code == 400
 
         headers = response.headers
-
-        assert headers["access-control-allow-origin"] == "*"
-        assert (
-            headers["access-control-allow-headers"]
-            == "Origin, Content-Type, Accept, X-User-Agent"
-        )
         assert headers["content-type"] != "text/plain"
 
         assert response.content == b"Found too many repos"
@@ -1505,6 +1504,16 @@ class UploadHandlerRouteTest(APITestCase):
                     repo_id=self.repo.repoid,
                     breadcrumb_data=COMMIT_PROCESSED_BREADCRUMB_DATA,
                 ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=PREPARING_FOR_REPORT_BREADCRUMB_DATA,
+                ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=READY_FOR_REPORT_BREADCRUMB_DATA,
+                ),
             ]
         )
 
@@ -1575,6 +1584,16 @@ class UploadHandlerRouteTest(APITestCase):
                     repo_id=self.repo.repoid,
                     breadcrumb_data=COMMIT_PROCESSED_BREADCRUMB_DATA,
                 ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=PREPARING_FOR_REPORT_BREADCRUMB_DATA,
+                ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=READY_FOR_REPORT_BREADCRUMB_DATA,
+                ),
             ]
         )
 
@@ -1638,12 +1657,6 @@ class UploadHandlerRouteTest(APITestCase):
         assert response.status_code == 400
 
         headers = response.headers
-
-        assert headers["access-control-allow-origin"] == "*"
-        assert (
-            headers["access-control-allow-headers"]
-            == "Origin, Content-Type, Accept, X-User-Agent"
-        )
         assert headers["content-type"] != "text/plain"
 
         assert response.content == b"Could not determine repo and owner"
@@ -1710,12 +1723,6 @@ class UploadHandlerRouteTest(APITestCase):
         assert response.status_code == 400
 
         headers = response.headers
-
-        assert headers["access-control-allow-origin"] == "*"
-        assert (
-            headers["access-control-allow-headers"]
-            == "Origin, Content-Type, Accept, X-User-Agent"
-        )
         assert headers["content-type"] != "text/plain"
 
         assert response.content == b"Found too many repos"

--- a/apps/codecov-api/upload/tests/test_upload_download.py
+++ b/apps/codecov-api/upload/tests/test_upload_download.py
@@ -31,7 +31,7 @@ class UploadDownloadHelperTest(APITestCase):
             kwargs={
                 "service": "gh",
                 "owner_username": "codecovtest",
-                "repo_name": "invalid",
+                "repo_name": "upload-test-repo",
             },
         )
         assert response.status_code == 404
@@ -41,7 +41,7 @@ class UploadDownloadHelperTest(APITestCase):
             kwargs={
                 "service": "gh",
                 "owner_username": "codecovtest",
-                "repo_name": "invalid",
+                "repo_name": "upload-test-repo",
             },
             data={"path": "v2"},
         )
@@ -52,7 +52,7 @@ class UploadDownloadHelperTest(APITestCase):
             kwargs={
                 "service": "gh",
                 "owner_username": "invalid",
-                "repo_name": "invalid",
+                "repo_name": "upload-test-repo",
             },
             data={"path": "v4/raw"},
         )

--- a/apps/codecov-api/upload/views/legacy.py
+++ b/apps/codecov-api/upload/views/legacy.py
@@ -16,6 +16,7 @@ from django.views import View
 from rest_framework import renderers, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
 from rest_framework.views import APIView
 
 from codecov_auth.commands.owner import OwnerCommands
@@ -63,21 +64,7 @@ class UploadHandler(ShelterMixin, APIView):
     permission_classes = [AllowAny]
     renderer_classes = [PlainTextRenderer, renderers.JSONRenderer]
 
-    def get(self, request, *args, **kwargs):
-        return HttpResponse(status=status.HTTP_405_METHOD_NOT_ALLOWED)
-
-    def options(self, request, *args, **kwargs):
-        response = HttpResponse()
-        response["Accept"] = "text/*"
-        response["Access-Control-Allow-Origin"] = "*"
-        response["Access-Control-Allow-Method"] = "POST"
-        response["Access-Control-Allow-Headers"] = (
-            "Origin, Content-Type, Accept, X-User-Agent"
-        )
-
-        return response
-
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args, **kwargs) -> HttpResponse:
         # Extract the version
         version = self.kwargs["version"]
         endpoint = Endpoints.LEGACY_UPLOAD_COVERAGE
@@ -102,12 +89,7 @@ class UploadHandler(ShelterMixin, APIView):
             },
         )
 
-        # Set response headers
         response = HttpResponse()
-        response["Access-Control-Allow-Origin"] = "*"
-        response["Access-Control-Allow-Headers"] = (
-            "Origin, Content-Type, Accept, X-User-Agent"
-        )
 
         # Parse request parameters
         request_params = {

--- a/apps/codecov-api/upload/views/legacy.py
+++ b/apps/codecov-api/upload/views/legacy.py
@@ -1,14 +1,22 @@
 import asyncio
 import logging
 import re
+from collections.abc import Callable
 from json import dumps
+from typing import Any, cast
 from uuid import uuid4
 
 import minio
 from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned
-from django.http import Http404, HttpResponse, HttpResponseServerError
+from django.http import (
+    Http404,
+    HttpRequest,
+    HttpResponse,
+    HttpResponseBase,
+    HttpResponseServerError,
+)
 from django.utils import timezone
 from django.utils.decorators import classonlymethod
 from django.utils.encoding import smart_str
@@ -21,6 +29,7 @@ from rest_framework.views import APIView
 
 from codecov_auth.commands.owner import OwnerCommands
 from core.commands.repository import RepositoryCommands
+from core.models import Repository
 from services.analytics import AnalyticsService
 from services.task import TaskService
 from shared.api_archive.archive import ArchiveService
@@ -58,15 +67,17 @@ class PlainTextRenderer(renderers.BaseRenderer):
     media_type = "text/plain"
     format = "txt"
 
-    def render(self, data, media_type=None, renderer_context=None):
-        return smart_str(data, encoding=self.charset)
+    def render(
+        self, data: Any, media_type: str | None = None, renderer_context: Any = None
+    ) -> str:
+        return smart_str(data, encoding=cast(str, self.charset))
 
 
 class UploadHandler(ShelterMixin, APIView):
     permission_classes = [AllowAny]
     renderer_classes = [PlainTextRenderer, renderers.JSONRenderer]
 
-    def post(self, request: Request, *args, **kwargs) -> HttpResponse:
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         # Extract the version
         version = self.kwargs["version"]
         endpoint = Endpoints.LEGACY_UPLOAD_COVERAGE
@@ -386,12 +397,12 @@ class UploadHandler(ShelterMixin, APIView):
 
 class UploadDownloadHandler(View):
     @classonlymethod
-    def as_view(_, **initkwargs):
+    def as_view(_, **initkwargs: Any) -> Callable[..., HttpResponseBase]:
         view = super().as_view(**initkwargs)
         view._is_coroutine = asyncio.coroutines._is_coroutine
         return view
 
-    async def get_repo(self):
+    async def get_repo(self) -> Repository:
         owner = await OwnerCommands(
             self.request.current_owner, self.service
         ).fetch_owner(self.owner_username)
@@ -409,7 +420,7 @@ class UploadDownloadHandler(View):
         return repo
 
     @sync_to_async
-    def validate_path(self, repo):
+    def validate_path(self, repo: Repository) -> None:
         msg = "Requested report could not be found"
         if not self.path:
             raise Http404(msg)
@@ -419,7 +430,7 @@ class UploadDownloadHandler(View):
 
             # Verify that the repo hash in the path matches the repo in the URL by generating the repo hash
             archive_service = ArchiveService(repo)
-            if archive_service.storage_hash not in self.path:
+            if cast(str, archive_service.storage_hash) not in self.path:
                 raise Http404(msg)
         elif self.path.startswith("shelter/"):
             # Shelter upload
@@ -431,19 +442,19 @@ class UploadDownloadHandler(View):
             # unexpected path structure
             raise Http404(msg)
 
-    def read_params(self):
+    def read_params(self) -> None:
         self.path = self.request.GET.get("path")
         self.service = get_long_service_name(self.kwargs.get("service"))
         self.repo_name = self.kwargs.get("repo_name")
         self.owner_username = self.kwargs.get("owner_username")
 
     @sync_to_async
-    def get_presigned_url(self, repo):
+    def get_presigned_url(self, repo: Repository) -> str:
         archive_service = ArchiveService(repo)
 
         try:
             return archive_service.storage.create_presigned_get(
-                archive_service.root, self.path, expires=30
+                archive_service.root, cast(str, self.path), expires=30
             )
         except minio.error.S3Error as e:
             if e.code == "NoSuchKey":
@@ -451,7 +462,9 @@ class UploadDownloadHandler(View):
             else:
                 raise
 
-    async def get(self, request, *args, **kwargs):
+    async def get(
+        self, request: HttpRequest, *args: Any, **kwargs: Any
+    ) -> HttpResponse:
         await self._get_user(request)
 
         self.read_params()
@@ -463,7 +476,7 @@ class UploadDownloadHandler(View):
         return response
 
     @sync_to_async
-    def _get_user(self, request):
+    def _get_user(self, request: HttpRequest) -> None:
         # force eager evaluation of `request.user` (a lazy object)
         # while we're in a sync context
         if request.user:

--- a/apps/codecov-api/upload/views/reports.py
+++ b/apps/codecov-api/upload/views/reports.py
@@ -2,9 +2,9 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from django.http import HttpRequest, HttpResponseNotAllowed
 from rest_framework import status
-from rest_framework.generics import ListCreateAPIView
+from rest_framework.generics import CreateAPIView
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -48,7 +48,7 @@ def create_report(
     return instance
 
 
-class ReportViews(ListCreateAPIView, GetterMixin):
+class ReportViews(GetterMixin, CreateAPIView):
     serializer_class = CommitReportSerializer
     permission_classes = [CanDoCoverageUploadsPermission]
     authentication_classes = [
@@ -94,12 +94,6 @@ class ReportViews(ListCreateAPIView, GetterMixin):
                 position="end",
             ),
         )
-        return instance
-
-    def list(
-        self, request: HttpRequest, service: str, repo: str, commit_sha: str
-    ) -> HttpResponseNotAllowed:
-        return HttpResponseNotAllowed(permitted_methods=["POST"])
 
 
 EMPTY_RESPONSE = {
@@ -122,11 +116,13 @@ class ReportResultsView(APIView, GetterMixin):
         TokenlessAuthentication,
     ]
 
-    def get_exception_handler(self) -> Callable[[Exception, dict[str, Any]], Response]:
+    def get_exception_handler(
+        self,
+    ) -> Callable[[Exception, dict[str, Any]], Response | None]:
         return repo_auth_custom_exception_handler
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args, **kwargs) -> Response:
         return Response(EMPTY_RESPONSE)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args, **kwargs) -> Response:
         return Response(EMPTY_RESPONSE, status=status.HTTP_201_CREATED)

--- a/apps/codecov-api/upload/views/reports.py
+++ b/apps/codecov-api/upload/views/reports.py
@@ -1,11 +1,12 @@
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from rest_framework import status
 from rest_framework.generics import CreateAPIView
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.serializers import BaseSerializer
 from rest_framework.views import APIView
 
 from codecov_auth.authentication.repo_auth import (
@@ -20,9 +21,16 @@ from codecov_auth.authentication.repo_auth import (
 from core.models import Commit, Repository
 from reports.models import CommitReport
 from services.task import TaskService
+from shared.django_apps.upload_breadcrumbs.models import (
+    BreadcrumbData,
+    Endpoints,
+    Errors,
+    Milestones,
+)
 from shared.metrics import inc_counter
 from upload.helpers import (
     generate_upload_prometheus_metrics_labels,
+    upload_breadcrumb_context,
     validate_activated_repo,
 )
 from upload.metrics import API_UPLOAD_COUNTER
@@ -34,7 +42,10 @@ log = logging.getLogger(__name__)
 
 
 def create_report(
-    serializer: CommitReportSerializer, repository: Repository, commit: Commit
+    serializer: CommitReportSerializer,
+    repository: Repository,
+    commit: Commit,
+    endpoint: Endpoints,
 ) -> CommitReport:
     code = serializer.validated_data.get("code")
     if code == "default":
@@ -45,6 +56,15 @@ def create_report(
     )
     if was_created:
         TaskService().preprocess_upload(repository.repoid, commit.commitid)
+    else:
+        TaskService().upload_breadcrumb(
+            commit_sha=commit.commitid,
+            repo_id=repository.repoid,
+            breadcrumb_data=BreadcrumbData(
+                milestone=Milestones.READY_FOR_REPORT,
+                endpoint=endpoint,
+            ),
+        )
     return instance
 
 
@@ -60,10 +80,13 @@ class ReportViews(GetterMixin, CreateAPIView):
         TokenlessAuthentication,
     ]
 
-    def get_exception_handler(self) -> Callable[[Exception, dict[str, Any]], Response]:
+    def get_exception_handler(
+        self,
+    ) -> Callable[[Exception, dict[str, Any]], Response | None]:
         return repo_auth_custom_exception_handler
 
-    def perform_create(self, serializer: CommitReportSerializer) -> CommitReport:
+    def perform_create(self, serializer: BaseSerializer) -> None:
+        endpoint = Endpoints.CREATE_REPORT
         inc_counter(
             API_UPLOAD_COUNTER,
             labels=generate_upload_prometheus_metrics_labels(
@@ -75,13 +98,34 @@ class ReportViews(GetterMixin, CreateAPIView):
             ),
         )
         repository = self.get_repo()
-        validate_activated_repo(repository)
-        commit = self.get_commit(repository)
+
+        with upload_breadcrumb_context(
+            initial_breadcrumb=True,
+            commit_sha=self.kwargs.get("commit_sha"),
+            repo_id=repository.repoid,
+            milestone=Milestones.PREPARING_FOR_REPORT,
+            endpoint=endpoint,
+            error=Errors.REPO_DEACTIVATED,
+        ):
+            validate_activated_repo(repository)
+
+        with upload_breadcrumb_context(
+            initial_breadcrumb=False,
+            commit_sha=self.kwargs.get("commit_sha"),
+            repo_id=repository.repoid,
+            milestone=Milestones.PREPARING_FOR_REPORT,
+            endpoint=endpoint,
+            error=Errors.COMMIT_NOT_FOUND,
+        ):
+            commit = self.get_commit(repository)
+
         log.info(
             "Request to create new report",
             extra={"repo": repository.name, "commit": commit.commitid},
         )
-        instance = create_report(serializer, repository, commit)
+        create_report(
+            cast(CommitReportSerializer, serializer), repository, commit, endpoint
+        )
 
         inc_counter(
             API_UPLOAD_COUNTER,
@@ -121,8 +165,8 @@ class ReportResultsView(APIView, GetterMixin):
     ) -> Callable[[Exception, dict[str, Any]], Response | None]:
         return repo_auth_custom_exception_handler
 
-    def get(self, request: Request, *args, **kwargs) -> Response:
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return Response(EMPTY_RESPONSE)
 
-    def post(self, request: Request, *args, **kwargs) -> Response:
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return Response(EMPTY_RESPONSE, status=status.HTTP_201_CREATED)

--- a/apps/codecov-api/upload/views/upload_coverage.py
+++ b/apps/codecov-api/upload/views/upload_coverage.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import Callable
+from typing import Any
 
 from django.conf import settings
 from rest_framework import status
@@ -56,7 +58,9 @@ class UploadCoverageView(GetterMixin, APIView):
     ]
     throttle_classes = [UploadsPerCommitThrottle, UploadsPerWindowThrottle]
 
-    def get_exception_handler(self):
+    def get_exception_handler(
+        self,
+    ) -> Callable[[Exception, dict[str, Any]], Response | None]:
         return repo_auth_custom_exception_handler
 
     def emit_metrics(self, position: str) -> None:
@@ -71,7 +75,7 @@ class UploadCoverageView(GetterMixin, APIView):
             ),
         )
 
-    def post(self, request: Request, *args, **kwargs) -> Response:
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         self.emit_metrics(position="start")
         endpoint = Endpoints.UPLOAD_COVERAGE
 

--- a/libs/shared/shared/django_apps/upload_breadcrumbs/models.py
+++ b/libs/shared/shared/django_apps/upload_breadcrumbs/models.py
@@ -62,10 +62,12 @@ class Errors(models.TextChoices):
     Possible errors for an upload breadcrumb.
     """
 
+    BAD_REQUEST = "br", _("Bad request, see API response for details")
     REPO_DEACTIVATED = "rd", _("Repository is deactivated within Codecov")
     REPO_MISSING_VALID_BOT = "rmb", _("Repository is missing a valid bot")
     REPO_NOT_FOUND = "rnf", _("Repository not found by the configured bot")
     REPO_BLACKLISTED = "rb", _("Repository is blacklisted by Codecov")
+    COMMIT_NOT_FOUND = "cnf", _("Commit not found in the repository")
     COMMIT_UPLOAD_LIMIT = "cul", _("Upload limit exceeded for this commit")
     OWNER_UPLOAD_LIMIT = "oul", _("Owner (user or team) upload limit exceeded")
     GIT_CLIENT_ERROR = "gce", _("Git client returned a 4xx error")
@@ -73,6 +75,9 @@ class Errors(models.TextChoices):
     MALFORMED_INPUT = "mi", _("Malformed coverage report input")
     UNRECOGNIZED_FORMAT = "uf", _("Unrecognized coverage report format")
     TASK_TIMED_OUT = "tto", _("Task timed out")
+    # Errors that should not be shown to the user
+    INTERNAL_LOCK_ERROR = "int_le", _("Unable to acquire or release lock")
+    # Catch-all for other errors
     UNKNOWN = "u", _("Unknown error")
 
 


### PR DESCRIPTION
* Upload breadcrumbs for create report step
  * Added to create report, coverage upload, and legacy endpoint uploads
  * Added to pre-process upload worker task
* Simplified some view logic so that returning method not allowed is not necessary and is handled by the rest framework library automatically