### PR TITLE
fix: show up to date TA data

### DIFF
--- a/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
+++ b/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
@@ -417,7 +417,7 @@ async def resolve_test_results(
             if filters
             else MeasurementInterval.INTERVAL_30_DAY
         )
-        end_date = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = datetime.now(UTC)
         start_date = end_date - timedelta(days=measurement_interval.value)
         ordering_param = (
             ordering.get("parameter", TestResultsOrderingParameter.AVG_DURATION)
@@ -501,7 +501,7 @@ async def resolve_test_results_aggregates(
         measurement_interval = (
             interval if interval else MeasurementInterval.INTERVAL_30_DAY
         )
-        end_date = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = datetime.now(UTC)
         start_date = end_date - timedelta(days=measurement_interval.value)
         return await sync_to_async(get_test_results_aggregates_from_timescale)(
             repoid=repository.repoid,
@@ -530,7 +530,7 @@ async def resolve_flake_aggregates(
         measurement_interval = (
             interval if interval else MeasurementInterval.INTERVAL_30_DAY
         )
-        end_date = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = datetime.now(UTC)
         start_date = end_date - timedelta(days=measurement_interval.value)
         return await sync_to_async(get_flake_aggregates_from_timescale)(
             repoid=repository.repoid,

--- a/apps/codecov-api/utils/timescale_test_results.py
+++ b/apps/codecov-api/utils/timescale_test_results.py
@@ -86,14 +86,14 @@ def get_test_data_queryset_via_ca(
         test_data = TestrunBranchSummary.objects.filter(
             repo_id=repoid,
             branch=branch,
-            timestamp_bin__gte=start_date,
-            timestamp_bin__lt=end_date,
+            timestamp_bin__gt=start_date,
+            timestamp_bin__lte=end_date,
         )
     else:
         test_data = TestrunSummary.objects.filter(
             repo_id=repoid,
-            timestamp_bin__gte=start_date,
-            timestamp_bin__lt=end_date,
+            timestamp_bin__gt=start_date,
+            timestamp_bin__lte=end_date,
         )
 
     test_data = test_data.values("computed_name", "testsuite").annotate(  # type: ignore[assignment]
@@ -168,8 +168,8 @@ def get_test_data_queryset_via_ca(
                         branch=branch,
                         computed_name=OuterRef("computed_name"),
                         testsuite=OuterRef("testsuite"),
-                        timestamp_bin__gte=start_date,
-                        timestamp_bin__lt=end_date,
+                        timestamp_bin__gt=start_date,
+                        timestamp_bin__lte=end_date,
                     )
                     .order_by("-timestamp_bin")
                     .values("timestamp_bin")[:1],
@@ -207,8 +207,8 @@ def get_test_data_queryset_via_testrun(
     test_data = Testrun.objects.filter(
         repo_id=repoid,
         branch=branch,
-        timestamp__gte=start_date,
-        timestamp__lt=end_date,
+        timestamp__gt=start_date,
+        timestamp__lte=end_date,
     )
 
     test_data = test_data.values("computed_name", "testsuite").annotate(  # type: ignore[assignment]
@@ -379,26 +379,26 @@ def get_repo_aggregates_via_ca(
     if branch is None:
         test_data = TestrunSummary.objects.filter(
             repo_id=repoid,
-            timestamp_bin__gte=start_date,
-            timestamp_bin__lt=end_date,
+            timestamp_bin__gt=start_date,
+            timestamp_bin__lte=end_date,
         )
         repo_data = AggregateDaily.objects.filter(
             repo_id=repoid,
-            bucket_daily__gte=start_date,
-            bucket_daily__lt=end_date,
+            bucket_daily__gt=start_date,
+            bucket_daily__lte=end_date,
         )
     elif branch in PRECOMPUTED_BRANCHES:
         test_data = TestrunBranchSummary.objects.filter(
             repo_id=repoid,
             branch=branch,
-            timestamp_bin__gte=start_date,
-            timestamp_bin__lt=end_date,
+            timestamp_bin__gt=start_date,
+            timestamp_bin__lte=end_date,
         )
         repo_data = BranchAggregateDaily.objects.filter(
             repo_id=repoid,
             branch=branch,
-            bucket_daily__gte=start_date,
-            bucket_daily__lt=end_date,
+            bucket_daily__gt=start_date,
+            bucket_daily__lte=end_date,
         )
 
     daily_aggregates = repo_data.aggregate(
@@ -487,26 +487,26 @@ def get_flake_aggregates_via_ca(
     if branch is None:
         test_data = TestrunSummary.objects.filter(
             repo_id=repoid,
-            timestamp_bin__gte=start_date,
-            timestamp_bin__lt=end_date,
+            timestamp_bin__gt=start_date,
+            timestamp_bin__lte=end_date,
         )
         repo_data = AggregateDaily.objects.filter(
             repo_id=repoid,
-            bucket_daily__gte=start_date,
-            bucket_daily__lt=end_date,
+            bucket_daily__gt=start_date,
+            bucket_daily__lte=end_date,
         )
     else:
         test_data = TestrunBranchSummary.objects.filter(
             repo_id=repoid,
             branch=branch,
-            timestamp_bin__gte=start_date,
-            timestamp_bin__lt=end_date,
+            timestamp_bin__gt=start_date,
+            timestamp_bin__lte=end_date,
         )
         repo_data = BranchAggregateDaily.objects.filter(
             repo_id=repoid,
             branch=branch,
-            bucket_daily__gte=start_date,
-            bucket_daily__lt=end_date,
+            bucket_daily__gt=start_date,
+            bucket_daily__lte=end_date,
         )
 
     daily_aggregates = repo_data.aggregate(


### PR DESCRIPTION
I'm changing the bounds on the TA data to show the most up to date data we can show. Given we've enabled real time aggregates