### PR TITLE
fix: aggregate test results from TA hypertable if data's not in CAs

### DIFF
--- a/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_test_results_timescale_branch__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_test_results_timescale_branch__0.json
@@ -1,0 +1,93 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "testResults": {
+          "totalCount": 5,
+          "edges": [
+            {
+              "cursor": "NC4wfG5hbWU0",
+              "node": {
+                "name": "name4",
+                "failureRate": 0.0,
+                "flakeRate": 0.0,
+                "avgDuration": 4.0,
+                "totalDuration": 4.0,
+                "totalFailCount": 0,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 1,
+                "totalSkipCount": 0,
+                "commitsFailed": 0,
+                "lastDuration": 4.0
+              }
+            },
+            {
+              "cursor": "My4wfG5hbWUz",
+              "node": {
+                "name": "name3",
+                "failureRate": 1.0,
+                "flakeRate": 0.0,
+                "avgDuration": 3.0,
+                "totalDuration": 3.0,
+                "totalFailCount": 1,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 0,
+                "totalSkipCount": 0,
+                "commitsFailed": 1,
+                "lastDuration": 3.0
+              }
+            },
+            {
+              "cursor": "Mi4wfG5hbWUy",
+              "node": {
+                "name": "name2",
+                "failureRate": 0.0,
+                "flakeRate": 0.0,
+                "avgDuration": 2.0,
+                "totalDuration": 2.0,
+                "totalFailCount": 0,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 1,
+                "totalSkipCount": 0,
+                "commitsFailed": 0,
+                "lastDuration": 2.0
+              }
+            },
+            {
+              "cursor": "MS4wfG5hbWUx",
+              "node": {
+                "name": "name1",
+                "failureRate": 1.0,
+                "flakeRate": 0.0,
+                "avgDuration": 1.0,
+                "totalDuration": 1.0,
+                "totalFailCount": 1,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 0,
+                "totalSkipCount": 0,
+                "commitsFailed": 1,
+                "lastDuration": 1.0
+              }
+            },
+            {
+              "cursor": "MC4wfG5hbWUw",
+              "node": {
+                "name": "name0",
+                "failureRate": 0.0,
+                "flakeRate": 0.0,
+                "avgDuration": 0.0,
+                "totalDuration": 0.0,
+                "totalFailCount": 0,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 1,
+                "totalSkipCount": 0,
+                "commitsFailed": 0,
+                "lastDuration": 0.0
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_test_results_timescale_non_precomputed_branch__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_test_results_timescale_non_precomputed_branch__0.json
@@ -1,0 +1,93 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "testResults": {
+          "totalCount": 5,
+          "edges": [
+            {
+              "cursor": "NC4wfG5hbWU0",
+              "node": {
+                "name": "name4",
+                "failureRate": 0.0,
+                "flakeRate": 0.0,
+                "avgDuration": 4.0,
+                "totalDuration": 4.0,
+                "totalFailCount": 0,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 1,
+                "totalSkipCount": 0,
+                "commitsFailed": 0,
+                "lastDuration": 4.0
+              }
+            },
+            {
+              "cursor": "My4wfG5hbWUz",
+              "node": {
+                "name": "name3",
+                "failureRate": 1.0,
+                "flakeRate": 0.0,
+                "avgDuration": 3.0,
+                "totalDuration": 3.0,
+                "totalFailCount": 1,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 0,
+                "totalSkipCount": 0,
+                "commitsFailed": 1,
+                "lastDuration": 3.0
+              }
+            },
+            {
+              "cursor": "Mi4wfG5hbWUy",
+              "node": {
+                "name": "name2",
+                "failureRate": 0.0,
+                "flakeRate": 0.0,
+                "avgDuration": 2.0,
+                "totalDuration": 2.0,
+                "totalFailCount": 0,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 1,
+                "totalSkipCount": 0,
+                "commitsFailed": 0,
+                "lastDuration": 2.0
+              }
+            },
+            {
+              "cursor": "MS4wfG5hbWUx",
+              "node": {
+                "name": "name1",
+                "failureRate": 1.0,
+                "flakeRate": 0.0,
+                "avgDuration": 1.0,
+                "totalDuration": 1.0,
+                "totalFailCount": 1,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 0,
+                "totalSkipCount": 0,
+                "commitsFailed": 1,
+                "lastDuration": 1.0
+              }
+            },
+            {
+              "cursor": "MC4wfG5hbWUw",
+              "node": {
+                "name": "name0",
+                "failureRate": 0.0,
+                "flakeRate": 0.0,
+                "avgDuration": 0.0,
+                "totalDuration": 0.0,
+                "totalFailCount": 0,
+                "totalFlakyFailCount": 0,
+                "totalPassCount": 1,
+                "totalSkipCount": 0,
+                "commitsFailed": 0,
+                "lastDuration": 0.0
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
@@ -15,7 +15,7 @@ from .helper import GraphQLTestHelper
 def repository():
     owner = OwnerFactory(username="codecov-user")
     repo = RepositoryFactory(
-        author=owner, name="testRepoName", active=True, branch="main"
+        repoid=1, author=owner, name="testRepoName", active=True, branch="main"
     )
 
     return repo
@@ -142,7 +142,7 @@ class TestAnalyticsTestCaseNew(GraphQLTestHelper):
 
         assert snapshot("json") == result
 
-    def test_gql_query_test_results_timescale_empty_parameter(
+    def test_gql_query_test_results_timescale_branch(
         self, repository, populate_timescale, snapshot
     ):
         query = f"""
@@ -152,6 +152,45 @@ class TestAnalyticsTestCaseNew(GraphQLTestHelper):
                         ... on Repository {{
                             testAnalytics {{
                                 testResults(filters: {{branch: "main"}}) {{
+                                    totalCount
+                                    edges {{
+                                        cursor
+                                        node {{
+                                            name
+                                            failureRate
+                                            flakeRate
+                                            avgDuration
+                                            totalDuration
+                                            totalFailCount
+                                            totalFlakyFailCount
+                                            totalPassCount
+                                            totalSkipCount
+                                            commitsFailed
+                                            lastDuration
+                                        }}
+                                    }}
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        result = self.gql_request(query, owner=repository.author)
+
+        assert snapshot("json") == result
+
+    def test_gql_query_test_results_timescale_non_precomputed_branch(
+        self, repository, populate_timescale, snapshot
+    ):
+        query = f"""
+            query {{
+                owner(username: "{repository.author.username}") {{
+                    repository(name: "{repository.name}") {{
+                        ... on Repository {{
+                            testAnalytics {{
+                                testResults(filters: {{branch: "feature"}}) {{
                                     totalCount
                                     edges {{
                                         cursor

--- a/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
+++ b/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
@@ -360,7 +360,7 @@ async def resolve_test_results(
             term=term,
         )
 
-        return await queryset_to_connection(
+        connection = await queryset_to_connection(
             aggregated_queryset,
             ordering=(ordering_param, "name"),
             ordering_direction=(ordering_direction, OrderingDirection.DESC),
@@ -370,6 +370,7 @@ async def resolve_test_results(
             before=before,
         )
 
+        return connection
     else:
         queryset = await sync_to_async(generate_test_results)(
             ordering=ordering.get(


### PR DESCRIPTION
Fixes CCMRG-1395

the continuous aggregates only rollup raw testrun data at a branch level
granularity for certain branches. For branches that aren't being rolled up we
can't fetch the data from CAs, instead we have to aggrgate directly from the
testrun hypertable.

We don't have to compute test results aggregates or flake aggregates yet, as
that adds too much complexity for now, and we'll probably test out a new CA
where we compute rollups for all branches before we build that.