### PR TITLE
fix: allow bypass of auth when coming from sentry with jwt

### DIFF
--- a/apps/codecov-api/graphql_api/helpers/mutation.py
+++ b/apps/codecov-api/graphql_api/helpers/mutation.py
@@ -1,4 +1,5 @@
 from codecov.commands import exceptions
+from codecov_auth.constants import USE_SENTRY_APP_INDICATOR
 from codecov_auth.helpers import current_user_part_of_org
 
 
@@ -50,7 +51,10 @@ def wrap_error_handling_mutation(resolver):
 def require_authenticated(resolver):
     def authenticated_resolver(instance, info, *args, **kwargs):
         current_user = info.context["request"].user
-        if not current_user.is_authenticated:
+        if (
+            not getattr(info.context["request"], USE_SENTRY_APP_INDICATOR, False)
+            and not current_user.is_authenticated
+        ):
             raise exceptions.Unauthenticated()
 
         return resolver(instance, info, *args, **kwargs)


### PR DESCRIPTION
This PR introduces a conditional that allows us to bypass the requires_authentication middleware when we're coming from the Sentry app. This will allow us to run GQL mutations from the Sentry app using the new sentry GQL endpoint wrapper.

Also adds some UTs

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
