### PR TITLE
fix(api): Make all config values use standard config function

### DIFF
--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -426,11 +426,13 @@ SHELTER_SHARED_SECRET = get_config("setup", "shelter_shared_secret", default=Non
 SHELTER_ENABLED = get_config("setup", "shelter_enabled", default=True)
 
 SENTRY_ENV = os.environ.get("CODECOV_ENV", None)
-SENTRY_DSN = os.environ.get("SERVICES__SENTRY__SERVER_DSN", None)
+SENTRY_DSN = get_config("services", "sentry", "server_dsn", default=None)
 SENTRY_DENY_LIST = DEFAULT_DENYLIST + ["_headers", "token_to_use"]
 
 if SENTRY_DSN is not None:
-    SENTRY_SAMPLE_RATE = float(os.environ.get("SERVICES__SENTRY__SAMPLE_RATE", "0.1"))
+    SENTRY_SAMPLE_RATE = float(
+        get_config("services", "sentry", "sample_rate", default="0.1")
+    )
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         event_scrubber=EventScrubber(denylist=SENTRY_DENY_LIST),
@@ -446,7 +448,7 @@ if SENTRY_DSN is not None:
         environment=SENTRY_ENV,
         traces_sample_rate=SENTRY_SAMPLE_RATE,
         profiles_sample_rate=float(
-            os.environ.get("SERVICES__SENTRY__PROFILE_SAMPLE_RATE", "0.01")
+            get_config("services", "sentry", "profile_sample_rate", default="0.01")
         ),
     )
     if os.getenv("CLUSTER_ENV"):

--- a/apps/codecov-api/codecov/settings_prod.py
+++ b/apps/codecov-api/codecov/settings_prod.py
@@ -13,8 +13,10 @@ if THIS_POD_IP:
 WEBHOOK_URL = get_config("setup", "webhook_url", default="https://codecov.io")
 
 
-STRIPE_API_KEY = os.environ.get("SERVICES__STRIPE__API_KEY", None)
-STRIPE_ENDPOINT_SECRET = os.environ.get("SERVICES__STRIPE__ENDPOINT_SECRET", None)
+STRIPE_API_KEY = get_config("services", "stripe", "api_key", default=None)
+STRIPE_ENDPOINT_SECRET = get_config(
+    "services", "stripe", "endpoint_secret", default=None
+)
 
 CORS_ALLOW_HEADERS += ["sentry-trace", "baggage"]
 CODECOV_URL = get_config("setup", "codecov_url", default="https://codecov.io")

--- a/apps/codecov-api/codecov/settings_staging.py
+++ b/apps/codecov-api/codecov/settings_staging.py
@@ -14,8 +14,10 @@ WEBHOOK_URL = get_config(
     "setup", "webhook_url", default="https://stage-api.codecov.dev"
 )
 
-STRIPE_API_KEY = os.environ.get("SERVICES__STRIPE__API_KEY", None)
-STRIPE_ENDPOINT_SECRET = os.environ.get("SERVICES__STRIPE__ENDPOINT_SECRET", None)
+STRIPE_API_KEY = get_config("services", "stripe", "api_key", default=None)
+STRIPE_ENDPOINT_SECRET = get_config(
+    "services", "stripe", "endpoint_secret", default=None
+)
 COOKIES_DOMAIN = ".codecov.dev"
 SESSION_COOKIE_DOMAIN = ".codecov.dev"
 


### PR DESCRIPTION
This allows configuration via both environment variables or via the config file instead of just the former