### PR TITLE
feat(devenv): Django admin now works locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ $ make devenv
 # Run migrations
 $ make devenv.migrate
 
+# Designate a user as an admin. This is necessary to access the admin interface.
+$ make devenv.admin
+
 # Rebuild and restart `umbrella` containers. Necessary if dependencies change.
 # Run this after pulling if you haven't pulled in a while.
 $ make devenv.refresh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - "${CODECOV_PORT-8080}:8080"
     environment:
+      - CODECOV_API_ADMIN_ENABLED=true
       - CODECOV_GATEWAY_MINIO_ENABLED=true
       - CODECOV_MINIO_PORT=9002
     networks:

--- a/tools/devenv/Makefile.devenv
+++ b/tools/devenv/Makefile.devenv
@@ -53,6 +53,13 @@ devenv.migrate:
 	docker compose run --entrypoint python --rm worker migrate_timeseries.py
 	docker compose run --entrypoint python --rm worker manage.py pgpartition --yes
 
+.PHONY: devenv.admin
+devenv.admin:
+	@echo "Enter the external ID of the user to make an admin. The user must have first logged into the main application and then their ID can be found in the database or by visiting the admin interface (http://localhost:8080/admin/) and copying the ID that appears on the login page."
+	@printf "Input: "; \
+	read external_id; \
+	docker compose run --entrypoint python --rm api manage.py shell -c "from codecov_auth.models import User; user = User.objects.get(external_id='$$external_id'); user.is_staff = True; user.is_superuser = True; user.save(); print(f'User {user.name} (external_id: $$external_id) is now an admin')"
+
 .PHONY: devenv.stop
 devenv.stop:
 	docker compose down --remove-orphans


### PR DESCRIPTION
* Proxies the local Django admin interface so that it can be accessed in development (depends on https://github.com/codecov/codecov-gateway/pull/125)
* Adds a make command to make a user an admin