### PR TITLE
feat(admin): Admin view for upload breadcrumbs

### DIFF
--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -428,6 +428,10 @@ SHELTER_ENABLED = get_config("setup", "shelter_enabled", default=True)
 SENTRY_ENV = os.environ.get("CODECOV_ENV", None)
 SENTRY_DSN = os.environ.get("SERVICES__SENTRY__SERVER_DSN", None)
 SENTRY_DENY_LIST = DEFAULT_DENYLIST + ["_headers", "token_to_use"]
+# For linking to traces in Django admin, defaults to your most recently visited sentry.io org
+SENTRY_ORG_URL = get_config(
+    "services", "sentry", "org_domain", default="https://sentry.io"
+)
 
 if SENTRY_DSN is not None:
     SENTRY_SAMPLE_RATE = float(os.environ.get("SERVICES__SENTRY__SAMPLE_RATE", "0.1"))

--- a/libs/shared/shared/django_apps/settings_test.py
+++ b/libs/shared/shared/django_apps/settings_test.py
@@ -66,6 +66,8 @@ TEMPLATES = [
     }
 ]
 
+SENTRY_ORG_URL = "https://test.sentry.io"
+
 TELEMETRY_VANILLA_DB = "default"
 TELEMETRY_TIMESCALE_DB = "timeseries"
 

