### PR TITLE
fix: redefine new CAs to group by test_id

### DIFF
--- a/apps/codecov-api/api/public/v2/tests/test_api_coverage_viewset.py
+++ b/apps/codecov-api/api/public/v2/tests/test_api_coverage_viewset.py
@@ -1,11 +1,13 @@
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
 from django.conf import settings
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from reports.tests.factories import RepositoryFlagFactory
 from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
+from timeseries.helpers import refresh_measurement_summaries
 from timeseries.models import MeasurementName
 from timeseries.tests.factories import DatasetFactory, MeasurementFactory
 from utils.test_utils import APIClient
@@ -15,7 +17,7 @@ from utils.test_utils import APIClient
     not settings.TIMESERIES_ENABLED, reason="requires timeseries data storage"
 )
 @patch("api.shared.repo.repository_accessors.RepoAccessors.get_repo_permissions")
-class CoverageViewSetTestCase(TestCase):
+class CoverageViewSetTestCase(TransactionTestCase):
     databases = {"default", "timeseries"}
 
     def setUp(self):
@@ -76,6 +78,11 @@ class CoverageViewSetTestCase(TestCase):
             measurable_id="9999",
             branch="main",
             value=10.0,
+        )
+
+        refresh_measurement_summaries(
+            start_date=datetime(2021, 1, 1, tzinfo=UTC),
+            end_date=datetime(2023, 1, 1, tzinfo=UTC),
         )
 
         response = self.client.get(
@@ -148,6 +155,11 @@ class CoverageViewSetTestCase(TestCase):
             measurable_id="9999",
             branch="other",
             value=10.0,
+        )
+
+        refresh_measurement_summaries(
+            start_date=datetime(2021, 1, 1, tzinfo=UTC),
+            end_date=datetime(2023, 1, 1, tzinfo=UTC),
         )
 
         response = self.client.get(
@@ -256,6 +268,11 @@ class CoverageViewSetTestCase(TestCase):
             measurable_id=str(flag1.pk),
             branch="main",
             value=100.0,
+        )
+
+        refresh_measurement_summaries(
+            start_date=datetime(2021, 1, 1, tzinfo=UTC),
+            end_date=datetime(2023, 1, 1, tzinfo=UTC),
         )
 
         response = self.client.get(

--- a/apps/codecov-api/graphql_api/tests/test_bundle_analysis_measurements.py
+++ b/apps/codecov-api/graphql_api/tests/test_bundle_analysis_measurements.py
@@ -1,5 +1,7 @@
+from datetime import UTC, datetime
+
 import pytest
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from reports.models import CommitReport
 from reports.tests.factories import CommitReportFactory
@@ -11,13 +13,14 @@ from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     RepositoryFactory,
 )
+from timeseries.helpers import refresh_measurement_summaries
 from timeseries.tests.factories import MeasurementFactory
 
 from .helper import GraphQLTestHelper
 
 
 @pytest.mark.usefixtures("mock_storage_cls")
-class TestBundleAnalysisMeasurements(GraphQLTestHelper, TestCase):
+class TestBundleAnalysisMeasurements(GraphQLTestHelper, TransactionTestCase):
     databases = {"default", "timeseries"}
 
     def setUp(self):
@@ -83,6 +86,11 @@ class TestBundleAnalysisMeasurements(GraphQLTestHelper, TestCase):
                 timestamp=item[2],
                 value=item[3],
             )
+
+        refresh_measurement_summaries(
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime(2025, 1, 1, tzinfo=UTC),
+        )
 
     def test_bundle_report_measurements(self):
         with open("./services/tests/samples/bundle_with_uuid.sqlite", "rb") as f:
@@ -2179,6 +2187,11 @@ class TestBundleAnalysisMeasurements(GraphQLTestHelper, TestCase):
                 value=item[3],
             )
 
