### PR TITLE
fix: repo deletion

### DIFF
--- a/apps/worker/services/cleanup/repository.py
+++ b/apps/worker/services/cleanup/repository.py
@@ -101,6 +101,7 @@ def start_repo_cleanup(repo_id: int) -> tuple[bool, int]:
             author=shadow_owner,
             upload_token=new_token,
             image_token=new_token,
+            name=f"{owner_name}-{uuid4().hex}",
         )
 
     return (True, shadow_owner.ownerid)


### PR DESCRIPTION
more context here:
https://linear.app/getsentry/issue/CCMRG-1449/request-to-delete-specified-repositories

essentially, if we failed to do the raw deletion in a previous step then the user syncs repos and we try deleting the repo again the deletion hard fails because we can't  move the current repo to the shadow owner anymore since it will break (ownerid, name) constraints

so we should make sure that when we move repos to the shadow owner we also modify their name to something unique