### PR TITLE
feat(api): Upload breadcrumbs for waiting on coverage upload and notifications triggered

### DIFF
--- a/apps/codecov-api/codecov_auth/authentication/types.py
+++ b/apps/codecov-api/codecov_auth/authentication/types.py
@@ -1,26 +1,32 @@
+from abc import ABC, abstractmethod
+
 from django.contrib.auth.models import Group, Permission
 from django.db.models.manager import EmptyManager
 
 from core.models import Repository
+from shared.django_apps.codecov_auth.models import TokenTypeChoices
 
 
 class RepositoryAsUser:
-    def __init__(self, repository):
+    def __init__(self, repository: Repository):
         self._repository = repository
 
-    def is_authenticated(self):
+    def is_authenticated(self) -> bool:
         return True
 
 
-class RepositoryAuthInterface:
-    def get_scopes():
-        raise NotImplementedError()
+class RepositoryAuthInterface(ABC):
+    @abstractmethod
+    def get_scopes(self) -> list[str] | list[TokenTypeChoices]:
+        pass
 
-    def get_repositories() -> list[Repository]:
-        raise NotImplementedError()
+    @abstractmethod
+    def get_repositories(self) -> list[Repository]:
+        pass
 
+    @abstractmethod
     def allows_repo(self, repository: Repository) -> bool:
-        raise NotImplementedError()
+        pass
 
 
 class DjangoUser:
@@ -33,19 +39,19 @@ class DjangoUser:
     _user_permissions = EmptyManager(Permission)
 
     @property
-    def is_anonymous(self):
+    def is_anonymous(self) -> bool:
         return False
 
     @property
-    def is_authenticated(self):
+    def is_authenticated(self) -> bool:
         return False
 
     @property
-    def groups(self):
+    def groups(self) -> bool:
         return False
 
     @property
-    def user_permissions(self):
+    def user_permissions(self) -> bool:
         return False
 
     def get_user_permissions(self, obj=None):

--- a/apps/codecov-api/upload/tests/test_upload.py
+++ b/apps/codecov-api/upload/tests/test_upload.py
@@ -75,6 +75,11 @@ READY_FOR_REPORT_BREADCRUMB_DATA = BreadcrumbData(
     endpoint=Endpoints.LEGACY_UPLOAD_COVERAGE,
 )
 
+WAITING_FOR_COVERAGE_UPLOAD_BREADCRUMB_DATA = BreadcrumbData(
+    milestone=Milestones.WAITING_FOR_COVERAGE_UPLOAD,
+    endpoint=Endpoints.LEGACY_UPLOAD_COVERAGE,
+)
+
 
 def mock_get_config_global_upload_tokens(*args):
     if args == ("github", "global_upload_token"):
@@ -1514,6 +1519,11 @@ class UploadHandlerRouteTest(APITestCase):
                     repo_id=self.repo.repoid,
                     breadcrumb_data=READY_FOR_REPORT_BREADCRUMB_DATA,
                 ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=WAITING_FOR_COVERAGE_UPLOAD_BREADCRUMB_DATA,
+                ),
             ]
         )
 
@@ -1593,6 +1603,11 @@ class UploadHandlerRouteTest(APITestCase):
                     commit_sha=query_params["commit"],
                     repo_id=self.repo.repoid,
                     breadcrumb_data=READY_FOR_REPORT_BREADCRUMB_DATA,
+                ),
+                call(
+                    commit_sha=query_params["commit"],
+                    repo_id=self.repo.repoid,
+                    breadcrumb_data=WAITING_FOR_COVERAGE_UPLOAD_BREADCRUMB_DATA,
                 ),
             ]
         )

--- a/apps/codecov-api/upload/tests/views/test_upload_coverage.py
+++ b/apps/codecov-api/upload/tests/views/test_upload_coverage.py
@@ -177,6 +177,15 @@ def test_upload_coverage_with_errors(db, mocker):
                     endpoint=Endpoints.UPLOAD_COVERAGE,
                 ),
             ),
