### PR TITLE
feat(api): Flatten directories with single child directory for tree v…

### DIFF
--- a/apps/codecov-api/services/path.py
+++ b/apps/codecov-api/services/path.py
@@ -243,13 +243,31 @@ class ReportPaths:
             grouped[path.basename].append(path)
 
         results: list[File | Dir] = []
+        # check if current level has multiple groups to allow for flattening
+        has_siblings = len(grouped) > 1
 
         for basename, paths in grouped.items():
-            if len(paths) == 1 and paths[0].is_file:
-                path = paths[0]
-                results.append(
-                    File(full_path=path.full_path, totals=self._totals(path))
-                )
+            if len(paths) == 1:
+                if paths[0].is_file:
+                    path = paths[0]
+                    results.append(
+                        File(full_path=path.full_path, totals=self._totals(path))
+                    )
+                else:
+                    # continue on if there is only one child and it is a directory
+                    children = self._single_directory_recursive(
+                        PrefixedPath(full_path=path.full_path, prefix=basename)
+                        for path in paths
+                    )
+
+                    # we don't flatten directories with a single child if that parent
+                    # directory has siblings
+                    if has_siblings:
+                        results.append(Dir(full_path=basename, children=children))
+                    else:
+                        # we flatten directories with a single child when they
+                        # also only have a single child
+                        results.extend(children)
             else:
                 children = self._single_directory_recursive(
                     PrefixedPath(full_path=path.full_path, prefix=basename)

--- a/apps/codecov-api/services/tests/test_path.py
+++ b/apps/codecov-api/services/tests/test_path.py
@@ -270,6 +270,7 @@ class TestReportPathsNested(TestCase):
                             File(full_path="dir/subdir/dir2/file3.py", totals=totals3),
                             Dir(
                                 full_path="dir/subdir/dir2/dir3/dir4",
+                                max_directory_level=2,
                                 children=[
                                     File(
                                         full_path="dir/subdir/dir2/dir3/dir4/file4.py",
@@ -281,6 +282,7 @@ class TestReportPathsNested(TestCase):
                                     ),
                                     Dir(
                                         full_path="dir/subdir/dir2/dir3/dir4/dir5/dir6",
+                                        max_directory_level=2,
                                         children=[
                                             File(
                                                 full_path="dir/subdir/dir2/dir3/dir4/dir5/dir6/file6.py",
@@ -301,6 +303,7 @@ class TestReportPathsNested(TestCase):
             File(full_path="other1/file1.py", totals=totals3),
             Dir(
                 full_path="other1/other2/other3/other4",
+                max_directory_level=3,
                 children=[
                     File(
                         full_path="other1/other2/other3/other4/file2.py", totals=totals3

--- a/apps/codecov-api/services/tests/test_path.py
+++ b/apps/codecov-api/services/tests/test_path.py
@@ -242,6 +242,9 @@ class TestReportPathsNested(TestCase):
             "dir/subdir/dir2/dir3/dir4/file4.py": file_data3,
             "dir/subdir/dir2/dir3/dir4/file5.py": file_data3,
             "dir/subdir/dir2/dir3/dir4/dir5/dir6/file6.py": file_data3,
+            "other1/file1.py": file_data3,
+            "other1/other2/other3/other4/file2.py": file_data3,
+            "other1/other2/other3/other4/file3.py": file_data3,
             "src/ui/A/A.js": file_data3,
             "src/ui/Avatar/A.js": file_data3,
         }
@@ -266,33 +269,44 @@ class TestReportPathsNested(TestCase):
                         children=[
                             File(full_path="dir/subdir/dir2/file3.py", totals=totals3),
                             Dir(
-                                full_path="dir/subdir/dir2/dir3",
+                                full_path="dir/subdir/dir2/dir3/dir4",
                                 children=[
+                                    File(
+                                        full_path="dir/subdir/dir2/dir3/dir4/file4.py",
+                                        totals=totals3,
+                                    ),
+                                    File(
+                                        full_path="dir/subdir/dir2/dir3/dir4/file5.py",
+                                        totals=totals3,
+                                    ),
                                     Dir(
-                                        full_path="dir/subdir/dir2/dir3/dir4",
+                                        full_path="dir/subdir/dir2/dir3/dir4/dir5/dir6",
                                         children=[
                                             File(
-                                                full_path="dir/subdir/dir2/dir3/dir4/file4.py",
+                                                full_path="dir/subdir/dir2/dir3/dir4/dir5/dir6/file6.py",
                                                 totals=totals3,
-                                            ),
-                                            File(
-                                                full_path="dir/subdir/dir2/dir3/dir4/file5.py",
-                                                totals=totals3,
-                                            ),
-                                            Dir(
-                                                full_path="dir/subdir/dir2/dir3/dir4/dir5",
-                                                children=[
-                                                    File(
-                                                        full_path="dir/subdir/dir2/dir3/dir4/dir5/dir6/file6.py",
-                                                        totals=totals3,
-                                                    ),
-                                                ],
                                             ),
                                         ],
                                     ),
                                 ],
                             ),
                         ],
+                    ),
+                ],
+            ),
+        ]
+
+        report_paths = ReportPaths(self.report, path="other1")
+        assert report_paths.single_directory() == [
+            File(full_path="other1/file1.py", totals=totals3),
+            Dir(
+                full_path="other1/other2/other3/other4",
+                children=[
+                    File(
+                        full_path="other1/other2/other3/other4/file2.py", totals=totals3
+                    ),
+                    File(
+                        full_path="other1/other2/other3/other4/file3.py", totals=totals3
                     ),
                 ],
             ),

--- a/apps/codecov-api/services/tests/test_path.py
+++ b/apps/codecov-api/services/tests/test_path.py
@@ -30,8 +30,8 @@ file_data1 = [
 
 file_data2 = [
     2,
-    [0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0],
-    [[0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0]],
+    [0, 10, 7, 3, 0, "70.00000", 0, 0, 0, 0, 0, 0, 0],
+    [[0, 10, 7, 3, 0, "70.00000", 0, 0, 0, 0, 0, 0, 0]],
     [0, 2, 1, 1, 0, "50.00000", 0, 0, 0, 0, 0, 0, 0],
 ]
 
@@ -61,10 +61,10 @@ totals1 = ReportTotals(
 totals2 = ReportTotals(
     files=0,
     lines=10,
-    hits=8,
-    misses=2,
+    hits=7,
+    misses=3,
     partials=0,
-    coverage="80.00000",
+    coverage="70.00000",
     branches=0,
     methods=0,
     messages=0,
@@ -239,6 +239,9 @@ class TestReportPathsNested(TestCase):
             "dir/subdir/file2.py": file_data2,
             "dir/subdir/dir1/file3.py": file_data3,
             "dir/subdir/dir2/file3.py": file_data3,
+            "dir/subdir/dir2/dir3/dir4/file4.py": file_data3,
+            "dir/subdir/dir2/dir3/dir4/file5.py": file_data3,
+            "dir/subdir/dir2/dir3/dir4/dir5/dir6/file6.py": file_data3,
             "src/ui/A/A.js": file_data3,
             "src/ui/Avatar/A.js": file_data3,
         }
@@ -262,6 +265,33 @@ class TestReportPathsNested(TestCase):
                         full_path="dir/subdir/dir2",
                         children=[
                             File(full_path="dir/subdir/dir2/file3.py", totals=totals3),
+                            Dir(
+                                full_path="dir/subdir/dir2/dir3",
+                                children=[
+                                    Dir(
+                                        full_path="dir/subdir/dir2/dir3/dir4",
+                                        children=[
+                                            File(
+                                                full_path="dir/subdir/dir2/dir3/dir4/file4.py",
+                                                totals=totals3,
+                                            ),
+                                            File(
+                                                full_path="dir/subdir/dir2/dir3/dir4/file5.py",
+                                                totals=totals3,
+                                            ),
+                                            Dir(
+                                                full_path="dir/subdir/dir2/dir3/dir4/dir5",
+                                                children=[
+                                                    File(
+                                                        full_path="dir/subdir/dir2/dir3/dir4/dir5/dir6/file6.py",
+                                                        totals=totals3,
+                                                    ),
+                                                ],
+                                            ),
+                                        ],
+                                    ),
+                                ],
+                            ),
                         ],
                     ),
                 ],


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1219/snowflake-flatten-file-paths-in-the-file-viewer-component

This PR modifies how the "tree" viewer shows directories that have a single directory as its only child by flattening. This scenario occurs often in java/kotlin/go projects and while our "list" viewer shows full file paths, it is not the most efficient way to navigate to files.

SOLUTION: If a directory has a single child that is a directory, we tack on the child to the parent and link them together. This is similar to how GitHub shows their tree directories and gives users quick navigation with clarity. (This is slightly different from the proposed solution in the ticket).

Flatten example:
```
src/a/file1.py
src/a/b/c/d/file2.py
```
Clicking into directory `src/a` will show a link to file1.py and a flattened link to `/b/c/d` as `b` and `c` only have one child that is directory. 

Note:
I originally implemented a solution that started flattening at a directory that was an only child and only had one child, directory or file, as its child but I decided that this was not as useful as its criteria was very narrow. For example, for the above input, even though `/b` only has one child, because it has a sibling in file1.py, the flattening would not start until inside of `/b` for `/c/d/file2.py`. If it were to start earlier inside `/a`, it could have been potentially confusing for the user seeing a link to a file and a link to file with flatten dirs in between.
Ex:
```
Viewing /src/a
- file.py
- /b/c/d/file2.py
```


https://github.com/user-attachments/assets/52fe265b-a5f7-440b-ace9-4a374cd752f3