+        refresh_measurement_summaries(
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+
         with open("./services/tests/samples/bundle_with_uuid.sqlite", "rb") as f:
             storage_path = StoragePaths.bundle_report.path(
                 repo_key=ArchiveService.get_archive_hash(self.repo),
@@ -2435,6 +2448,11 @@ class TestBundleAnalysisMeasurements(GraphQLTestHelper, TestCase):
                 timestamp=item[2],
                 value=item[3],
             )
+
+        refresh_measurement_summaries(
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime(2025, 1, 1, tzinfo=UTC),
+        )
 
         with open("./services/tests/samples/bundle_with_uuid.sqlite", "rb") as f:
             storage_path = StoragePaths.bundle_report.path(
@@ -2706,6 +2724,11 @@ class TestBundleAnalysisMeasurements(GraphQLTestHelper, TestCase):
                 timestamp=item[2],
                 value=item[3],
             )
+
+        refresh_measurement_summaries(
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime(2025, 1, 1, tzinfo=UTC),
+        )
 
         with open("./services/tests/samples/bundle_with_uuid.sqlite", "rb") as f:
             storage_path = StoragePaths.bundle_report.path(

--- a/apps/codecov-api/graphql_api/tests/test_components.py
+++ b/apps/codecov-api/graphql_api/tests/test_components.py
@@ -1,9 +1,9 @@
+from datetime import UTC, datetime
 from unittest.mock import PropertyMock, patch
 
 import pytest
 from django.conf import settings
-from django.test import TestCase, override_settings
-from django.utils import timezone
+from django.test import TestCase, TransactionTestCase, override_settings
 
 from compare.models import CommitComparison
 from compare.tests.factories import CommitComparisonFactory, ComponentComparisonFactory
@@ -18,6 +18,7 @@ from shared.django_apps.core.tests.factories import (
 from shared.reports.resources import Report, ReportFile
 from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
+from timeseries.helpers import refresh_measurement_summaries
 from timeseries.models import MeasurementName
 from timeseries.tests.factories import DatasetFactory, MeasurementFactory
 
@@ -902,7 +903,7 @@ query ComponentMeasurements(
 @pytest.mark.skipif(
     not settings.TIMESERIES_ENABLED, reason="requires timeseries data storage"
 )
-class TestComponentMeasurements(GraphQLTestHelper, TestCase):
+class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
     databases = {"default", "timeseries"}
 
     def setUp(self):
@@ -995,9 +996,13 @@ class TestComponentMeasurements(GraphQLTestHelper, TestCase):
             "name": self.org.username,
             "repo": self.repo.name,
             "interval": "INTERVAL_1_DAY",
-            "after": timezone.datetime(2022, 6, 20),
-            "before": timezone.datetime(2022, 6, 23),
+            "after": datetime(2022, 6, 20, tzinfo=UTC),
+            "before": datetime(2022, 6, 23, tzinfo=UTC),
         }
+        refresh_measurement_summaries(
+            start_date=datetime(2021, 1, 1, tzinfo=UTC),
+            end_date=datetime(2023, 1, 1, tzinfo=UTC),
+        )
         data = self.gql_request(query_component_measurements, variables=variables)
 
         assert data == {
@@ -1082,8 +1087,8 @@ class TestComponentMeasurements(GraphQLTestHelper, TestCase):
             "name": self.org.username,
             "repo": self.repo.name,
             "interval": "INTERVAL_1_DAY",
-            "after": timezone.datetime(2022, 6, 20),
-            "before": timezone.datetime(2022, 6, 23),
+            "after": datetime(2022, 6, 20, tzinfo=UTC),
+            "before": datetime(2022, 6, 23, tzinfo=UTC),
         }
         data = self.gql_request(query_component_measurements, variables=variables)
         assert data == {
@@ -1119,8 +1124,8 @@ class TestComponentMeasurements(GraphQLTestHelper, TestCase):
             "name": self.org.username,
             "repo": self.repo.name,
             "interval": "INTERVAL_1_DAY",
-            "after": timezone.datetime(2022, 6, 20),
-            "before": timezone.datetime(2022, 6, 23),
+            "after": datetime(2022, 6, 20, tzinfo=UTC),
+            "before": datetime(2022, 6, 23, tzinfo=UTC),
         }
         data = self.gql_request(query_component_measurements, variables=variables)
         assert data == {
@@ -1193,10 +1198,14 @@ class TestComponentMeasurements(GraphQLTestHelper, TestCase):
             "name": self.org.username,
             "repo": self.repo.name,
             "interval": "INTERVAL_1_DAY",
-            "after": timezone.datetime(2022, 6, 20),
-            "before": timezone.datetime(2022, 6, 23),
+            "after": datetime(2022, 6, 20, tzinfo=UTC),
+            "before": datetime(2022, 6, 23, tzinfo=UTC),
             "filters": {"components": ["python"]},
         }
+        refresh_measurement_summaries(
+            start_date=datetime(2021, 1, 1, tzinfo=UTC),
+            end_date=datetime(2023, 1, 1, tzinfo=UTC),
+        )
         data = self.gql_request(query_component_measurements, variables=variables)
 
         assert data == {
@@ -1309,10 +1318,14 @@ class TestComponentMeasurements(GraphQLTestHelper, TestCase):
             "name": self.org.username,
             "repo": self.repo.name,
             "interval": "INTERVAL_1_DAY",
-            "after": timezone.datetime(2022, 6, 20),
-            "before": timezone.datetime(2022, 6, 23),
+            "after": datetime(2022, 6, 20, tzinfo=UTC),
+            "before": datetime(2022, 6, 23, tzinfo=UTC),
             "branch": "dev",
         }
+        refresh_measurement_summaries(
+            start_date=datetime(2021, 1, 1, tzinfo=UTC),
+            end_date=datetime(2023, 1, 1, tzinfo=UTC),
+        )
         data = self.gql_request(query_component_measurements, variables=variables)
 
         assert data == {
@@ -1462,10 +1475,14 @@ class TestComponentMeasurements(GraphQLTestHelper, TestCase):
             "name": self.org.username,
             "repo": self.repo.name,
             "interval": "INTERVAL_1_DAY",
-            "after": timezone.datetime(2022, 6, 20),
-            "before": timezone.datetime(2022, 6, 23),
+            "after": datetime(2022, 6, 20, tzinfo=UTC),
+            "before": datetime(2022, 6, 23, tzinfo=UTC),
             "branch": "dev",
         }
+        refresh_measurement_summaries(
+            start_date=datetime(2021, 1, 1, tzinfo=UTC),
+            end_date=datetime(2023, 1, 1, tzinfo=UTC),
+        )
         data = self.gql_request(query, variables=variables)
 
         assert data == {

--- a/ci-tests.docker-compose.yml
+++ b/ci-tests.docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - codecov
 
   timescale:
-    image: timescale/timescaledb-ha:pg14-latest
+    image: timescale/timescaledb:latest-pg14
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
       - codecov
 
   timescale:
-    image: timescale/timescaledb-ha:pg14-latest
+    image: timescale/timescaledb:latest-pg14
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:

--- a/libs/shared/shared/django_apps/migration_utils.py
+++ b/libs/shared/shared/django_apps/migration_utils.py
@@ -167,3 +167,113 @@ class RiskyRunPython(migrations.RunPython):
             return
 
         super().database_backwards(app_label, schema_editor, from_state, to_state)
+
+
+def drop_materialized_view(view_name: str, if_exists: bool = True) -> migrations.RunSQL:
+    exists_clause = " IF EXISTS" if if_exists else ""
+    forward_sql = f"DROP MATERIALIZED VIEW{exists_clause} {view_name};"
+    return migrations.RunSQL(forward_sql)
+
+
+def create_continuous_aggregate(
+    view_name: str,
+    select_sql: str,
+    *,
+    materialized_only: bool = False,
+    create_group_indexes: bool = False,
+    with_no_data: bool = True,
+) -> migrations.RunSQL:
+    options = [
+        "timescaledb.continuous",
+        f"timescaledb.materialized_only = {'true' if materialized_only else 'false'}",
+        f"timescaledb.create_group_indexes = {'true' if create_group_indexes else 'false'}",
+    ]
+
+    select_sql_clean = select_sql.strip()
+    if select_sql_clean.endswith(";"):
+        select_sql_clean = select_sql_clean[:-1]
+
+    with_no_data_sql = "\nWITH NO DATA" if with_no_data else ""
+
+    forward_sql = f"""
+        CREATE MATERIALIZED VIEW {view_name}
+        WITH (
+            {",\n    ".join(options)}
+        ) AS
+        {select_sql_clean}{with_no_data_sql};
+    """.strip()
+
+    reverse_sql = f"DROP MATERIALIZED VIEW IF EXISTS {view_name};"
+    return migrations.RunSQL(forward_sql, reverse_sql=reverse_sql)
+
+
+def create_index(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+) -> migrations.RunSQL:
+    column_exprs: list[str] = [str(col) for col in columns]
+
+    cols_sql = ", ".join(column_exprs)
+    forward_sql = (
+        f"CREATE INDEX IF NOT EXISTS {index_name} ON {table_name} ({cols_sql});"
+    )
+    reverse_sql = f"DROP INDEX IF EXISTS {index_name};"
+    return migrations.RunSQL(forward_sql, reverse_sql=reverse_sql)
+
+
+def add_continuous_aggregate_policy(
+    view_name: str,
+    *,
+    start_offset: str | None,
+    end_offset: str | None,
+    schedule_interval: str,
+) -> migrations.RunSQL:
+    start_sql = "NULL" if start_offset is None else f"'{start_offset}'"
+    end_sql = "NULL" if end_offset is None else f"'{end_offset}'"
+    schedule_sql = f"INTERVAL '{schedule_interval}'"
+
+    forward_sql = f"""
+        SELECT add_continuous_aggregate_policy(
+            '{view_name}',
+            start_offset => {start_sql},
+            end_offset => {end_sql},
+            schedule_interval => {schedule_sql}
+        );
+    """.strip()
+
+    reverse_sql = f"SELECT remove_continuous_aggregate_policy('{view_name}');"
+    return migrations.RunSQL(forward_sql, reverse_sql=reverse_sql)
+
+
+def add_retention_policy(relation_name: str, drop_after: str) -> migrations.RunSQL:
+    forward_sql = (
+        f"SELECT add_retention_policy('{relation_name}', INTERVAL '{drop_after}');"
+    )
+    reverse_sql = f"SELECT remove_retention_policy('{relation_name}');"
+    return migrations.RunSQL(forward_sql, reverse_sql=reverse_sql)
+
+
+def refresh_continuous_aggregate(
+    view_name: str,
+    start_expr_sql: str,
+    end_expr_sql: str | None,
+    *,
+    risky: bool,
+    force: bool = False,
+) -> RiskyRunSQL | migrations.RunSQL:
+    end_sql = "NULL" if end_expr_sql is None else end_expr_sql
+    force_sql = "true" if force else "false"
+    forward_sql = f"""
+        CALL refresh_continuous_aggregate(
+            '{view_name}',
+            {start_expr_sql},
+            {end_sql},
+            {force_sql}
+        );
+    """.strip()
+
+    if risky:
+        return RiskyRunSQL(forward_sql)
+    else:
+        return migrations.RunSQL(forward_sql)

--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0030_add_testrun_repo_test_time_idx.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0030_add_testrun_repo_test_time_idx.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+from shared.django_apps.migration_utils import RiskyAddIndex
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ta_timeseries", "0029_add_retention_policies_to_new_caggs"),
+    ]
+
+    operations = [
+        RiskyAddIndex(
+            model_name="testrun",
+            index=models.Index(
+                fields=["repo_id", "test_id", "timestamp"],
+                name="ta_ts__repo_test_time_idx",
+            ),
+        ),
+    ]

--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0031_redefine_test_aggregate_dailies_by_test_id.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0031_redefine_test_aggregate_dailies_by_test_id.py
@@ -1,0 +1,187 @@
+from django.db import migrations
+
+from shared.django_apps.migration_utils import (
+    add_continuous_aggregate_policy,
+    create_continuous_aggregate,
+    create_index,
+    drop_materialized_view,
+    refresh_continuous_aggregate,
+)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("ta_timeseries", "0030_add_testrun_repo_test_time_idx"),
+    ]
+
+    operations = [
+        drop_materialized_view("ta_timeseries_test_aggregate_daily"),
+        drop_materialized_view("ta_timeseries_branch_test_aggregate_daily"),
+        drop_materialized_view("ta_timeseries_test_aggregate_hourly"),
+        drop_materialized_view("ta_timeseries_branch_test_aggregate_hourly"),
+        create_continuous_aggregate(
+            "ta_timeseries_test_aggregate_hourly",
+            select_sql="""
+                SELECT
+                    repo_id,
+                    time_bucket(interval '1 hour', timestamp) AS bucket_hourly,
+                    test_id,
+                    min(computed_name) AS computed_name,
+                    min(testsuite) AS testsuite,
+                    array_agg(DISTINCT commit_sha) FILTER (WHERE outcome IN ('failure', 'flaky_fail')) AS failing_commits,
+                    LAST(duration_seconds, timestamp) AS last_duration_seconds,
+                    AVG(duration_seconds) AS avg_duration_seconds,
+                    COUNT(*) FILTER (WHERE outcome = 'pass') AS pass_count,
+                    COUNT(*) FILTER (WHERE outcome = 'failure') AS fail_count,
+                    COUNT(*) FILTER (WHERE outcome = 'skip') AS skip_count,
+                    COUNT(*) FILTER (WHERE outcome = 'flaky_fail') AS flaky_fail_count,
+                    LAST(outcome, timestamp) AS last_outcome,
+                    MAX(timestamp) AS updated_at,
+                    array_merge_dedup_agg(flags) AS flags
+                FROM ta_timeseries_testrun
+                GROUP BY repo_id, test_id, bucket_hourly
+            """,
+        ),
+        create_continuous_aggregate(
+            "ta_timeseries_branch_test_aggregate_hourly",
+            select_sql="""
+                SELECT
+                    repo_id,
+                    branch,
+                    time_bucket(interval '1 hour', timestamp) AS bucket_hourly,
+                    test_id,
+                    min(computed_name) AS computed_name,
+                    min(testsuite) AS testsuite,
+                    array_agg(DISTINCT commit_sha) FILTER (WHERE outcome IN ('failure', 'flaky_fail')) AS failing_commits,
+                    LAST(duration_seconds, timestamp) AS last_duration_seconds,
+                    AVG(duration_seconds) AS avg_duration_seconds,
+                    COUNT(*) FILTER (WHERE outcome = 'pass') AS pass_count,
+                    COUNT(*) FILTER (WHERE outcome = 'failure') AS fail_count,
+                    COUNT(*) FILTER (WHERE outcome = 'skip') AS skip_count,
+                    COUNT(*) FILTER (WHERE outcome = 'flaky_fail') AS flaky_fail_count,
+                    LAST(outcome, timestamp) AS last_outcome,
+                    MAX(timestamp) AS updated_at,
+                    array_merge_dedup_agg(flags) AS flags
+                FROM ta_timeseries_testrun
+                WHERE branch IN ('main', 'master', 'develop')
+                GROUP BY repo_id, branch, test_id, bucket_hourly
+            """,
+        ),
+        create_index(
+            "ta_ts_test_aggregate_hourly_repo_test_bucket_idx",
+            "ta_timeseries_test_aggregate_hourly",
+            ["repo_id", "test_id", "bucket_hourly DESC"],
+        ),
+        create_index(
+            "ta_ts_branch_test_aggregate_hourly_repo_branch_test_bucket_idx",
+            "ta_timeseries_branch_test_aggregate_hourly",
+            ["repo_id", "branch", "test_id", "bucket_hourly DESC"],
+        ),
+        create_continuous_aggregate(
+            "ta_timeseries_test_aggregate_daily",
+            select_sql="""
+                SELECT
+                    repo_id,
+                    time_bucket(interval '1 day', bucket_hourly) AS bucket_daily,
+                    test_id,
+                    min(computed_name) AS computed_name,
+                    min(testsuite) AS testsuite,
+                    array_merge_dedup_agg(failing_commits) AS failing_commits,
+                    LAST(last_duration_seconds, updated_at) AS last_duration_seconds,
+                    AVG(avg_duration_seconds) AS avg_duration_seconds,
+                    SUM(pass_count) AS pass_count,
+                    SUM(fail_count) AS fail_count,
+                    SUM(skip_count) AS skip_count,
+                    SUM(flaky_fail_count) AS flaky_fail_count,
+                    LAST(last_outcome, updated_at) AS last_outcome,
+                    MAX(updated_at) AS updated_at,
+                    array_merge_dedup_agg(flags) AS flags
+                FROM ta_timeseries_test_aggregate_hourly
+                GROUP BY repo_id, test_id, bucket_daily
+            """,
+        ),
+        create_continuous_aggregate(
+            "ta_timeseries_branch_test_aggregate_daily",
+            select_sql="""
+                SELECT
+                    repo_id,
+                    branch,
+                    time_bucket(interval '1 day', bucket_hourly) AS bucket_daily,
+                    test_id,
+                    min(computed_name) AS computed_name,
+                    min(testsuite) AS testsuite,
+                    array_merge_dedup_agg(failing_commits) AS failing_commits,
+                    LAST(last_duration_seconds, updated_at) AS last_duration_seconds,
+                    AVG(avg_duration_seconds) AS avg_duration_seconds,
+                    SUM(pass_count) AS pass_count,
+                    SUM(fail_count) AS fail_count,
+                    SUM(skip_count) AS skip_count,
+                    SUM(flaky_fail_count) AS flaky_fail_count,
+                    LAST(last_outcome, updated_at) AS last_outcome,
+                    MAX(updated_at) AS updated_at,
+                    array_merge_dedup_agg(flags) AS flags
+                FROM ta_timeseries_branch_test_aggregate_hourly
+                GROUP BY repo_id, branch, test_id, bucket_daily
+            """,
+        ),
+        create_index(
+            "ta_ts_test_aggregate_daily_repo_id_bucket_idx",
+            "ta_timeseries_test_aggregate_daily",
+            ["repo_id", "bucket_daily DESC"],
+        ),
+        create_index(
+            "ta_ts_branch_test_aggregate_daily_repo_branch_bucket_idx",
+            "ta_timeseries_branch_test_aggregate_daily",
+            ["repo_id", "branch", "bucket_daily DESC"],
+        ),
+        refresh_continuous_aggregate(
+            "ta_timeseries_test_aggregate_hourly",
+            "NOW() - INTERVAL '60 days'",
+            None,
+            risky=True,
+        ),
+        refresh_continuous_aggregate(
+            "ta_timeseries_branch_test_aggregate_hourly",
+            "NOW() - INTERVAL '60 days'",
+            None,
+            risky=True,
+        ),
+        refresh_continuous_aggregate(
+            "ta_timeseries_test_aggregate_daily",
+            "NOW() - INTERVAL '60 days'",
+            None,
+            risky=True,
+        ),
+        refresh_continuous_aggregate(
+            "ta_timeseries_branch_test_aggregate_daily",
+            "NOW() - INTERVAL '60 days'",
+            None,
+            risky=True,
+        ),
+        add_continuous_aggregate_policy(
+            "ta_timeseries_test_aggregate_hourly",
+            start_offset="2 hours",
+            end_offset=None,
+            schedule_interval="1 hour",
+        ),
+        add_continuous_aggregate_policy(
+            "ta_timeseries_branch_test_aggregate_hourly",
+            start_offset="2 hours",
+            end_offset=None,
+            schedule_interval="1 hour",
+        ),
+        add_continuous_aggregate_policy(
+            "ta_timeseries_test_aggregate_daily",
+            start_offset="2 days",
+            end_offset=None,
+            schedule_interval="1 day",
+        ),
+        add_continuous_aggregate_policy(
+            "ta_timeseries_branch_test_aggregate_daily",
+            start_offset="2 days",
+            end_offset=None,
+            schedule_interval="1 day",
+        ),
+    ]

--- a/libs/shared/shared/django_apps/ta_timeseries/models.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/models.py
@@ -66,6 +66,10 @@ class Testrun(ExportModelOperationsMixin("ta_timeseries.testrun"), models.Model)
                 fields=["repo_id", "branch", "test_id", "timestamp"],
             ),
             models.Index(
+                name="ta_ts__repo_test_time_idx",
+                fields=["repo_id", "test_id", "timestamp"],
+            ),
+            models.Index(
                 name="ta_ts__commit_i",
                 fields=["repo_id", "commit_sha", "timestamp"],
             ),
@@ -299,8 +303,7 @@ class TestAggregateHourly(
     __test__ = False
     bucket_hourly = models.DateTimeField(primary_key=True)
     repo_id = models.IntegerField()
-    name = models.TextField()
-    classname = models.TextField()
+    test_id = models.BinaryField()
     testsuite = models.TextField()
     computed_name = models.TextField()
     failing_commits = ArrayField(models.TextField(), default=list)
@@ -316,7 +319,10 @@ class TestAggregateHourly(
 
     __repr__ = sane_repr(
         "bucket_hourly",
+        "repo_id",
+        "test_id",
         "computed_name",
+        "testsuite",
         "pass_count",
         "fail_count",
         "skip_count",
@@ -337,8 +343,7 @@ class TestAggregateDaily(
     __test__ = False
     bucket_daily = models.DateTimeField(primary_key=True)
     repo_id = models.IntegerField()
-    name = models.TextField()
-    classname = models.TextField()
+    test_id = models.BinaryField()
     testsuite = models.TextField()
     computed_name = models.TextField()
     failing_commits = ArrayField(models.TextField(), default=list)
@@ -354,7 +359,10 @@ class TestAggregateDaily(
 
     __repr__ = sane_repr(
         "bucket_daily",
+        "repo_id",
+        "test_id",
         "computed_name",
+        "testsuite",
         "pass_count",
         "fail_count",
         "skip_count",
@@ -376,8 +384,7 @@ class BranchTestAggregateHourly(
     bucket_hourly = models.DateTimeField(primary_key=True)
     repo_id = models.IntegerField()
     branch = models.TextField()
-    name = models.TextField()
-    classname = models.TextField()
+    test_id = models.BinaryField()
     testsuite = models.TextField()
     computed_name = models.TextField()
     failing_commits = ArrayField(models.TextField(), default=list)
@@ -394,7 +401,10 @@ class BranchTestAggregateHourly(
     __repr__ = sane_repr(
         "bucket_hourly",
         "branch",
+        "repo_id",
+        "test_id",
         "computed_name",
+        "testsuite",
         "pass_count",
         "fail_count",
         "skip_count",
@@ -416,8 +426,7 @@ class BranchTestAggregateDaily(
     bucket_daily = models.DateTimeField(primary_key=True)
     repo_id = models.IntegerField()
     branch = models.TextField()
-    name = models.TextField()
-    classname = models.TextField()
+    test_id = models.BinaryField()
     testsuite = models.TextField()
     computed_name = models.TextField()
     failing_commits = ArrayField(models.TextField(), default=list)
@@ -434,7 +443,10 @@ class BranchTestAggregateDaily(
     __repr__ = sane_repr(
         "bucket_daily",
         "branch",
+        "repo_id",
+        "test_id",
         "computed_name",
+        "testsuite",
         "pass_count",
         "fail_count",
         "skip_count",


### PR DESCRIPTION
there's no index currently covering the testsuite, classname and name fields, and we don't want to create an index on those fields because names can be long, so we should group by test_id, because an index already exists