### PR TITLE
fix: Use `repr` for unknown upload breadcrumb errors

### DIFF
--- a/apps/codecov-api/upload/helpers.py
+++ b/apps/codecov-api/upload/helpers.py
@@ -927,7 +927,7 @@ def upload_breadcrumb_context(
                     milestone=milestone,
                     endpoint=endpoint,
                     error=error if error else Errors.UNKNOWN,
-                    error_text=str(e) if not error else None,
+                    error_text=repr(e) if not error else None,
                 ),
             )
         raise

--- a/apps/codecov-api/upload/tests/test_helpers.py
+++ b/apps/codecov-api/upload/tests/test_helpers.py
@@ -441,6 +441,6 @@ def test_upload_breadcrumb_context_with_exception(mocker):
         breadcrumb_data=BreadcrumbData(
             milestone=Milestones.FETCHING_COMMIT_DETAILS,
             error=Errors.UNKNOWN,
-            error_text=str(exc.value),
+            error_text=repr(exc.value),
         ),
     )

--- a/apps/codecov-api/upload/views/legacy.py
+++ b/apps/codecov-api/upload/views/legacy.py
@@ -329,7 +329,7 @@ class UploadHandler(ShelterMixin, APIView):
                         milestone=Milestones.WAITING_FOR_COVERAGE_UPLOAD,
                         endpoint=endpoint,
                         error=Errors.UNKNOWN,
-                        error_text=str(e),
+                        error_text=repr(e),
                     ),
                 )
                 return HttpResponseServerError("Unknown error, please try again later")

--- a/apps/worker/tasks/base.py
+++ b/apps/worker/tasks/base.py
@@ -428,7 +428,7 @@ class BaseCodecovTask(celery_app.Task):
                     commit_sha=commit.commitid,
                     repo_id=repository.repoid,
                     error=Errors.UNKNOWN,
-                    error_text=str(e),
+                    error_text=repr(e),
                 )
 
         return None

--- a/apps/worker/tasks/tests/unit/test_base.py
+++ b/apps/worker/tasks/tests/unit/test_base.py
@@ -404,7 +404,7 @@ class TestBaseCodecovTask:
                 "repo_id": mock_repo.repoid,
                 "breadcrumb_data": BreadcrumbData(
                     error=Errors.UNKNOWN,
-                    error_text=str(exception),
+                    error_text=repr(exception),
                 ),
                 "upload_ids": [],
                 "sentry_trace_id": None,

--- a/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_finisher_task.py
@@ -945,7 +945,7 @@ class TestUploadFinisherTask:
                 "breadcrumb_data": BreadcrumbData(
                     milestone=Milestones.UPLOAD_COMPLETE,
                     error=Errors.UNKNOWN,
-                    error_text="Unexpected error occurred",
+                    error_text="ValueError('Unexpected error occurred')",
                 ),
                 "upload_ids": [0],
                 "sentry_trace_id": None,

--- a/apps/worker/tasks/tests/unit/test_upload_processing_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_processing_task.py
@@ -1057,7 +1057,7 @@ class TestUploadProcessorTask:
                         "breadcrumb_data": BreadcrumbData(
                             milestone=Milestones.PROCESSING_UPLOAD,
                             error=Errors.UNKNOWN,
-                            error_text=str(mocked_2.side_effect),
+                            error_text=repr(mocked_2.side_effect),
                         ),
                         "upload_ids": [upload_1.id_],
                         "sentry_trace_id": None,

--- a/apps/worker/tasks/upload_finisher.py
+++ b/apps/worker/tasks/upload_finisher.py
@@ -182,7 +182,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 milestone=milestone,
                 upload_ids=upload_ids,
                 error=Errors.UNKNOWN,
-                error_text=str(e),
+                error_text=repr(e),
             )
             return {
                 "error": str(e),

--- a/apps/worker/tasks/upload_processor.py
+++ b/apps/worker/tasks/upload_processor.py
@@ -143,7 +143,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 milestone=Milestones.PROCESSING_UPLOAD,
                 upload_ids=[arguments["upload_id"]],
                 error=Errors.UNKNOWN,
-                error_text=str(e),
+                error_text=repr(e),
             )
             raise
 


### PR DESCRIPTION
Fixes the case where an exception is thrown without a message and so `str(exception)` returns just an empty string. Example [here](https://codecov.sentry.io/issues/6792055653/events/b145499872ec44fbb87a5ec7d049185f/) from [this exception](https://codecov.sentry.io/issues/6792055621/events/c5e41511c6ee4589a1537247b2f6854d/)