### PR TITLE
fix: Repo deletion fails for subsequent deletes on a single owner

### DIFF
--- a/apps/worker/services/cleanup/repository.py
+++ b/apps/worker/services/cleanup/repository.py
@@ -88,7 +88,7 @@ def start_repo_cleanup(repo_id: int) -> tuple[bool, int]:
 
         # We mark the repository as "scheduled for deletion" by setting the `deleted`
         # flag, moving it to a new shadow owner, and clearing some tokens.
-        shadow_owner = Owner.objects.get_or_create(
+        shadow_owner, _ = Owner.objects.get_or_create(
             # `Owner` is unique across service/id, and both are non-NULL,
             # so we cannot duplicate the values just like that, so lets change up the `service_id`
             # a bit. We need the `Repository.service_id` for further `ArchiveService` deletions.

--- a/apps/worker/services/cleanup/repository.py
+++ b/apps/worker/services/cleanup/repository.py
@@ -88,7 +88,7 @@ def start_repo_cleanup(repo_id: int) -> tuple[bool, int]:
 
         # We mark the repository as "scheduled for deletion" by setting the `deleted`
         # flag, moving it to a new shadow owner, and clearing some tokens.
-        shadow_owner = Owner.objects.create(
+        shadow_owner = Owner.objects.get_or_create(
             # `Owner` is unique across service/id, and both are non-NULL,
             # so we cannot duplicate the values just like that, so lets change up the `service_id`
             # a bit. We need the `Repository.service_id` for further `ArchiveService` deletions.


### PR DESCRIPTION
Fixes https://codecov.sentry.io/issues/6549361454/?project=4165036&query=is%3Aunresolved%20trace%3A37f1d2bb4969402da3709c31ff58ced3&referrer=issue-stream

Repo deletes after the first one were failing because we are trying to create a shadow owner that already exists.
