### PR TITLE
fix: update webhook github app installation handling

### DIFF
--- a/apps/codecov-api/webhook_handlers/views/github.py
+++ b/apps/codecov-api/webhook_handlers/views/github.py
@@ -5,6 +5,7 @@ from hashlib import sha1, sha256
 from typing import Literal
 
 import sentry_sdk
+from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
@@ -471,6 +472,11 @@ class GithubWebhookHandler(APIView):
                     return self._invalid_owner_on_existing_app_install(
                         ghapp_installation, owner, request, app_id, installation_id
                     )
+
+            sentry_app_id = settings.GITHUB_SENTRY_APP_ID
+            if sentry_app_id is not None and ghapp_installation.app_id == sentry_app_id:
+                ghapp_installation.app_id = app_id
+                ghapp_installation.pem_path = settings.GITHUB_SENTRY_APP_PEM
 
             # Either update or set
             ghapp_installation.name = self._decide_app_name(ghapp_installation)

--- a/libs/shared/shared/github/__init__.py
+++ b/libs/shared/shared/github/__init__.py
@@ -94,8 +94,12 @@ def get_github_jwt_token(
         "iat": now,
         # JWT expiration time (max 10 minutes)
         "exp": now + int(get_config(service, "integration", "expires", default=500)),
-        # Integration's GitHub identifier
-        "iss": app_id or get_config(service, "integration", "id"),
+        # NOTE: the Sentry app github app installations explicitly defines the app_id
+        # and pem_path so those will get passed down no matter what and we won't fall back
+        # to the default config value. We're essentially treating Sentry apps like the custom
+        # ones that are defined through the database, by including the app id and pem path when
+        # creating the DB object in the webhook handler.
+        "iss": app_id or get_config(service, "integration", "id"),  # github app ID
     }
     pem_kwargs = {"pem_path": pem_path} if pem_path else {"pem_name": service}
     return jwt.encode(payload, get_pem(**pem_kwargs), algorithm="RS256")


### PR DESCRIPTION
We're essentially treating Sentry apps like the custom ones that are defined through the database, by including the app id and pem path when creating the DB object in the webhook handler.

we're trusting that the logic that was written for supporting those custom apps defined through the DB works properly and with that assumption, this approach should work.