+            call(
+                commit_sha="abc1234",
+                repo_id=repository.repoid,
+                breadcrumb_data=BreadcrumbData(
+                    milestone=Milestones.WAITING_FOR_COVERAGE_UPLOAD,
+                    endpoint=Endpoints.UPLOAD_COVERAGE,
+                    error=Errors.BAD_REQUEST,
+                ),
+            ),
         ]
     )
 
@@ -315,6 +324,14 @@ def test_upload_coverage_post(db, mocker):
                     endpoint=Endpoints.UPLOAD_COVERAGE,
                 ),
             ),
+            call(
+                commit_sha=commit.commitid,
+                repo_id=repository.repoid,
+                breadcrumb_data=BreadcrumbData(
+                    milestone=Milestones.WAITING_FOR_COVERAGE_UPLOAD,
+                    endpoint=Endpoints.UPLOAD_COVERAGE,
+                ),
+            ),
         ]
     )
 
@@ -434,6 +451,14 @@ def test_upload_coverage_post_shelter(db, mocker):
                 repo_id=repository.repoid,
                 breadcrumb_data=BreadcrumbData(
                     milestone=Milestones.PREPARING_FOR_REPORT,
+                    endpoint=Endpoints.UPLOAD_COVERAGE,
+                ),
+            ),
+            call(
+                commit_sha=commit.commitid,
+                repo_id=repository.repoid,
+                breadcrumb_data=BreadcrumbData(
+                    milestone=Milestones.WAITING_FOR_COVERAGE_UPLOAD,
                     endpoint=Endpoints.UPLOAD_COVERAGE,
                 ),
             ),

--- a/apps/codecov-api/upload/tests/views/test_uploads.py
+++ b/apps/codecov-api/upload/tests/views/test_uploads.py
@@ -18,12 +18,18 @@ from reports.models import (
     UploadFlagMembership,
 )
 from reports.tests.factories import CommitReportFactory, UploadFactory
+from services.task.task import TaskService
 from shared.api_archive.archive import ArchiveService, MinioEndpoints
 from shared.django_apps.codecov_auth.tests.factories import PlanFactory, TierFactory
 from shared.django_apps.core.tests.factories import (
     CommitFactory,
     OwnerFactory,
     RepositoryFactory,
+)
+from shared.django_apps.upload_breadcrumbs.models import (
+    BreadcrumbData,
+    Endpoints,
+    Milestones,
 )
 from shared.plan.constants import PlanName, TierName
 from shared.utils.test_utils import mock_config_helper
@@ -328,6 +334,7 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
         "upload.views.uploads.trigger_upload_task", return_value=True
     )
     analytics_service_mock = mocker.patch("upload.views.uploads.AnalyticsService")
+    mock_upload_breadcrumb = mocker.patch.object(TaskService, "upload_breadcrumb")
 
     repository = RepositoryFactory(
         name="the_repo",
@@ -438,9 +445,18 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
                 "uploader_type": "CLI",
             },
         )
+        mock_upload_breadcrumb.assert_called_once_with(
+            commit_sha=commit.commitid,
+            repo_id=repository.repoid,
+            breadcrumb_data=BreadcrumbData(
+                milestone=Milestones.WAITING_FOR_COVERAGE_UPLOAD,
+                endpoint=Endpoints.DO_UPLOAD,
+            ),
+        )
     else:
         assert response.status_code == 401
         assert response.json().get("detail") == "Not valid tokenless upload"
+        mock_upload_breadcrumb.assert_not_called()
 
 
 @pytest.mark.parametrize("private", [False, True])
@@ -466,6 +482,7 @@ def test_uploads_post_token_required_auth_check(
         "upload.views.uploads.trigger_upload_task", return_value=True
     )
     analytics_service_mock = mocker.patch("upload.views.uploads.AnalyticsService")
+    mock_upload_breadcrumb = mocker.patch.object(TaskService, "upload_breadcrumb")
 
     repository = RepositoryFactory(
         name="the_repo",
@@ -583,9 +600,18 @@ def test_uploads_post_token_required_auth_check(
                 "uploader_type": "CLI",
             },
         )
