### PR TITLE
fix: new timescale CA definitions

### DIFF
--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0024_create_test_aggregate_daily_cas.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0024_create_test_aggregate_daily_cas.py
@@ -10,7 +10,8 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             """
-            CREATE MATERIALIZED VIEW ta_timeseries_test_aggregate_hourly
+            CREATE MATERIALIZED VIEW IF NOT EXISTS
+            ta_timeseries_test_aggregate_hourly
             WITH (timescaledb.continuous, timescaledb.materialized_only = false, timescaledb.create_group_indexes = false) AS
             SELECT
                 repo_id,
@@ -31,13 +32,15 @@ class Migration(migrations.Migration):
                 MAX(timestamp) AS updated_at,
                 array_merge_dedup_agg(flags) as flags
             FROM ta_timeseries_testrun
-            GROUP BY repo_id, testsuite, classname, name, bucket_hourly;
+            GROUP BY repo_id, testsuite, classname, name, bucket_hourly
+            WITH NO DATA;
             """,
             reverse_sql="DROP MATERIALIZED VIEW ta_timeseries_test_aggregate_hourly;",
         ),
         migrations.RunSQL(
             """
-            CREATE MATERIALIZED VIEW ta_timeseries_test_aggregate_daily
+            CREATE MATERIALIZED VIEW IF NOT EXISTS
+            ta_timeseries_test_aggregate_daily
             WITH (timescaledb.continuous, timescaledb.materialized_only = false, timescaledb.create_group_indexes = false) AS
             SELECT
                 repo_id,
@@ -58,13 +61,15 @@ class Migration(migrations.Migration):
                 MAX(updated_at) AS updated_at,
                 array_merge_dedup_agg(flags) as flags
             FROM ta_timeseries_test_aggregate_hourly
-            GROUP BY repo_id, testsuite, classname, name, bucket_daily;
+            GROUP BY repo_id, testsuite, classname, name, bucket_daily
+            WITH NO DATA;
             """,
             reverse_sql="DROP MATERIALIZED VIEW ta_timeseries_test_aggregate_daily;",
         ),
         migrations.RunSQL(
             """
-            CREATE MATERIALIZED VIEW ta_timeseries_branch_test_aggregate_hourly
+            CREATE MATERIALIZED VIEW IF NOT EXISTS
+            ta_timeseries_branch_test_aggregate_hourly
             WITH (timescaledb.continuous, timescaledb.materialized_only = false, timescaledb.create_group_indexes = false) AS
             SELECT
                 repo_id,
@@ -87,13 +92,15 @@ class Migration(migrations.Migration):
                 array_merge_dedup_agg(flags) as flags
             FROM ta_timeseries_testrun
             WHERE branch IN ('main', 'master', 'develop')
-            GROUP BY repo_id, branch, testsuite, classname, name, bucket_hourly;
+            GROUP BY repo_id, branch, testsuite, classname, name, bucket_hourly
+            WITH NO DATA;
             """,
             reverse_sql="DROP MATERIALIZED VIEW ta_timeseries_branch_test_aggregate_hourly;",
         ),
         migrations.RunSQL(
             """
-            CREATE MATERIALIZED VIEW ta_timeseries_branch_test_aggregate_daily
+            CREATE MATERIALIZED VIEW IF NOT EXISTS
+            ta_timeseries_branch_test_aggregate_daily
             WITH (timescaledb.continuous, timescaledb.materialized_only = false, timescaledb.create_group_indexes = false) AS
             SELECT
                 repo_id,
@@ -115,7 +122,8 @@ class Migration(migrations.Migration):
                 MAX(updated_at) AS updated_at,
                 array_merge_dedup_agg(flags) as flags
             FROM ta_timeseries_branch_test_aggregate_hourly
-            GROUP BY repo_id, branch, testsuite, classname, name, bucket_daily;
+            GROUP BY repo_id, branch, testsuite, classname, name, bucket_daily
+            WITH NO DATA;
             """,
             reverse_sql="DROP MATERIALIZED VIEW ta_timeseries_branch_test_aggregate_daily;",
         ),

--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0029_add_retention_policies_to_new_caggs.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0029_add_retention_policies_to_new_caggs.py
@@ -1,0 +1,74 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ta_timeseries", "0028_branchtestaggregatedaily_testaggregatedaily"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            SELECT add_retention_policy('ta_timeseries_aggregate_hourly', INTERVAL '3 days');
+            """,
+            reverse_sql="""
+            SELECT remove_retention_policy('ta_timeseries_aggregate_hourly');
+            """,
+        ),
+        migrations.RunSQL(
+            """
+            SELECT add_retention_policy('ta_timeseries_branch_aggregate_hourly', INTERVAL '3 days');
+            """,
+            reverse_sql="""
+            SELECT remove_retention_policy('ta_timeseries_branch_aggregate_hourly');
+            """,
+        ),
+        migrations.RunSQL(
+            """
+            SELECT add_retention_policy('ta_timeseries_test_aggregate_hourly', INTERVAL '3 days');
+            """,
+            reverse_sql="""
+            SELECT remove_retention_policy('ta_timeseries_test_aggregate_hourly');
+            """,
+        ),
+        migrations.RunSQL(
+            """
+            SELECT add_retention_policy('ta_timeseries_branch_test_aggregate_hourly', INTERVAL '3 days');
+            """,
+            reverse_sql="""
+            SELECT remove_retention_policy('ta_timeseries_branch_test_aggregate_hourly');
+            """,
+        ),
+        migrations.RunSQL(
+            """
+            SELECT add_retention_policy('ta_timeseries_aggregate_daily', INTERVAL '60 days');
+            """,
+            reverse_sql="""
+            SELECT remove_retention_policy('ta_timeseries_aggregate_daily');
+            """,
+        ),
+        migrations.RunSQL(
+            """
+            SELECT add_retention_policy('ta_timeseries_branch_aggregate_daily', INTERVAL '60 days');
+            """,
+            reverse_sql="""
+            SELECT remove_retention_policy('ta_timeseries_branch_aggregate_daily');
+            """,
+        ),
+        migrations.RunSQL(
+            """
+            SELECT add_retention_policy('ta_timeseries_test_aggregate_daily', INTERVAL '60 days');
+            """,
+            reverse_sql="""
+            SELECT remove_retention_policy('ta_timeseries_test_aggregate_daily');
+            """,
+        ),
+        migrations.RunSQL(
+            """
+            SELECT add_retention_policy('ta_timeseries_branch_test_aggregate_daily', INTERVAL '60 days');
+            """,
+            reverse_sql="""
+            SELECT remove_retention_policy('ta_timeseries_branch_test_aggregate_daily');
+            """,
+        ),
+    ]


### PR DESCRIPTION
we add if not exists so the migrations don't fall over if they were previously
partially applied

we add with no data so it doesn't refresh data on CA creation

also adds retention policies to new CAs in a separate migration