### PR TITLE
feat(shared): Config options for upload breadcrumbs retention period

### DIFF
--- a/libs/shared/shared/django_apps/utils/partitioning.py
+++ b/libs/shared/shared/django_apps/utils/partitioning.py
@@ -6,9 +6,22 @@ from psqlextra.partitioning import (
 )
 from psqlextra.partitioning.config import PostgresPartitioningConfig
 
+from shared.config import get_config
 from shared.django_apps.reports.models import DailyTestRollup
 from shared.django_apps.upload_breadcrumbs.models import UploadBreadcrumb
 from shared.django_apps.user_measurements.models import UserMeasurement
+
+upload_breadcrumbs_retention = get_config(
+    "setup", "upload_breadcrumbs", "retention", default={}
+)
+# Set unlimited to true to keep partitions forever (overrides all other options)
+ub_unlimited = upload_breadcrumbs_retention.get("unlimited", False)
+# Options to set retention period by years, months, and/or days (3 months by default)
+# If multiple options are set, the length will be the addition of all specified periods
+ub_years = upload_breadcrumbs_retention.get("years", 0)
+ub_months = upload_breadcrumbs_retention.get("months", 3)
+ub_days = upload_breadcrumbs_retention.get("days", 0)
+
 
 # Overlapping partitions will cause errors - https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE -> "create partitions"
 # Note that the partitioning manager will not perform the actual creation and deletion of partitions automatically, we have a Celery task for that.
@@ -37,14 +50,20 @@ manager = PostgresPartitioningManager(
             ),
         ),
         # 3 partitions ahead, each partition is one 1 week
-        # Delete partitions older than 3 months
+        # Delete partitions older than a specified retention period
         # Partitions will be named `[table_name]_[year]_week_[week number]`
         PostgresPartitioningConfig(
             model=UploadBreadcrumb,
             strategy=PostgresCurrentTimePartitioningStrategy(
                 size=PostgresTimePartitionSize(weeks=1),
                 count=3,
-                max_age=relativedelta(months=3),
+                max_age=None
+                if ub_unlimited
+                else relativedelta(
+                    years=ub_years,
+                    months=ub_months,
+                    days=ub_days,
+                ),
             ),
         ),
     ]


### PR DESCRIPTION
Allows for either unlimited retention or a retention policy based on years, months, and/or days. Defaults to the current value of 90 days.