+        mock_upload_breadcrumb.assert_called_once_with(
+            commit_sha=commit.commitid,
+            repo_id=repository.repoid,
+            breadcrumb_data=BreadcrumbData(
+                milestone=Milestones.WAITING_FOR_COVERAGE_UPLOAD,
+                endpoint=Endpoints.DO_UPLOAD,
+            ),
+        )
     else:
         assert response.status_code == 401
         assert response.json().get("detail") == "Not valid tokenless upload"
+        mock_upload_breadcrumb.assert_not_called()
 
 
 @patch("upload.views.uploads.AnalyticsService")
@@ -606,6 +632,7 @@ def test_uploads_post_github_oidc_auth(
     upload_task_mock = mocker.patch(
         "upload.views.uploads.trigger_upload_task", return_value=True
     )
+    mock_upload_breadcrumb = mocker.patch.object(TaskService, "upload_breadcrumb")
 
     repository = RepositoryFactory(
         name="the_repo",
@@ -709,6 +736,14 @@ def test_uploads_post_github_oidc_auth(
             "version": "version",
             "uploader_type": "CLI",
         },
+    )
+    mock_upload_breadcrumb.assert_called_once_with(
+        commit_sha=commit.commitid,
+        repo_id=repository.repoid,
+        breadcrumb_data=BreadcrumbData(
+            milestone=Milestones.WAITING_FOR_COVERAGE_UPLOAD,
+            endpoint=Endpoints.DO_UPLOAD,
+        ),
     )
 
 
@@ -871,6 +906,9 @@ class TestGitlabEnterpriseOIDC(APITestCase):
             return_value="presigned put",
         )
         self.mocker.patch("upload.views.uploads.trigger_upload_task", return_value=True)
