### PR TITLE
fix: Create partitions from the next time unit

### DIFF
--- a/libs/shared/shared/django_apps/utils/partitioning.py
+++ b/libs/shared/shared/django_apps/utils/partitioning.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
 from psqlextra.partitioning import (
     PostgresCurrentTimePartitioningStrategy,
@@ -10,6 +11,12 @@ from shared.django_apps.reports.models import DailyTestRollup
 from shared.django_apps.upload_breadcrumbs.models import UploadBreadcrumb
 from shared.django_apps.user_measurements.models import UserMeasurement
 
+class PostgresTimeUnitNextPartitioningStrategy(PostgresCurrentTimePartitioningStrategy):
+    def get_start_datetime(self) -> datetime:
+        """ Add 1 of PostgresTimePartitionUnit"""
+        unit_plus_one = {self.size.unit: 1}
+        return datetime.now(timezone.utc) + relativedelta(**unit_plus_one)
+
 # Overlapping partitions will cause errors - https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE -> "create partitions"
 # Note that the partitioning manager will not perform the actual creation and deletion of partitions automatically, we have a Celery task for that.
 manager = PostgresPartitioningManager(
@@ -19,7 +26,7 @@ manager = PostgresPartitioningManager(
         # Partitions will be named `[table_name]_[year]_[3-letter month name]`
         PostgresPartitioningConfig(
             model=UserMeasurement,
-            strategy=PostgresCurrentTimePartitioningStrategy(
+            strategy=PostgresTimeUnitNextPartitioningStrategy(
                 size=PostgresTimePartitionSize(months=1),
                 count=12,
                 max_age=relativedelta(months=12),
@@ -30,7 +37,7 @@ manager = PostgresPartitioningManager(
         # Partitions will be named `[table_name]_[year]_[3-letter month name]`
         PostgresPartitioningConfig(
             model=DailyTestRollup,
-            strategy=PostgresCurrentTimePartitioningStrategy(
+            strategy=PostgresTimeUnitNextPartitioningStrategy(
                 size=PostgresTimePartitionSize(months=1),
                 count=3,
                 max_age=relativedelta(months=3),
@@ -41,7 +48,7 @@ manager = PostgresPartitioningManager(
         # Partitions will be named `[table_name]_[year]_week_[week number]`
         PostgresPartitioningConfig(
             model=UploadBreadcrumb,
-            strategy=PostgresCurrentTimePartitioningStrategy(
+            strategy=PostgresTimeUnitNextPartitioningStrategy(
                 size=PostgresTimePartitionSize(weeks=1),
                 count=3,
                 max_age=relativedelta(months=3),


### PR DESCRIPTION
Hi 👋 

This is a proposed fix for initial creation of partitions when there is existing data.

We hit the following error:

```
codecov django.db.utils.IntegrityError: updated partition constraint for default partition "user_measurements_default" would be violated by some row
```

We beleieve this is because `python manage.py pgmigrate` was not run on startup, only `python manage.py migrate`, also the task to create new partitions was not run

Advice on the internet suggests creating partitions in advance, outside of the current time unit window.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
