### PR TITLE
fix: stop populating cache files and new repos read from timescale

### DIFF
--- a/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query__0.json
@@ -13,7 +13,10 @@
     "total_duration": 0.0,
     "avg_duration": 0.0,
     "last_duration": 0.0,
-    "flags": ["flag1", "flag2"],
+    "flags": [
+      "flag1",
+      "flag2"
+    ],
     "name": "name0"
   },
   {
@@ -30,7 +33,9 @@
     "total_duration": 1.0,
     "avg_duration": 1.0,
     "last_duration": 1.0,
-    "flags": ["flag3"],
+    "flags": [
+      "flag3"
+    ],
     "name": "name1"
   },
   {
@@ -47,7 +52,10 @@
     "total_duration": 2.0,
     "avg_duration": 2.0,
     "last_duration": 2.0,
-    "flags": ["flag1", "flag2"],
+    "flags": [
+      "flag1",
+      "flag2"
+    ],
     "name": "name2"
   },
   {
@@ -64,7 +72,9 @@
     "total_duration": 3.0,
     "avg_duration": 3.0,
     "last_duration": 3.0,
-    "flags": ["flag3"],
+    "flags": [
+      "flag3"
+    ],
     "name": "name3"
   },
   {
@@ -81,7 +91,10 @@
     "total_duration": 4.0,
     "avg_duration": 4.0,
     "last_duration": 4.0,
-    "flags": ["flag1", "flag2"],
+    "flags": [
+      "flag1",
+      "flag2"
+    ],
     "name": "name4"
   },
   {
@@ -98,7 +111,7 @@
     "total_duration": 0.0,
     "avg_duration": 0.0,
     "last_duration": 0.0,
-    "flags": ["flag1"],
+    "flags": null,
     "name": "name5"
   }
 ]

--- a/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_testsuites_and_flags_resolvers__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_testsuites_and_flags_resolvers__0.json
@@ -1,0 +1,21 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "testSuites": [
+          "testsuite0",
+          "testsuite1",
+          "testsuite2",
+          "testsuite3",
+          "testsuite4",
+          "testsuite5"
+        ],
+        "flags": [
+          "flag1",
+          "flag2",
+          "flag3"
+        ]
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_testsuites_and_flags_resolvers_with_term__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/analytics_timescale__TestAnalyticsTestCaseNew__gql_query_testsuites_and_flags_resolvers_with_term__0.json
@@ -1,0 +1,14 @@
+{
+  "owner": {
+    "repository": {
+      "testAnalytics": {
+        "testSuites": [
+          "testsuite1"
+        ],
+        "flags": [
+          "flag1"
+        ]
+      }
+    }
+  }
+}

--- a/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
@@ -82,7 +82,7 @@ def populate_timescale(repository):
                 outcome="skip",
                 duration_seconds=0,
                 commit_sha="test_commit_skip",
-                flags=["flag1"],
+                flags=None,
                 branch="main",
             )
         ]
@@ -308,6 +308,50 @@ class TestAnalyticsTestCaseNew(GraphQLTestHelper):
                                         }}
                                     }}
                                 }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        result = self.gql_request(query, owner=repository.author)
+
+        assert snapshot("json") == result
+
+    def test_gql_query_testsuites_and_flags_resolvers(
+        self, repository, populate_timescale, snapshot
+    ):
+        query = f"""
+            query {{
+                owner(username: "{repository.author.username}") {{
+                    repository(name: "{repository.name}") {{
+                        ... on Repository {{
+                            testAnalytics {{
+                                testSuites
+                                flags
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        result = self.gql_request(query, owner=repository.author)
+
+        assert snapshot("json") == result
+
+    def test_gql_query_testsuites_and_flags_resolvers_with_term(
+        self, repository, populate_timescale, snapshot
+    ):
+        query = f"""
+            query {{
+                owner(username: "{repository.author.username}") {{
+                    repository(name: "{repository.name}") {{
+                        ... on Repository {{
+                            testAnalytics {{
+                                testSuites(term: "testsuite1")
+                                flags(term: "flag1")
                             }}
                         }}
                     }}

--- a/apps/codecov-api/utils/test_results.py
+++ b/apps/codecov-api/utils/test_results.py
@@ -118,15 +118,8 @@ def get_results(
             cache to redis
     deserialize
     """
-    if use_new_impl(repoid):
-        func = new_get_results
-        label = "new"
-    else:
-        func = old_get_results
-        label = "old"
-
-    with get_results_summary.labels(label).time():
-        return func(repoid, branch, interval_start, interval_end)
+    with get_results_summary.labels("old").time():
+        return old_get_results(repoid, branch, interval_start, interval_end)
 
 
 def old_get_results(

--- a/apps/worker/services/test_analytics/tests/test_ta_cache_rollups.py
+++ b/apps/worker/services/test_analytics/tests/test_ta_cache_rollups.py
@@ -10,6 +10,7 @@ from shared.django_apps.ta_timeseries.models import (
     TestrunSummary,
     calc_test_id,
 )
+from shared.storage.exceptions import FileNotInStorageError
 from shared.storage.minio import MinioStorageService
 from tasks.cache_test_rollups import CacheTestRollupsTask
 
@@ -280,8 +281,5 @@ def test_cache_test_rollups_use_timeseries_branch(mock_storage, snapshot):
         impl_type="new",
     )
 
-    table = read_table(mock_storage, "test_analytics/branch_rollups/1/feature.arrow")
-    table_dict = table.to_dict(as_series=False)
-    del table_dict["timestamp_bin"]
-    del table_dict["updated_at"]
-    assert snapshot("json") == table_dict
+    with pytest.raises(FileNotInStorageError):
+        read_table(mock_storage, "test_analytics/branch_rollups/1/feature.arrow")

--- a/apps/worker/tasks/tests/unit/test_cache_test_rollups.py
+++ b/apps/worker/tasks/tests/unit/test_cache_test_rollups.py
@@ -237,27 +237,3 @@ def test_cache_test_rollups_update_date_does_not_exist(mock_storage, db):
         repository_id=repo.repoid, branch="main"
     ).first()
     assert obj.last_rollup_date == dt.date.today()
-
-
-@freeze_time()
-def test_cache_test_rollups_both(mock_storage, db, mocker):
-    mock_cache_rollups = mocker.patch("tasks.cache_test_rollups.cache_rollups")
-    task = CacheTestRollupsTask()
-    mocker.patch.object(task, "run_impl_within_lock")
-    repo = RepositoryFactory()
-    _ = task.run_impl(
-        _db_session=None,
-        repo_id=repo.repoid,
-        branch="main",
-        update_date=True,
-        impl_type="both",
-    )
-
-    mock_cache_rollups.assert_has_calls(
-        [
-            mocker.call(repo.repoid, "main"),
-            mocker.call(repo.repoid, None),
-        ]
-    )
-
-    task.run_impl_within_lock.assert_called_once()


### PR DESCRIPTION
this commit contains both API and worker changes

the worker change is that we're no longer caching rollups from timescale if the impl type passed to the cache rollup task is new or both

the reason for this is that the queries done against timescale to load the rollups are way too expensive and it's causing DB issues

because we're no longer updating the rollups we need users that were previously reading from those rollups to read directly from timescale instead which is what the API changes consist of.

We're creating "direct from Timescale" implementations of the TA testsuites and flags resolvers and we're changing the condition for the new implementation to check both the READ_NEW_TA feature flag and the use new impl function