--- a/libs/shared/shared/django_apps/upload_breadcrumbs/admin.py
+++ b/libs/shared/shared/django_apps/upload_breadcrumbs/admin.py
@@ -1,0 +1,433 @@
+import json
+from collections.abc import Iterator
+from typing import Any
+
+from django.conf import settings
+from django.contrib import admin
+from django.db.models import QuerySet
+from django.http import HttpRequest
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+
+from shared.django_apps.core.models import Repository
+from shared.django_apps.upload_breadcrumbs.models import (
+    Endpoints,
+    Errors,
+    Milestones,
+    UploadBreadcrumb,
+)
+
+
+class PresentDataFilter(admin.SimpleListFilter):
+    title = "Present Data"
+    parameter_name = "present_data"
+
+    def lookups(
+        self, request: HttpRequest, model_admin: admin.ModelAdmin
+    ) -> list[tuple[str, str]]:
+        return [
+            ("has_milestone", "Has Milestone"),
+            ("has_endpoint", "Has Endpoint"),
+            ("has_error", "Has Error"),
+            ("has_error_text", "Has Error Text"),
+            ("has_upload_ids", "Has Upload IDs"),
+            ("has_sentry_trace", "Has Sentry Trace"),
+        ]
+
+    def choices(self, changelist: Any) -> Iterator[Any]:
+        """Override choices to add multiselect functionality."""
+        yield {
+            "selected": self.value() is None,
+            "query_string": changelist.get_query_string(remove=[self.parameter_name]),
+            "display": "All",
+        }
+
+        value = self.value()
+        current_values = value.split(",") if isinstance(value, str) else []
+
+        for lookup, title in self.lookup_choices:
+            selected = lookup in current_values
+            if selected:
+                # Remove this value from current selection
+                new_values = [v for v in current_values if v != lookup]
+            else:
+                # Add this value to current selection
+                new_values = current_values + [lookup]
+
+            new_value = ",".join(new_values) if new_values else None
+            query_dict = {self.parameter_name: new_value} if new_value else {}
+
+            yield {
+                "selected": selected,
+                "query_string": changelist.get_query_string(
+                    query_dict, [self.parameter_name]
+                ),
+                "display": f"{'✓ ' if selected else ''}{title}",
+            }
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
+        if not self.value():
+            return queryset
+
+        selected_filters = (self.value() or "").split(",")
+
+        for filter_type in selected_filters:
+            if filter_type == "has_milestone":
+                queryset = queryset.filter(breadcrumb_data__milestone__isnull=False)
+            elif filter_type == "has_endpoint":
+                queryset = queryset.filter(breadcrumb_data__endpoint__isnull=False)
+            elif filter_type == "has_error":
+                queryset = queryset.filter(breadcrumb_data__error__isnull=False)
+            elif filter_type == "has_error_text":
+                queryset = queryset.filter(breadcrumb_data__error_text__isnull=False)
+            elif filter_type == "has_upload_ids":
+                queryset = queryset.extra(where=["array_length(upload_ids, 1) >= 1"])
+            elif filter_type == "has_sentry_trace":
+                queryset = queryset.filter(sentry_trace_id__isnull=False)
+
+        return queryset
+
+
+class MilestoneFilter(admin.SimpleListFilter):
+    title = "Milestone"
+    parameter_name = "milestone"
+
+    def lookups(
+        self, request: HttpRequest, model_admin: admin.ModelAdmin
+    ) -> list[tuple[str, str]]:
+        return [(choice.value, choice.label) for choice in Milestones]
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
+        if self.value():
+            return queryset.filter(breadcrumb_data__milestone=self.value())
+        return queryset
+
+
+class EndpointFilter(admin.SimpleListFilter):
+    title = "Endpoint"
+    parameter_name = "endpoint"
+
+    def lookups(
+        self, request: HttpRequest, model_admin: admin.ModelAdmin
+    ) -> list[tuple[str, str]]:
+        return [(choice.value, choice.name) for choice in Endpoints]
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
+        if self.value():
+            return queryset.filter(breadcrumb_data__endpoint=self.value())
+        return queryset
+
+
+class ErrorFilter(admin.SimpleListFilter):
+    title = "Error"
+    parameter_name = "error"
+
+    def lookups(
+        self, request: HttpRequest, model_admin: admin.ModelAdmin
+    ) -> list[tuple[str, str]]:
+        return [(choice.value, choice.name) for choice in Errors]
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
+        if self.value():
+            return queryset.filter(breadcrumb_data__error=self.value())
+        return queryset
+
+
+@admin.register(UploadBreadcrumb)
+class UploadBreadcrumbAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "repo_id",
+        "formatted_commit_sha",
+        "formatted_breadcrumb_data",
+        "formatted_upload_ids",
+        "formatted_sentry_trace_id",
+    )
+    show_full_result_count = False
+    search_fields = (
+        "repo_id__startswith",
+        "commit_sha__startswith",
+        "sentry_trace_id__exact",
+    )
+    search_help_text = "Search by repository ID (starts with match), commit SHA (starts with match), and/or Sentry trace ID (exact match). Separate multiple values with spaces to AND search (E.g. '<repo_id> <commit_sha>')."
+    list_filter = [
+        PresentDataFilter,
+        MilestoneFilter,
+        EndpointFilter,
+        ErrorFilter,
+    ]
+    fields = (
+        "created_at",
+        "formatted_repo_id",
+        "commit_sha",
+        "formatted_breadcrumb_data_detail",
+        "formatted_upload_ids_detail",
+        "formatted_sentry_trace_id_detail",
+        "log_links",
+    )
+    date_hierarchy = "created_at"
+    list_per_page = 50
+    list_max_show_all = 200
+    show_full_result_count = False  # Disable full result count for performance
+
+    @admin.display(description="Repository", ordering="repo_id")
+    def formatted_repo_id(self, obj: UploadBreadcrumb) -> str:
+        """Display repository ID with link to repository admin page."""
+        if not obj.repo_id:
+            return "-"
+
+        try:
+            repo = Repository.objects.get(repoid=obj.repo_id)
+            repo_url = f"/admin/core/repository/{repo.repoid}/change/"
+            return format_html(
+                '<a href="{}" target="_blank">{}</a> ({})',
+                repo_url,
+                obj.repo_id,
+                f"{repo.author.username}/{repo.name}",
+            )
+        except Exception:
+            return str(obj.repo_id)
+
+    @admin.display(description="Commit", ordering="commit_sha")
+    def formatted_commit_sha(self, obj: UploadBreadcrumb) -> str:
+        """Display commit SHA as short hash."""
+        if not obj.commit_sha:
+            return "-"
+
+        return obj.commit_sha[:7]
+
+    @admin.display(description="Breadcrumb Data")
+    def formatted_breadcrumb_data(self, obj: UploadBreadcrumb) -> str:
+        """Display breadcrumb data compactly for list view."""
+        if not obj.breadcrumb_data:
+            return "-"
+
+        parts = []
+        data = obj.breadcrumb_data
+
+        if data.get("milestone"):
+            milestone_label = Milestones(data["milestone"]).label
+            parts.append(f"📍 {milestone_label}")
+
+        if data.get("endpoint"):
+            endpoint_label = Endpoints(data["endpoint"]).label
+            parts.append(f"🔗 {endpoint_label}")
+
+        if data.get("error"):
+            error_label = Errors(data["error"]).label
+            parts.append(f"❌ {error_label}")
+
+        if data.get("error_text"):
+            error_text = data["error_text"]
+            if len(error_text) > 50:
+                error_text = error_text[:47] + "..."
+            parts.append(f"💬 {error_text}")
+
+        return mark_safe("<br>".join(parts)) if parts else "-"
+
+    @admin.display(description="Breadcrumb Data")
+    def formatted_breadcrumb_data_detail(self, obj: UploadBreadcrumb) -> str:
+        """Display detailed breadcrumb data for individual item view."""
+        if not obj.breadcrumb_data:
+            return "-"
+
+        data = obj.breadcrumb_data
+        html_parts = []
+
+        html_parts.append(
+            '<div style="font-family: monospace; padding: 15px; border-radius: 5px; border: 1px solid var(--hairline-color);">'
+        )
+
+        # Show each field with its label
+        if data.get("milestone"):
+            milestone_label = Milestones(data["milestone"]).label
+            html_parts.append(
+                f"<div><strong>📍 Milestone:</strong> {milestone_label} <span>({data['milestone']})</span></div>"
+            )
+
+        if data.get("endpoint"):
+            endpoint_label = Endpoints(data["endpoint"]).label
+            endpoint_name = Endpoints(data["endpoint"]).name
+            html_parts.append(
+                f"<div><strong>🔗 Endpoint:</strong> {endpoint_label} <span>({data['endpoint']} / {endpoint_name})</span></div>"
+            )
+
+        if data.get("error"):
+            error_label = Errors(data["error"]).label
+            html_parts.append(
+                f"<div><strong>❌ Error:</strong> {error_label} <span>({data['error']})</span></div>"
+            )
+
+        if data.get("error_text"):
+            html_parts.append(
+                f"<div><strong>💬 Error Text:</strong> {data['error_text']}</div>"
+            )
+
+        html_parts.append("</div>")
+
+        # Also show raw JSON
+        html_parts.append(
+            '<br><details><summary style="cursor: pointer; font-weight: bold;">Raw JSON Data</summary>'
+        )
+        html_parts.append(
+            f'<pre style="padding: 10px; border-radius: 5px; border: 1px solid var(--hairline-color); overflow-x: auto;">{json.dumps(data, indent=2)}</pre>'
+        )
+        html_parts.append("</details>")
+
+        return mark_safe("".join(html_parts))
+
+    @admin.display(description="Upload IDs")
+    def formatted_upload_ids(self, obj: UploadBreadcrumb) -> str:
+        """Display upload IDs compactly for list view."""
+        if not obj.upload_ids:
+            return "-"
+
+        if len(obj.upload_ids) <= 3:
+            return ", ".join(str(uid) for uid in obj.upload_ids)
+        else:
+            return f"{', '.join(str(uid) for uid in obj.upload_ids[:3])}, ... (+{len(obj.upload_ids) - 3} more)"
+
+    @admin.display(description="Upload IDs")
+    def formatted_upload_ids_detail(self, obj: UploadBreadcrumb) -> str:
+        """Display detailed upload IDs for individual item view."""
+        if not obj.upload_ids:
+            return "-"
+
+        html_parts = []
+        html_parts.append(
+            '<div style="font-family: monospace; padding: 15px; border-radius: 5px; border: 1px solid var(--hairline-color);">'
+        )
+        html_parts.append(
+            f"<div><strong>Upload IDs ({len(obj.upload_ids)} total):</strong></div>"
+        )
+        html_parts.append('<div style="margin-top: 10px;">')
+
+        upload_items = [
+            f"<div style='margin-left: 10px;'>• {upload_id}</div>"
+            for upload_id in obj.upload_ids
+        ]
+        html_parts.extend(upload_items)
+
+        html_parts.append("</div>")
+        html_parts.append("</div>")
+
+        return mark_safe("".join(html_parts))
+
+    @admin.display(description="Sentry Trace", ordering="sentry_trace_id")
+    def formatted_sentry_trace_id(self, obj: UploadBreadcrumb) -> str:
+        """Display Sentry trace ID as a hyperlink for list view."""
+        if not obj.sentry_trace_id:
+            return "-"
+
+        short_trace = (
+            obj.sentry_trace_id[:8] + "..."
+            if len(obj.sentry_trace_id) > 8
+            else obj.sentry_trace_id
+        )
+
+        sentry_url = (
+            f"{settings.SENTRY_ORG_URL}/explore/traces/trace/{obj.sentry_trace_id}"
+        )
+
+        return format_html(
+            '<a href="{}" target="_blank" title="{}">{}</a>',
+            sentry_url,
+            obj.sentry_trace_id,
+            short_trace,
+        )
+
+    @admin.display(description="Sentry Trace")
+    def formatted_sentry_trace_id_detail(self, obj: UploadBreadcrumb) -> str:
+        """Display detailed Sentry trace ID with full link for individual item view."""
+        if not obj.sentry_trace_id:
+            return "-"
+
+        sentry_url = (
+            f"{settings.SENTRY_ORG_URL}/explore/traces/trace/{obj.sentry_trace_id}"
+        )
+
+        html_parts = []
+        html_parts.append(
+            '<div style="font-family: monospace; padding: 15px; border-radius: 5px; border: 1px solid var(--hairline-color, #e1e4e8);">'
+        )
+        html_parts.append(
+            f'<div style="margin-bottom: 10px;"><strong>Trace ID:</strong> {obj.sentry_trace_id}</div>'
+        )
+        html_parts.append(
+            f'<div><strong>Sentry Link:</strong> <a href="{sentry_url}" target="_blank">{sentry_url}</a></div>'
+        )
+        html_parts.append("</div>")
+
+        return mark_safe("".join(html_parts))
+
+    @admin.display(description="Log Links")
+    def log_links(self, obj: UploadBreadcrumb) -> str:
+        logs_base_url = "https://console.cloud.google.com/logs/query"
+
+        html_parts = []
+        html_parts.append("<div>")
+
+        if obj.commit_sha:
+            url = f"{logs_base_url};query=resource.type%3D%22k8s_container%22%0ASEARCH%2528%22%60{obj.commit_sha}%60%22%2529;duration=P2D"
+            html_parts.append(
+                f'<div>• <a href="{url}" target="_blank">Commit SHA Logs</a></div>'
+            )
+
+        if obj.sentry_trace_id:
+            url = f"{logs_base_url};query=resource.type%3D%22k8s_container%22%0ASEARCH%2528%22%60{obj.sentry_trace_id}%60%22%2529;duration=P2D"
+            html_parts.append(
+                f'<div>• <a href="{url}" target="_blank">Sentry Trace Logs</a></div>'
+            )
+
+        html_parts.append("</div>")
+
+        return mark_safe("".join(html_parts)) if len(html_parts) > 2 else "-"
+
+    def changelist_view(
+        self, request: HttpRequest, extra_context: dict | None = None
+    ) -> Any:
+        """Override to add info dialog explaining breadcrumbs."""
+        extra_context = extra_context or {}
+
+        milestone_list = "".join(
+            [f"<li>{milestone.label}</li>" for milestone in Milestones]
+        )
+
+        breadcrumb_info = f"""
+        <div style="padding-bottom: 20px;">
+            <details>
+                <summary style="cursor: pointer; font-weight: bold; margin-bottom: 10px;">
+                    Upload Breadcrumbs Information (click to expand)
+                </summary>
+                <div style="margin-left: 20px;">
+                    Upload breadcrumbs track the progress of coverage uploads throughout every stage of the upload process.
+                    Each breadcrumb represents a step in the upload process and may include:
+                    <ul style="margin: 10px 0 10px 20px;">
+                        <li><strong>Milestone:</strong> Current stage of the upload. The possible milestones are as follows and should appear for a given upload in this order:
+                            <ol style="margin: 5px 0 5px 20px;">
+                                {milestone_list}
+                            </ol>
+                        </li>
+                        <li><strong>Endpoint:</strong> API endpoint that triggered this breadcrumb. This is helpful to determine if there is an issue related to a specific endpoint.</li>
+                        <li><strong>Error:</strong> Any errors encountered during processing. This will either be a pre-defined error or "Unknown" for anything else. Not every error is indicative of total failure (such as retries), but they give insight into potential issues.</li>
+                        <li><strong>Error Text:</strong> If the error was not a known error, additional context will be provided here.</li>
+                        <li><strong>Upload IDs:</strong> Associated upload identifiers generated from worker. These indicate how an upload gets batched and processed with other uploads.</li>
+                        <li><strong>Sentry Trace:</strong> Trace ID for error tracking and debugging.</li>
+                    </ul>
+                    You can use the search bar and filters below to find specific breadcrumbs or uploads. Click on the ID of each to get more details and see relevant external links.
+                </div>
+            </details>
+        </div>
+        """
+
+        extra_context["breadcrumb_info"] = mark_safe(breadcrumb_info)
+        return super().changelist_view(request, extra_context)
+
+    def has_delete_permission(self, request: HttpRequest, obj: Any = None) -> bool:
+        return False
+
+    def has_add_permission(self, request: HttpRequest, obj: Any = None) -> bool:
+        return False
+
+    def has_change_permission(self, request: HttpRequest, obj: Any = None) -> bool:
+        return False

