### PR TITLE
chore: Bump default soft and hard time limit values

### DIFF
--- a/apps/worker/tasks/tests/unit/test_base.py
+++ b/apps/worker/tasks/tests/unit/test_base.py
@@ -121,7 +121,7 @@ class TestBaseCodecovTask:
     def test_hard_time_limit_task_from_default_app(self, mocker):
         mocker.patch.object(SampleTask, "request", timelimit=None)
         r = SampleTask()
-        assert r.hard_time_limit_task == 480
+        assert r.hard_time_limit_task == 720
 
     @patch("tasks.base.datetime", MockDateTime)
     def test_sample_run(self, mocker, dbsession):

--- a/libs/shared/shared/celery_config.py
+++ b/libs/shared/shared/celery_config.py
@@ -209,12 +209,12 @@ class BaseCeleryConfig:
 
     # http://celery.readthedocs.org/en/latest/configuration.html#celeryd-task-soft-time-limit
     task_soft_time_limit = int(
-        get_config("setup", "tasks", "celery", "soft_timelimit", default=400)
+        get_config("setup", "tasks", "celery", "soft_timelimit", default=600)
     )
 
     # http://celery.readthedocs.org/en/latest/configuration.html#std:setting-CELERYD_TASK_TIME_LIMIT
     task_time_limit = int(
-        get_config("setup", "tasks", "celery", "hard_timelimit", default=480)
+        get_config("setup", "tasks", "celery", "hard_timelimit", default=720)
     )
 
     notify_soft_time_limit = int(


### PR DESCRIPTION
Bumps the default soft time limit to 600s and hard time limit to 720s to match our Helm chart defaults that are being removed.