### PR TITLE
fix: temporarily default to default branch data until we update the FE

### DIFF
--- a/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__gql_query_flake_aggregates_timescale__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__gql_query_flake_aggregates_timescale__0.json
@@ -5,8 +5,8 @@
         "flakeAggregates": {
           "flakeRate": 0.5,
           "flakeCount": 1,
-          "flakeRatePercentChange": -0.5,
-          "flakeCountPercentChange": -0.6666666666666666
+          "flakeRatePercentChange": 0.0,
+          "flakeCountPercentChange": 0.0
         }
       }
     }

--- a/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__gql_query_test_results_aggregates_timescale__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__gql_query_test_results_aggregates_timescale__0.json
@@ -8,10 +8,10 @@
           "totalFails": 1,
           "totalSkips": 0,
           "totalSlowTests": 1,
-          "totalDurationPercentChange": -0.42857142857142855,
-          "slowestTestsDurationPercentChange": -0.4444444444444444,
+          "totalDurationPercentChange": 0.0,
+          "slowestTestsDurationPercentChange": 0.0,
           "totalFailsPercentChange": 0.0,
-          "totalSkipsPercentChange": -1.0,
+          "totalSkipsPercentChange": 0.0,
           "totalSlowTestsPercentChange": 0.0
         }
       }

--- a/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_flake_aggregates_timescale.py
@@ -177,6 +177,7 @@ class TestFlakeAggregatesTimescale(GraphQLTestHelper):
 
         assert snapshot("json") == result
 
+    @pytest.mark.skip(reason="Temporarily only fetching default branch data")
     def test_flake_aggregates_timescale_non_precomputed_branch(
         self, repository, populate_timescale_flake_aggregates, snapshot
     ):

--- a/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_results_aggregates_timescale.py
@@ -193,6 +193,7 @@ class TestTestResultsAggregatesTimescale(GraphQLTestHelper):
 
         assert snapshot("json") == result
 
+    @pytest.mark.skip(reason="Temporarily only fetching default branch data")
     def test_test_results_aggregates_timescale_non_precomputed_branch(
         self, repository, populate_timescale_test_results_aggregates, snapshot
     ):

--- a/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
+++ b/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
@@ -505,7 +505,7 @@ async def resolve_test_results_aggregates(
         start_date = end_date - timedelta(days=measurement_interval.value)
         return await sync_to_async(get_test_results_aggregates_from_timescale)(
             repoid=repository.repoid,
-            branch=branch,
+            branch=repository.branch,
             start_date=start_date,
             end_date=end_date,
         )
@@ -534,7 +534,7 @@ async def resolve_flake_aggregates(
         start_date = end_date - timedelta(days=measurement_interval.value)
         return await sync_to_async(get_flake_aggregates_from_timescale)(
             repoid=repository.repoid,
-            branch=branch,
+            branch=repository.branch,
             start_date=start_date,
             end_date=end_date,
         )


### PR DESCRIPTION
gazebo doesn't explicitly pass the branch to flake aggregates or test results aggregates so having the default be all branches is confusing for users because the table data is showing default branch data but the metrics section is showing all branches data
