### PR TITLE
fix: fields that can be null in TA upload endpoint

### DIFF
--- a/apps/codecov-api/upload/views/test_results.py
+++ b/apps/codecov-api/upload/views/test_results.py
@@ -44,12 +44,12 @@ class UploadTestResultsPermission(BasePermission):
 class UploadSerializer(serializers.Serializer):
     commit = serializers.CharField(required=True)
     slug = serializers.CharField(required=True)
-    service = serializers.CharField(required=False)  # git_service
-    build = serializers.CharField(required=False)
-    buildUrl = serializers.CharField(required=False)
-    code = serializers.CharField(required=False)
-    flags = FlagListField(required=False)
-    pr = serializers.CharField(required=False)
+    service = serializers.CharField(required=False, allow_null=True)  # git_service
+    build = serializers.CharField(required=False, allow_null=True)
+    buildUrl = serializers.CharField(required=False, allow_null=True)
+    code = serializers.CharField(required=False, allow_null=True)
+    flags = FlagListField(required=False, allow_null=True)
+    pr = serializers.CharField(required=False, allow_null=True)
     branch = serializers.CharField(required=False, allow_null=True)
     storage_path = serializers.CharField(required=False)
     file_not_found = serializers.BooleanField(required=False)


### PR DESCRIPTION
these fields can all be `None` later in the code, we don't care if the client chooses to express this by omitting them or by setting them to null because those mean the same thing. We don't want to error if we receive a null value for any of these fields.