### PR TITLE
fix(worker): Resolve noisy SQLAlchemy warning

### DIFF
--- a/apps/worker/tasks/notify.py
+++ b/apps/worker/tasks/notify.py
@@ -915,7 +915,7 @@ def get_ta_relevant_context(
         )
         upload_error = (
             db_session.query(UploadError)
-            .filter(UploadError.upload_id.in_(ta_upload_ids))
+            .filter(UploadError.upload_id.in_(ta_upload_ids.select()))
             .first()
         )
 


### PR DESCRIPTION
Warning was `SAWarning: Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly: .filter(UploadError.upload_id.in_(ta_upload_ids))`

[GCP logs for frequency](https://cloudlogging.app.goo.gl/jcp7pHf1DpBT7hQRA)