--- a/libs/shared/shared/django_apps/upload_breadcrumbs/templates/admin/upload_breadcrumbs/uploadbreadcrumb/change_list.html
+++ b/libs/shared/shared/django_apps/upload_breadcrumbs/templates/admin/upload_breadcrumbs/uploadbreadcrumb/change_list.html
@@ -1,0 +1,6 @@
+{% extends "admin/change_list.html" %}
+
+{% block content_title %}
+    {{ breadcrumb_info | default:"" }}
+    {{ block.super }}
+{% endblock %}

--- a/libs/shared/shared/django_apps/upload_breadcrumbs/tests/test_admin.py
+++ b/libs/shared/shared/django_apps/upload_breadcrumbs/tests/test_admin.py
@@ -1,0 +1,612 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from django.contrib.admin.sites import AdminSite
+from django.test import Client, TestCase
+from django.utils.safestring import SafeString
+
+from shared.django_apps.codecov_auth.tests.factories import UserFactory
+from shared.django_apps.core.tests.factories import RepositoryFactory
+from shared.django_apps.upload_breadcrumbs.admin import (
+    EndpointFilter,
+    ErrorFilter,
+    MilestoneFilter,
+    PresentDataFilter,
+    UploadBreadcrumbAdmin,
+)
+from shared.django_apps.upload_breadcrumbs.models import (
+    Endpoints,
+    Errors,
+    Milestones,
+    UploadBreadcrumb,
+)
+from shared.django_apps.upload_breadcrumbs.tests.factories import (
+    UploadBreadcrumbFactory,
+)
+
+
+class UploadBreadcrumbAdminTest(TestCase):
+    def setUp(self):
+        self.user = UserFactory(is_staff=True)
+        self.client = Client()
+        self.client.force_login(self.user)
+        self.admin = UploadBreadcrumbAdmin(UploadBreadcrumb, AdminSite())
+        self.repo = RepositoryFactory()
+
+    def test_permissions_disabled(self):
+        """Test that all permissions are disabled for upload breadcrumbs."""
+        request = MagicMock()
+        self.assertFalse(self.admin.has_delete_permission(request))
+        self.assertFalse(self.admin.has_add_permission(request))
+        self.assertFalse(self.admin.has_change_permission(request))
+
+    def test_formatted_repo_id_with_existing_repo(self):
+        """Test formatted_repo_id displays repo info correctly."""
+        breadcrumb = UploadBreadcrumbFactory(repo_id=self.repo.repoid)
+
+        result = self.admin.formatted_repo_id(breadcrumb)
+
+        self.assertIsInstance(result, SafeString)
+        self.assertIn(str(self.repo.repoid), result)
+        self.assertIn(self.repo.author.username, result)
+        self.assertIn(self.repo.name, result)
+        self.assertIn("/admin/core/repository/", result)
+
+    def test_formatted_repo_id_with_nonexistent_repo(self):
+        """Test formatted_repo_id handles missing related repo object gracefully."""
+        breadcrumb = UploadBreadcrumbFactory(repo_id=999999)
+
+        result = self.admin.formatted_repo_id(breadcrumb)
+
+        self.assertEqual(result, "999999")
+
+    def test_formatted_repo_id_with_no_repo_id(self):
+        """Test formatted_repo_id handles None repo_id."""
+        # Create a breadcrumb with a valid repo_id first, then set it to None to bypass validation
+        breadcrumb = UploadBreadcrumbFactory(repo_id=self.repo.repoid)
+        breadcrumb.repo_id = None
+
+        result = self.admin.formatted_repo_id(breadcrumb)
+
+        self.assertEqual(result, "-")
+
+    def test_formatted_commit_sha(self):
+        """Test commit SHA formatting with various input lengths."""
+        test_cases = [
+            ("abcdefghijklmnop1234567890", "abcdefg"),  # Long SHA truncated to 7
+            ("abc123", "abc123"),  # Short SHA not truncated
+            ("", "-"),  # Empty SHA returns dash
+        ]
+
+        for commit_sha, expected_result in test_cases:
+            with self.subTest(commit_sha=commit_sha):
+                breadcrumb = UploadBreadcrumbFactory(commit_sha=commit_sha)
+                result = self.admin.formatted_commit_sha(breadcrumb)
+                self.assertEqual(result, expected_result)
+
+    def test_formatted_breadcrumb_data_with_all_fields(self):
+        """Test breadcrumb data formatting with all fields present."""
+        breadcrumb_data = {
+            "milestone": Milestones.COMMIT_PROCESSED.value,
+            "endpoint": Endpoints.CREATE_COMMIT.value,
+            "error": Errors.BAD_REQUEST.value,
+            "error_text": "This is a test error message that is very long and should be truncated",
+        }
+        breadcrumb = UploadBreadcrumbFactory(breadcrumb_data=breadcrumb_data)
+
+        result = self.admin.formatted_breadcrumb_data(breadcrumb)
+
+        self.assertIsInstance(result, SafeString)
+        self.assertIn("📍", result)  # milestone emoji
+        self.assertIn("🔗", result)  # endpoint emoji
+        self.assertIn("❌", result)  # error emoji
+        self.assertIn("💬", result)  # error text emoji
+        self.assertIn(str(Milestones.COMMIT_PROCESSED.label), result)
+        self.assertIn(str(Endpoints.CREATE_COMMIT.label), result)
+        self.assertIn(str(Errors.BAD_REQUEST.label), result)
+        self.assertIn("This is a test error message that is very long ...", result)
+
+    def test_formatted_breadcrumb_data_empty(self):
+        """Test breadcrumb data formatting with no data."""
+        breadcrumb = UploadBreadcrumbFactory(breadcrumb_data={})
+
+        result = self.admin.formatted_breadcrumb_data(breadcrumb)
+
+        self.assertEqual(result, "-")
+
+    def test_formatted_breadcrumb_data_individual_fields(self):
+        """Test breadcrumb data formatting with individual fields."""
+        test_cases = [
+            (
+                {"milestone": Milestones.COMMIT_PROCESSED.value},
+                "📍",
+                str(Milestones.COMMIT_PROCESSED.label),
+                ["🔗", "❌", "💬"],
+            ),
+            (
+                {"endpoint": Endpoints.CREATE_COMMIT.value},
+                "🔗",
+                str(Endpoints.CREATE_COMMIT.label),
+                ["📍", "❌", "💬"],
+            ),
+            (
+                {"error": Errors.BAD_REQUEST.value},
+                "❌",
+                str(Errors.BAD_REQUEST.label),
+                ["📍", "🔗", "💬"],
+            ),
+            (
+                {"error_text": "Short error"},
+                "💬",
+                "Short error",
+                ["📍", "🔗", "❌"],
+            ),
+        ]
+
+        for (
+            breadcrumb_data,
+            expected_emoji,
+            expected_content,
+            not_expected_emojis,
+        ) in test_cases:
+            with self.subTest(breadcrumb_data=breadcrumb_data):
+                breadcrumb = UploadBreadcrumbFactory(breadcrumb_data=breadcrumb_data)
+                result = self.admin.formatted_breadcrumb_data(breadcrumb)
+
+                self.assertIsInstance(result, SafeString)
+                self.assertIn(expected_emoji, result)
+                self.assertIn(expected_content, result)
+                for emoji in not_expected_emojis:
+                    self.assertNotIn(emoji, result)
+
+    def test_formatted_breadcrumb_data_detail(self):
+        """Test detailed breadcrumb data formatting."""
+        breadcrumb_data = {
+            "milestone": Milestones.COMMIT_PROCESSED.value,
+            "endpoint": Endpoints.CREATE_COMMIT.value,
+            "error": Errors.BAD_REQUEST.value,
+            "error_text": "Test error",
+        }
+        breadcrumb = UploadBreadcrumbFactory(breadcrumb_data=breadcrumb_data)
+
+        result = self.admin.formatted_breadcrumb_data_detail(breadcrumb)
+
+        self.assertIsInstance(result, SafeString)
+        self.assertIn("📍 Milestone:", result)
+        self.assertIn("🔗 Endpoint:", result)
+        self.assertIn("❌ Error:", result)
+        self.assertIn("💬 Error Text:", result)
+        self.assertIn("Raw JSON Data", result)
+        self.assertIn(json.dumps(breadcrumb_data, indent=2), result)
+
+    def test_formatted_breadcrumb_data_detail_empty(self):
+        """Test detailed breadcrumb data formatting with no data."""
+        breadcrumb = UploadBreadcrumbFactory(breadcrumb_data={})
+
+        result = self.admin.formatted_breadcrumb_data_detail(breadcrumb)
+
+        self.assertEqual(result, "-")
+
+    def test_formatted_breadcrumb_data_detail_none(self):
+        """Test detailed breadcrumb data formatting with None data."""
+        breadcrumb = MagicMock()
+        breadcrumb.breadcrumb_data = None
+
+        result = self.admin.formatted_breadcrumb_data_detail(breadcrumb)
+
+        self.assertEqual(result, "-")
+
+    def test_formatted_breadcrumb_data_detail_individual_fields(self):
+        """Test detailed breadcrumb data formatting with individual fields."""
+        # Test milestone only
+        breadcrumb = UploadBreadcrumbFactory(
+            breadcrumb_data={"milestone": Milestones.COMMIT_PROCESSED.value}
+        )
+        result = self.admin.formatted_breadcrumb_data_detail(breadcrumb)
+        self.assertIn("📍 Milestone:", result)
+        self.assertIn(str(Milestones.COMMIT_PROCESSED.label), result)
+
+        # Test endpoint only
+        breadcrumb = UploadBreadcrumbFactory(
+            breadcrumb_data={"endpoint": Endpoints.CREATE_COMMIT.value}
+        )
+        result = self.admin.formatted_breadcrumb_data_detail(breadcrumb)
+        self.assertIn("🔗 Endpoint:", result)
+        self.assertIn(str(Endpoints.CREATE_COMMIT.label), result)
+        self.assertIn(Endpoints.CREATE_COMMIT.name, result)
+
+        # Test error only
+        breadcrumb = UploadBreadcrumbFactory(
+            breadcrumb_data={"error": Errors.BAD_REQUEST.value}
+        )
+        result = self.admin.formatted_breadcrumb_data_detail(breadcrumb)
+        self.assertIn("❌ Error:", result)
+        self.assertIn(str(Errors.BAD_REQUEST.label), result)
+
+        # Test error_text only
+        breadcrumb = UploadBreadcrumbFactory(
+            breadcrumb_data={"error_text": "Custom error message"}
+        )
+        result = self.admin.formatted_breadcrumb_data_detail(breadcrumb)
+        self.assertIn("💬 Error Text:", result)
+        self.assertIn("Custom error message", result)
+
+    def test_formatted_upload_ids(self):
+        """Test upload IDs formatting for list view with various inputs."""
+        test_cases = [
+            ([123, 456, 789], "123, 456, 789"),  # Few IDs
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "1, 2, 3, ... (+7 more)"),  # Many IDs
+            (None, "-"),  # None IDs
+            ([], "-"),  # Empty list
+        ]
+
+        for upload_ids, expected_result in test_cases:
+            with self.subTest(upload_ids=upload_ids):
+                breadcrumb = UploadBreadcrumbFactory(upload_ids=upload_ids)
+                result = self.admin.formatted_upload_ids(breadcrumb)
+                self.assertEqual(result, expected_result)
+
+    def test_formatted_upload_ids_detail_empty_cases(self):
+        """Test detailed upload IDs formatting with empty cases."""
+        test_cases = [
+            (None, "-"),
+            ([], "-"),
+        ]
+
+        for upload_ids, expected_result in test_cases:
+            with self.subTest(upload_ids=upload_ids):
+                breadcrumb = UploadBreadcrumbFactory(upload_ids=upload_ids)
+                result = self.admin.formatted_upload_ids_detail(breadcrumb)
+                self.assertEqual(result, expected_result)
+
+    def test_formatted_upload_ids_detail(self):
+        """Test detailed upload IDs formatting."""
+        upload_ids = [123, 456, 789]
+        breadcrumb = UploadBreadcrumbFactory(upload_ids=upload_ids)
+
+        result = self.admin.formatted_upload_ids_detail(breadcrumb)
+
+        self.assertIsInstance(result, SafeString)
+        self.assertIn("Upload IDs (3 total):", result)
+        self.assertIn("• 123", result)
+        self.assertIn("• 456", result)
+        self.assertIn("• 789", result)
+
+    def test_formatted_sentry_trace_id(self):
+        """Test Sentry trace ID formatting with various inputs."""
+        test_cases = [
+            ("abcdef1234567890", "abcdef12...", True),  # Long trace with ellipsis
+            ("abc123", "abc123", False),  # Short trace without ellipsis
+            (None, "-", False),  # None trace returns dash
+        ]
+
+        for trace_id, expected_display, should_have_ellipsis in test_cases:
+            with self.subTest(trace_id=trace_id):
+                breadcrumb = UploadBreadcrumbFactory(sentry_trace_id=trace_id)
+                result = self.admin.formatted_sentry_trace_id(breadcrumb)
+
+                if trace_id is None:
+                    self.assertEqual(result, "-")
+                else:
+                    self.assertIsInstance(result, SafeString)
+                    self.assertIn(expected_display, result)
+                    if should_have_ellipsis:
+                        self.assertIn("...", result)
+                        self.assertIn(
+                            f"https://test.sentry.io/explore/traces/trace/{trace_id}",
+                            result,
+                        )
+                        self.assertIn('target="_blank"', result)
+                    else:
+                        self.assertNotIn("...", result)
+
+    def test_formatted_sentry_trace_id_detail(self):
+        """Test detailed Sentry trace ID formatting."""
+        test_cases = [
+            ("abcdef1234567890", "formatted"),  # Valid trace ID
+            (None, "-"),  # None trace returns dash
+        ]
+
+        for trace_id, expected_result in test_cases:
+            with self.subTest(trace_id=trace_id):
+                breadcrumb = UploadBreadcrumbFactory(sentry_trace_id=trace_id)
+                result = self.admin.formatted_sentry_trace_id_detail(breadcrumb)
+
+                if expected_result == "-":
+                    self.assertEqual(result, "-")
+                else:
+                    self.assertIsInstance(result, SafeString)
+                    self.assertIn(f"Trace ID:</strong> {trace_id}", result)
+                    self.assertIn(
+                        f"https://test.sentry.io/explore/traces/trace/{trace_id}",
+                        result,
+                    )
+
+    def test_log_links(self):
+        """Test log links generation."""
+        commit_sha = "abcdef123"
+        trace_id = "trace123"
+        breadcrumb = UploadBreadcrumbFactory(
+            commit_sha=commit_sha, sentry_trace_id=trace_id
+        )
+
+        result = self.admin.log_links(breadcrumb)
+
+        self.assertIsInstance(result, SafeString)
+        self.assertIn("Commit SHA Logs", result)
+        self.assertIn("Sentry Trace Logs", result)
+        self.assertIn("console.cloud.google.com", result)
+        self.assertIn(commit_sha, result)
+        self.assertIn(trace_id, result)
+
+    def test_log_links_empty(self):
+        """Test log links with no commit SHA or trace ID."""
+        breadcrumb = UploadBreadcrumbFactory(commit_sha="", sentry_trace_id=None)
+
+        result = self.admin.log_links(breadcrumb)
+
+        self.assertEqual(result, "-")
+
+    def test_log_links_only_commit_sha(self):
+        """Test log links with only commit SHA."""
+        commit_sha = "abcdef123"
+        breadcrumb = UploadBreadcrumbFactory(
+            commit_sha=commit_sha, sentry_trace_id=None
+        )
+
+        result = self.admin.log_links(breadcrumb)
+
+        self.assertIsInstance(result, SafeString)
+        self.assertIn("Commit SHA Logs", result)
+        self.assertNotIn("Sentry Trace Logs", result)
+        self.assertIn(commit_sha, result)
+
+    def test_changelist_view_includes_info(self):
+        """Test that changelist view includes breadcrumb information."""
+        request = MagicMock()
+
+        # Mock the super().changelist_view call to capture what extra_context is passed to it
+        with patch("django.contrib.admin.ModelAdmin.changelist_view") as mock_super:
+            mock_super.return_value = MagicMock()
+
+            # Call the method with None extra_context (the typical case)
+            self.admin.changelist_view(request, None)
+
+            # Verify the parent method was called
+            mock_super.assert_called_once()
+
+            # Get the extra_context that was passed to the parent method
+            call_args = mock_super.call_args
+            self.assertEqual(len(call_args[0]), 2)  # request and extra_context
+            passed_extra_context = call_args[0][1]
+
+            # Verify extra_context contains breadcrumb_info
+            self.assertIn("breadcrumb_info", passed_extra_context)
+            self.assertIsInstance(passed_extra_context["breadcrumb_info"], SafeString)
+            self.assertIn(
+                "Upload Breadcrumbs Information",
+                passed_extra_context["breadcrumb_info"],
+            )
+            self.assertIn("Milestone:", passed_extra_context["breadcrumb_info"])
+
+            # Check that milestone list is included
+            for milestone in Milestones:
+                self.assertIn(
+                    str(milestone.label), passed_extra_context["breadcrumb_info"]
+                )
+
+
+class PresentDataFilterTest(TestCase):
+    def setUp(self):
+        self.filter = PresentDataFilter(
+            None, {}, UploadBreadcrumb, UploadBreadcrumbAdmin
+        )
+
+    def test_lookups(self):
+        """Test filter lookups are correct."""
+        request = MagicMock()
+        model_admin = MagicMock()
+
+        lookups = self.filter.lookups(request, model_admin)
+
+        expected = [
+            ("has_milestone", "Has Milestone"),
+            ("has_endpoint", "Has Endpoint"),
+            ("has_error", "Has Error"),
+            ("has_error_text", "Has Error Text"),
+            ("has_upload_ids", "Has Upload IDs"),
+            ("has_sentry_trace", "Has Sentry Trace"),
+        ]
+        self.assertEqual(lookups, expected)
+
+    def test_queryset_no_value(self):
+        """Test queryset returns unchanged when no filter value."""
+        request = MagicMock()
+        queryset = UploadBreadcrumb.objects.all()
+
+        with patch.object(self.filter, "value", return_value=None):
+            result = self.filter.queryset(request, queryset)
+
+        self.assertEqual(result, queryset)
+
+    def test_queryset_multiple_filters(self):
+        """Test multiple filters combined."""
+        request = MagicMock()
+        queryset = UploadBreadcrumb.objects.all()
+
+        with patch.object(
+            self.filter,
+            "value",
+            return_value="has_milestone,has_endpoint,has_error,has_error_text,has_upload_ids,has_sentry_trace",
+        ):
+            result = self.filter.queryset(request, queryset)
+
+        # Check that the filter was applied
+        self.assertNotEqual(result, queryset)
+
+    def test_choices_multiselect(self):
+        """Test multiselect choices functionality."""
+        changelist = MagicMock()
+        changelist.get_query_string.return_value = "test_query_string"
+
+        with patch.object(self.filter, "value", return_value="has_milestone,has_error"):
+            choices = list(self.filter.choices(changelist))
+
+        # Should have "All" option plus all filter options
+        self.assertEqual(len(choices), 7)  # 1 "All" + 6 filter options
+
+        # Check that selected items have checkmarks
+        milestone_choice = next(c for c in choices if "Has Milestone" in c["display"])
+        error_choice = next(c for c in choices if "Has Error" in c["display"])
+        endpoint_choice = next(c for c in choices if "Has Endpoint" in c["display"])
+
+        self.assertTrue(milestone_choice["selected"])
+        self.assertTrue(error_choice["selected"])
+        self.assertFalse(endpoint_choice["selected"])
+        self.assertIn("✓", milestone_choice["display"])
+        self.assertIn("✓", error_choice["display"])
+        self.assertNotIn("✓", endpoint_choice["display"])
+
+    def test_queryset_individual_filters(self):
+        """Test each filter type individually."""
+        request = MagicMock()
+        queryset = UploadBreadcrumb.objects.all()
+
+        # Test each filter type individually
+        filter_types = [
+            "has_milestone",
+            "has_endpoint",
+            "has_error",
+            "has_error_text",
+            "has_upload_ids",
+            "has_sentry_trace",
+        ]
+
+        for filter_type in filter_types:
+            with self.subTest(filter_type=filter_type):
+                with patch.object(self.filter, "value", return_value=filter_type):
+                    result = self.filter.queryset(request, queryset)
+                    # Check that the filter was applied (queryset changed)
+                    self.assertNotEqual(result, queryset)
+
+    def test_queryset_with_unknown_filter(self):
+        """Test with unknown filter type"""
+        request = MagicMock()
+        queryset = UploadBreadcrumb.objects.all()
+
+        with patch.object(self.filter, "value", return_value="unknown_filter"):
+            result = self.filter.queryset(request, queryset)
+            self.assertEqual(result, queryset)
+
+
+class MilestoneFilterTest(TestCase):
+    def setUp(self):
+        self.filter = MilestoneFilter(None, {}, UploadBreadcrumb, UploadBreadcrumbAdmin)
+
+    def test_lookups(self):
+        """Test milestone filter lookups."""
+        request = MagicMock()
+        model_admin = MagicMock()
+
+        lookups = self.filter.lookups(request, model_admin)
+
+        # Should have all milestone choices
+        self.assertEqual(len(lookups), len(Milestones))
+        for choice in Milestones:
+            self.assertIn((choice.value, str(choice.label)), lookups)
+
+    def test_queryset(self):
+        """Test milestone filter queryset behavior."""
+        test_cases = [
+            (Milestones.COMMIT_PROCESSED.value, True),
+            (None, False),
+        ]
+
+        for filter_value, should_change_queryset in test_cases:
+            with self.subTest(filter_value=filter_value):
+                request = MagicMock()
+                queryset = UploadBreadcrumb.objects.all()
+
+                with patch.object(self.filter, "value", return_value=filter_value):
+                    result = self.filter.queryset(request, queryset)
+
+                if should_change_queryset:
+                    self.assertNotEqual(result, queryset)
+                else:
+                    self.assertEqual(result, queryset)
+
+
+class EndpointFilterTest(TestCase):
+    def setUp(self):
+        self.filter = EndpointFilter(None, {}, UploadBreadcrumb, UploadBreadcrumbAdmin)
+
+    def test_lookups(self):
+        """Test endpoint filter lookups use enum names."""
+        request = MagicMock()
+        model_admin = MagicMock()
+
+        lookups = self.filter.lookups(request, model_admin)
+
+        # Should have all endpoint choices with names (not labels)
+        self.assertEqual(len(lookups), len(Endpoints))
+        for choice in Endpoints:
+            self.assertIn((choice.value, choice.name), lookups)
+
+    def test_queryset(self):
+        """Test endpoint filter queryset behavior."""
+        test_cases = [
+            (Endpoints.CREATE_COMMIT.value, True),
+            (None, False),
+        ]
+
+        for filter_value, should_change_queryset in test_cases:
+            with self.subTest(filter_value=filter_value):
+                request = MagicMock()
+                queryset = UploadBreadcrumb.objects.all()
+
+                with patch.object(self.filter, "value", return_value=filter_value):
+                    result = self.filter.queryset(request, queryset)
+
+                if should_change_queryset:
+                    self.assertNotEqual(result, queryset)
+                else:
+                    self.assertEqual(result, queryset)
+
+
+class ErrorFilterTest(TestCase):
+    def setUp(self):
+        self.filter = ErrorFilter(None, {}, UploadBreadcrumb, UploadBreadcrumbAdmin)
+
+    def test_lookups(self):
+        """Test error filter lookups use enum names."""
+        request = MagicMock()
+        model_admin = MagicMock()
+
+        lookups = self.filter.lookups(request, model_admin)
+
+        # Should have all error choices with names (not labels)
+        self.assertEqual(len(lookups), len(Errors))
+        for choice in Errors:
+            self.assertIn((choice.value, choice.name), lookups)
+
+    def test_queryset(self):
+        """Test error filter queryset behavior with different values."""
+        test_cases = [
+            (Errors.BAD_REQUEST.value, True),
+            (None, False),
+        ]
+
+        for filter_value, should_change_queryset in test_cases:
+            with self.subTest(filter_value=filter_value):
+                request = MagicMock()
+                queryset = UploadBreadcrumb.objects.all()
+
+                with patch.object(self.filter, "value", return_value=filter_value):
+                    result = self.filter.queryset(request, queryset)
+
+                if should_change_queryset:
+                    # Check that the filter was applied
+                    self.assertNotEqual(result, queryset)
+                else:
+                    # Should return original queryset
+                    self.assertEqual(result, queryset)


### PR DESCRIPTION
As the title says, this PR introduces an admin view for upload breadcrumbs. Photos below:

## Expandable explainer

<img width="1714" height="695" alt="image" src="https://github.com/user-attachments/assets/2a282ac1-bedc-4c97-bda5-089aaf3cb616" />

## List page with search and filters

<img width="1721" height="906" alt="image" src="https://github.com/user-attachments/assets/6853e8e2-810a-40f3-bbe6-83cb770b1ed0" />

## Detailed view (2 examples)

<img width="1724" height="784" alt="image" src="https://github.com/user-attachments/assets/59226a2b-683c-4dcd-92d1-5682f1bf849a" />
<img width="1722" height="783" alt="image" src="https://github.com/user-attachments/assets/10872008-d30e-4a7e-8871-2960d6b4a3f8" />