+        mock_upload_breadcrumb = self.mocker.patch.object(
+            TaskService, "upload_breadcrumb"
+        )
 
         repository = RepositoryFactory(
             name="the_repo",
@@ -912,6 +950,14 @@ class TestGitlabEnterpriseOIDC(APITestCase):
         assert response.status_code == 201
         mock_jwks_client.assert_called_with(
             "https://example.com/_services/token/.well-known/jwks"
+        )
+        mock_upload_breadcrumb.assert_called_once_with(
+            commit_sha=commit.commitid,
+            repo_id=repository.repoid,
+            breadcrumb_data=BreadcrumbData(
+                milestone=Milestones.WAITING_FOR_COVERAGE_UPLOAD,
+                endpoint=Endpoints.DO_UPLOAD,
+            ),
         )
 
     @patch("upload.views.uploads.AnalyticsService")

--- a/apps/codecov-api/upload/tests/views/test_uploads.py
+++ b/apps/codecov-api/upload/tests/views/test_uploads.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIClient, APITestCase
 
 from billing.tests.mocks import mock_all_plans_and_tiers
 from codecov_auth.authentication.repo_auth import OrgLevelTokenRepositoryAuth
+from codecov_auth.authentication.types import RepositoryAuthInterface
 from codecov_auth.services.org_level_token_service import OrgLevelTokenService
 from reports.models import (
     CommitReport,
@@ -35,10 +36,10 @@ from upload.views.uploads import (
 
 
 def test_upload_permission_class_pass(db, mocker):
-    request_mocked = MagicMock(auth=MagicMock())
+    request_mocked = MagicMock(auth=MagicMock(spec=RepositoryAuthInterface))
     request_mocked.auth.get_scopes.return_value = ["upload"]
     permission = CanDoCoverageUploadsPermission()
-    assert permission.has_permission(request_mocked, MagicMock())
+    assert permission.has_permission(request_mocked, MagicMock(spec=UploadViews))
     request_mocked.auth.get_scopes.assert_called_once()
 
 
@@ -52,7 +53,7 @@ def test_upload_permission_orglevel_token(db, mocker):
     token = OrgLevelTokenService.get_or_create_org_token(owner)
 
     request_mocked = MagicMock(auth=OrgLevelTokenRepositoryAuth(token))
-    mocked_view = MagicMock()
+    mocked_view = MagicMock(spec=UploadViews)
     mocked_view.get_repo = MagicMock(return_value=repo)
     permission = CanDoCoverageUploadsPermission()
     assert permission.has_permission(request_mocked, mocked_view)
@@ -60,10 +61,10 @@ def test_upload_permission_orglevel_token(db, mocker):
 
 
 def test_upload_permission_class_fail(db, mocker):
-    request_mocked = MagicMock(auth=MagicMock())
+    request_mocked = MagicMock(auth=MagicMock(spec=RepositoryAuthInterface))
     request_mocked.auth.get_scopes.return_value = ["wrong_scope"]
     permission = CanDoCoverageUploadsPermission()
-    assert not permission.has_permission(request_mocked, MagicMock())
+    assert not permission.has_permission(request_mocked, MagicMock(spec=UploadViews))
     request_mocked.auth.get_scopes.assert_called_once()
 
 
@@ -77,7 +78,7 @@ def test_upload_permission_orglevel_fail(db, mocker):
     token = OrgLevelTokenService.get_or_create_org_token(owner)
 
     request_mocked = MagicMock(auth=OrgLevelTokenRepositoryAuth(token))
-    mocked_view = MagicMock()
+    mocked_view = MagicMock(spec=UploadViews)
     mocked_view.get_repo = MagicMock(return_value=repo)
     permission = CanDoCoverageUploadsPermission()
     assert not permission.has_permission(request_mocked, mocked_view)

--- a/apps/codecov-api/upload/views/reports.py
+++ b/apps/codecov-api/upload/views/reports.py
@@ -87,6 +87,7 @@ class ReportViews(GetterMixin, CreateAPIView):
 
     def perform_create(self, serializer: BaseSerializer) -> None:
         endpoint = Endpoints.CREATE_REPORT
+        milestone = Milestones.PREPARING_FOR_REPORT
         inc_counter(
             API_UPLOAD_COUNTER,
             labels=generate_upload_prometheus_metrics_labels(
@@ -103,7 +104,7 @@ class ReportViews(GetterMixin, CreateAPIView):
             initial_breadcrumb=True,
             commit_sha=self.kwargs.get("commit_sha"),
             repo_id=repository.repoid,
-            milestone=Milestones.PREPARING_FOR_REPORT,
+            milestone=milestone,
             endpoint=endpoint,
             error=Errors.REPO_DEACTIVATED,
         ):
@@ -113,7 +114,7 @@ class ReportViews(GetterMixin, CreateAPIView):
             initial_breadcrumb=False,
             commit_sha=self.kwargs.get("commit_sha"),
             repo_id=repository.repoid,
-            milestone=Milestones.PREPARING_FOR_REPORT,
+            milestone=milestone,
             endpoint=endpoint,
             error=Errors.COMMIT_NOT_FOUND,
         ):

--- a/apps/codecov-api/upload/views/transplant_report.py
+++ b/apps/codecov-api/upload/views/transplant_report.py
@@ -2,9 +2,9 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from django.http import HttpRequest
 from rest_framework import serializers, status
 from rest_framework.generics import CreateAPIView
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from codecov_auth.authentication.repo_auth import (
@@ -40,10 +40,12 @@ class TransplantReportView(GetterMixin, CreateAPIView):
         RepositoryLegacyTokenAuthentication,
     ]
 
-    def get_exception_handler(self) -> Callable[[Exception, dict[str, Any]], Response]:
+    def get_exception_handler(
+        self,
+    ) -> Callable[[Exception, dict[str, Any]], Response | None]:
         return repo_auth_custom_exception_handler
 
-    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> Response:
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         inc_counter(
             API_UPLOAD_COUNTER,
             labels=generate_upload_prometheus_metrics_labels(

--- a/libs/shared/shared/django_apps/upload_breadcrumbs/models.py
+++ b/libs/shared/shared/django_apps/upload_breadcrumbs/models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import ValidationError
@@ -135,13 +137,13 @@ class BreadcrumbData(
 
     @field_validator("*", mode="after")
     @classmethod
-    def validate_initialized(cls, value):
+    def validate_initialized(cls, value: Any) -> Any:
         if value == "":
             raise ValueError("field must not be empty.")
         return value
 
     @model_validator(mode="after")
-    def require_at_least_one_field(self):
+    def require_at_least_one_field(self) -> "BreadcrumbData":
         if not any(
             [
                 self.milestone,
@@ -154,23 +156,23 @@ class BreadcrumbData(
         return self
 
     @model_validator(mode="after")
-    def check_error_dependency(self):
+    def check_error_dependency(self) -> "BreadcrumbData":
         if self.error_text and not self.error:
             raise ValueError("'error_text' is provided, but 'error' is missing.")
         return self
 
     @model_validator(mode="after")
-    def check_unknown_error(self):
+    def check_unknown_error(self) -> "BreadcrumbData":
         if self.error == Errors.UNKNOWN and not self.error_text:
             raise ValueError("'error_text' must be provided when 'error' is UNKNOWN.")
         return self
 
-    def model_dump(self, *args, **kwargs):
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, str]:
         kwargs["exclude_none"] = True
         return super().model_dump(*args, **kwargs)
 
     @classmethod
-    def django_validate(cls, *args, **kwargs) -> None:
+    def django_validate(cls, *args: Any, **kwargs: Any) -> None:
         """
         Performs validation in a way that conforms to the expectations of
         Django's model validation system.

--- a/libs/shared/shared/django_apps/upload_breadcrumbs/tests/test_models.py
+++ b/libs/shared/shared/django_apps/upload_breadcrumbs/tests/test_models.py
@@ -15,6 +15,160 @@ from shared.django_apps.upload_breadcrumbs.tests.factories import (
 )
 
 
+@pytest.mark.parametrize(
+    "enum_class, enum_entries, enum_values, enum_labels",
+    [
+        (
+            Milestones,
+            [
+                Milestones.FETCHING_COMMIT_DETAILS,
+                Milestones.COMMIT_PROCESSED,
+                Milestones.PREPARING_FOR_REPORT,
+                Milestones.READY_FOR_REPORT,
+                Milestones.WAITING_FOR_COVERAGE_UPLOAD,
+                Milestones.COMPILING_UPLOADS,
+                Milestones.PROCESSING_UPLOAD,
+                Milestones.UPLOAD_COMPLETE,
+                Milestones.NOTIFICATIONS_TRIGGERED,
+                Milestones.NOTIFICATIONS_SENT,
+            ],
+            ["fcd", "cp", "pfr", "rfr", "wfcu", "cu", "pu", "uc", "nt", "ns"],
+            [
+                "Fetching commit details",
+                "Commit processed",
+                "Preparing for report",
+                "Ready for report",
+                "Waiting for coverage upload",
+                "Compiling uploads",
+                "Processing upload",
+                "Upload complete",
+                "Notifications triggered",
+                "Notifications sent",
+            ],
+        ),
+        (
+            Endpoints,
+            [
+                Endpoints.CREATE_COMMIT,
+                Endpoints.CREATE_REPORT,
+                Endpoints.DO_UPLOAD,
+                Endpoints.EMPTY_UPLOAD,
+                Endpoints.UPLOAD_COMPLETION,
+                Endpoints.UPLOAD_COVERAGE,
+                Endpoints.LEGACY_UPLOAD_COVERAGE,
+            ],
+            ["cc", "cr", "du", "eu", "ucomp", "ucov", "luc"],
+            [
+                "new_upload.commits",
+                "new_upload.reports",
+                "new_upload.uploads",
+                "new_upload.empty_upload",
+                "new_upload.upload-complete",
+                "new_upload.upload_coverage",
+                "upload-handler",
+            ],
+        ),
+        (
+            Errors,
+            [
+                Errors.BAD_REQUEST,
+                Errors.REPO_DEACTIVATED,
+                Errors.REPO_MISSING_VALID_BOT,
+                Errors.REPO_NOT_FOUND,
+                Errors.REPO_BLACKLISTED,
+                Errors.COMMIT_NOT_FOUND,
+                Errors.COMMIT_UPLOAD_LIMIT,
+                Errors.OWNER_UPLOAD_LIMIT,
+                Errors.GIT_CLIENT_ERROR,
+                Errors.REPORT_NOT_FOUND,
+                Errors.UPLOAD_NOT_FOUND,
+                Errors.MALFORMED_INPUT,
+                Errors.UNRECOGNIZED_FORMAT,
+                Errors.TASK_TIMED_OUT,
+                Errors.INTERNAL_LOCK_ERROR,
+                Errors.INTERNAL_RETRYING,
+                Errors.INTERNAL_OUT_OF_RETRIES,
+                Errors.INTERNAL_NO_PENDING_JOBS,
+                Errors.INTERNAL_NO_ARGUMENTS,
+                Errors.UNKNOWN,
+            ],
+            [
+                "br",
+                "rd",
+                "rmb",
+                "rnf",
+                "rb",
+                "cnf",
+                "cul",
+                "oul",
+                "gce",
+                "rptnf",
+                "unf",
+                "mi",
+                "uf",
+                "tto",
+                "int_le",
+                "int_re",
+                "int_or",
+                "int_np",
+                "int_na",
+                "u",
+            ],
+            [
+                "Bad request, see API response for details",
+                "Repository is deactivated within Codecov",
+                "Repository is missing a valid bot",
+                "Repository not found by the configured bot",
+                "Repository is blacklisted by Codecov",
+                "Commit not found in the repository",
+                "Upload limit exceeded for this commit",
+                "Owner (user or team) upload limit exceeded",
+                "Git client returned a 4xx error",
+                "Report not found for the commit",
+                "Upload not found for the commit",
+                "Malformed coverage report input",
+                "Unrecognized coverage report format",
+                "Task timed out",
+                "Unable to acquire or release lock",
+                "Retrying the upload task",
+                "Out of retries for the upload task",
+                "No pending jobs found for the commit",
+                "No arguments found in Redis for the upload task",
+                "Unknown error",
+            ],
+        ),
+    ],
+)
+def test_enums(
+    enum_class: Milestones | Errors | Endpoints,
+    enum_entries: list[Milestones | Errors | Endpoints],
+    enum_values: list[str],
+    enum_labels: list[str],
+):
+    """
+    This test ensures that when any of the upload breadcrumb enums are updated,
+    a developer is reminded to:
+
+    * Consider the implications of removing or renaming an enum value
+      * The values and labels are used in various places, including being shown
+        to users, Django admins, and in Prometheus metrics
+      * Old values may still be present in the database so reading them may
+        fail and cause unexpected behavior
+    * Update this test with the added/changed/removed enum value(s) and/or
+      label(s)
+    """
+
+    message = (
+        "You are modifying an important enum. Please read the comments"
+        " associated with this test for details."
+    )
+
+    assert len(enum_class) == len(enum_entries), message
+    for entry, value, label in zip(enum_entries, enum_values, enum_labels):
+        assert entry.value == value, message
+        assert entry.label == label, message
+
+
 class TestBreadcrumbData:
     def test_valid_all_fields(self):
         data = BreadcrumbData(
@@ -61,7 +215,7 @@ class TestBreadcrumbData:
             ),
             (
                 {
-                    "error": Errors.MISSING_TOKEN,
+                    "error": Errors.REPO_NOT_FOUND,
                     "error_text": "",
                 },
                 "field must not be empty.",

--- a/libs/shared/shared/upload/utils.py
+++ b/libs/shared/shared/upload/utils.py
@@ -56,7 +56,7 @@ def insert_coverage_measurement(
     uploader_used: str,
     private_repo: bool,
     report_type: ReportType,
-):
+) -> UserMeasurement:
     return UserMeasurement.objects.create(
         repo_id=repo_id,
         commit_id=commit_id,


### PR DESCRIPTION
* Added breadcrumbs on the API side for
  * Waiting on coverage upload: legacy (now complete), coverage upload (now complete), and upload endpoints
  * Notifications triggered: empty upload and upload completion endpoints
* Added more predefined upload breadcrumb errors
* Typing improvements for multiple upload-related files