### PR TITLE
feat: Performance improvements for Django admin

### DIFF
--- a/apps/codecov-api/compare/admin.py
+++ b/apps/codecov-api/compare/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from shared.django_apps.utils.paginator import EstimatedCountPaginator
+
 from .models import CommitComparison
 
 
@@ -13,6 +15,7 @@ class CommitComparisonAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     )
+    paginator = EstimatedCountPaginator
 
     def get_base_commit(self, obj):
         return obj.base_commit.commitid

--- a/apps/codecov-api/core/admin.py
+++ b/apps/codecov-api/core/admin.py
@@ -1,15 +1,13 @@
 from django import forms
 from django.contrib import admin
-from django.core.paginator import Paginator
-from django.db import connections
 from django.db.models import QuerySet
 from django.http import HttpRequest
-from django.utils.functional import cached_property
 
 from codecov.admin import AdminMixin
 from codecov_auth.models import RepositoryToken
 from core.models import Pull, Repository
 from services.task.task import TaskService
+from shared.django_apps.utils.paginator import EstimatedCountPaginator
 
 
 class RepositoryTokenInline(admin.TabularInline):
@@ -24,26 +22,6 @@ class RepositoryTokenInline(admin.TabularInline):
 
     class Meta:
         readonly_fields = ("key",)
-
-
-class EstimatedCountPaginator(Paginator):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.object_list.count = self.count
-
-    @cached_property
-    def count(self):
-        # Inspired by https://code.djangoproject.com/ticket/8408
-        if self.object_list.query.where:
-            return self.object_list.count()
-
-        db_table = self.object_list.model._meta.db_table
-        cursor = connections[self.object_list.db].cursor()
-        cursor.execute("SELECT reltuples FROM pg_class WHERE relname = %s", (db_table,))
-        result = cursor.fetchone()
-        if not result:
-            return 0
-        return int(result[0])
 
 
 class RepositoryAdminForm(forms.ModelForm):

--- a/apps/codecov-api/reports/admin.py
+++ b/apps/codecov-api/reports/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 
 from codecov.admin import AdminMixin
 from reports.models import ReportSession
+from shared.django_apps.utils.paginator import EstimatedCountPaginator
 
 
 @admin.register(ReportSession)
@@ -11,6 +12,7 @@ class ReportSessionAdmin(AdminMixin, admin.ModelAdmin):
     readonly_fields = ("external_id", "storage_path", "upload_type")
     search_fields = ("external_id",)
     fields = readonly_fields
+    paginator = EstimatedCountPaginator
 
     def has_delete_permission(self, request, obj=None):
         return False

--- a/apps/codecov-api/timeseries/admin.py
+++ b/apps/codecov-api/timeseries/admin.py
@@ -9,6 +9,7 @@ from django.shortcuts import render
 from codecov.admin import AdminMixin
 from core.models import Repository
 from services.task import TaskService
+from shared.django_apps.utils.paginator import EstimatedCountPaginator
 from timeseries.models import Dataset
 
 
@@ -33,6 +34,7 @@ class BackfillForm(forms.Form):
 class DatasetAdmin(AdminMixin, admin.ModelAdmin):
     list_display = ("name", "repository", "backfilled")
     actions = ["backfill"]
+    paginator = EstimatedCountPaginator
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)

--- a/libs/shared/shared/django_apps/upload_breadcrumbs/admin.py
+++ b/libs/shared/shared/django_apps/upload_breadcrumbs/admin.py
@@ -18,6 +18,7 @@ from shared.django_apps.upload_breadcrumbs.models import (
     Milestones,
     UploadBreadcrumb,
 )
+from shared.django_apps.utils.paginator import EstimatedCountPaginator
 
 
 class PresentDataFilter(admin.SimpleListFilter):
@@ -155,6 +156,10 @@ class UploadBreadcrumbAdmin(admin.ModelAdmin):
         "formatted_upload_ids",
         "formatted_sentry_trace_id",
     )
+    sortable_by = (
+        "repo_id",
+        "formatted_commit_sha",
+    )  # Limit sorting options to indexed columns
     show_full_result_count = False
     search_fields = (
         "repo_id__startswith",
@@ -177,10 +182,10 @@ class UploadBreadcrumbAdmin(admin.ModelAdmin):
         "formatted_sentry_trace_id_detail",
         "log_links",
     )
-    date_hierarchy = "created_at"
     list_per_page = 50
     list_max_show_all = 200
     show_full_result_count = False  # Disable full result count for performance
+    paginator = EstimatedCountPaginator
 
     @admin.display(description="Repository", ordering="repo_id")
     def formatted_repo_id(self, obj: UploadBreadcrumb) -> str:

--- a/libs/shared/shared/django_apps/utils/paginator.py
+++ b/libs/shared/shared/django_apps/utils/paginator.py
@@ -1,0 +1,70 @@
+from django.core.paginator import Paginator
+from django.db import connections
+from django.utils.functional import cached_property
+
+
+class EstimatedCountPaginator(Paginator):
+    """
+    Overrides the count method of QuerySet objects to avoid timeouts.
+
+    Based on: https://gist.github.com/adinhodovic/f27f6c466900086a914e113e1d41031c
+
+    * Get an estimate instead of actual count when not filtered (this estimate
+      can be stale and hence not fit for situations where the count of objects
+      actually matters)
+    * If any other exception occurred fall back to the default behaviour
+    """
+
+    @cached_property
+    def count(self) -> int:
+        """
+        Returns an estimated number of objects, across all pages.
+        """
+        if not self.object_list.query.where:  # type: ignore
+            try:
+                with connections[self.object_list.db].cursor() as cursor:  # type: ignore
+                    # Obtain estimated values (only valid with PostgreSQL)
+
+                    table_name = self.object_list.query.model._meta.db_table  # type: ignore
+
+                    # Check if the table is partitioned
+                    cursor.execute(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1 FROM pg_inherits i
+                            JOIN pg_class p ON i.inhparent = p.oid
+                            WHERE p.relname = %s
+                        )
+                    """,
+                        [table_name],
+                    )
+
+                    is_partitioned = cursor.fetchone()[0]
+
+                    if is_partitioned:
+                        # For partitioned tables, sum estimates across all partitions
+                        cursor.execute(
+                            """
+                            SELECT SUM(c.reltuples)::bigint as estimated_count
+                            FROM pg_class c
+                            JOIN pg_inherits i ON c.oid = i.inhrelid
+                            JOIN pg_class p ON i.inhparent = p.oid
+                            WHERE p.relname = %s
+                            AND c.relkind = 'r'
+                        """,
+                            [table_name],
+                        )
+                    else:
+                        # For regular tables, use the simple query
+                        cursor.execute(
+                            "SELECT reltuples FROM pg_class WHERE relname = %s",
+                            [table_name],
+                        )
+
+                    result = cursor.fetchone()
+                    estimate = int(result[0]) if result and result[0] is not None else 0
+                    return estimate
+            except Exception:
+                # If any other exception occurred fall back to default behaviour
+                pass
+        return super().count

--- a/libs/shared/tests/unit/django_apps/utils/test_paginator.py
+++ b/libs/shared/tests/unit/django_apps/utils/test_paginator.py
@@ -1,0 +1,212 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shared.django_apps.core.models import Repository
+from shared.django_apps.core.tests.factories import RepositoryFactory
+from shared.django_apps.utils.paginator import EstimatedCountPaginator
+
+
+@pytest.mark.django_db
+class TestEstimatedCountPaginator:
+    @patch("shared.django_apps.utils.paginator.connections")
+    def test_count_with_no_filters_regular_table(
+        self, mock_connections: MagicMock
+    ) -> None:
+        """Test count estimation for unfiltered queryset on regular (non-partitioned) table."""
+        queryset = Repository.objects.all()
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.side_effect = [
+            [False],  # is_partitioned check returns False
+            [1000],  # reltuples returns 1000
+        ]
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+
+        paginator = EstimatedCountPaginator(queryset, per_page=10)
+        count = paginator.count
+
+        assert count == 1000
+        assert mock_cursor.execute.call_count == 2
+
+        calls = mock_cursor.execute.call_args_list
+        # First call should check if table is partitioned
+        assert "pg_inherits" in calls[0][0][0]
+        assert calls[0][0][1] == [Repository._meta.db_table]
+
+        # Second call should get reltuples for regular table
+        assert "reltuples FROM pg_class" in calls[1][0][0]
+        assert calls[1][0][1] == [Repository._meta.db_table]
+
+    @patch("shared.django_apps.utils.paginator.connections")
+    def test_count_with_no_filters_partitioned_table(
+        self, mock_connections: MagicMock
+    ) -> None:
+        """Test count estimation for unfiltered queryset on partitioned table."""
+        queryset = Repository.objects.all()
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.side_effect = [
+            [True],  # is_partitioned check returns True
+            [2500],  # For partitioned table query
+        ]
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+
+        paginator = EstimatedCountPaginator(queryset, per_page=25)
+        count = paginator.count
+
+        assert count == 2500
+        assert mock_cursor.execute.call_count == 2
+
+        calls = mock_cursor.execute.call_args_list
+        # First call should check if table is partitioned
+        assert "pg_inherits" in calls[0][0][0]
+        assert calls[0][0][1] == [Repository._meta.db_table]
+
+        # Second call should sum estimates across partitions
+        assert "SUM(c.reltuples)" in calls[1][0][0]
+        assert calls[1][0][1] == [Repository._meta.db_table]
+
+    @patch("shared.django_apps.utils.paginator.connections")
+    def test_count_with_null_result(self, mock_connections: MagicMock) -> None:
+        """Test count estimation when database returns null result."""
+        queryset = Repository.objects.all()
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.side_effect = [
+            [False],  # is_partitioned check returns False
+            [None],  # reltuples returns None
+        ]
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+
+        paginator = EstimatedCountPaginator(queryset, per_page=10)
+        count = paginator.count
+
+        assert count == 0
+
+    @patch("shared.django_apps.utils.paginator.connections")
+    def test_count_with_empty_result(self, mock_connections: MagicMock) -> None:
+        """Test count estimation when database returns empty result."""
+        queryset = Repository.objects.all()
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.side_effect = [
+            [False],  # is_partitioned check returns False
+            None,  # fetchone returns None (no result)
+        ]
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+
+        paginator = EstimatedCountPaginator(queryset, per_page=10)
+        count = paginator.count
+
+        assert count == 0
+
+    def test_count_with_filters_falls_back_to_parent(self) -> None:
+        """Test that count falls back to parent implementation when queryset has filters."""
+        RepositoryFactory.create_batch(5)
+
+        queryset = Repository.objects.filter(name__icontains="test")
+
+        paginator = EstimatedCountPaginator(queryset, per_page=10)
+
+        with patch.object(
+            EstimatedCountPaginator.__bases__[0], "count", new_callable=lambda: 3
+        ):
+            count = paginator.count
+            # The count should come from parent class, not our estimation logic
+            assert count == 3
+
+    @patch("shared.django_apps.utils.paginator.connections")
+    def test_count_with_database_exception_falls_back_to_parent(
+        self, mock_connections: MagicMock
+    ) -> None:
+        """Test that count falls back to parent implementation when database exception occurs."""
+        queryset = Repository.objects.all()
+
+        mock_connections.__getitem__.return_value.cursor.side_effect = Exception(
+            "Database error"
+        )
+
+        paginator = EstimatedCountPaginator(queryset, per_page=10)
+
+        # Should fall back to parent implementation
+        with patch.object(
+            EstimatedCountPaginator.__bases__[0], "count", new_callable=lambda: 42
+        ):
+            count = paginator.count
+            assert count == 42
+
+    @patch("shared.django_apps.utils.paginator.connections")
+    def test_count_with_cursor_exception_falls_back_to_parent(
+        self, mock_connections: MagicMock
+    ) -> None:
+        """Test that count falls back to parent implementation when cursor operation fails."""
+        queryset = Repository.objects.all()
+
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = Exception("SQL error")
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+
+        paginator = EstimatedCountPaginator(queryset, per_page=10)
+
+        # Should fall back to parent implementation
+        with patch.object(
+            EstimatedCountPaginator.__bases__[0], "count", new_callable=lambda: 99
+        ):
+            count = paginator.count
+            assert count == 99
+
+    def test_count_property_is_cached(self) -> None:
+        """Test that the count property is cached and not recalculated on subsequent accesses."""
+        RepositoryFactory.create_batch(3)
+
+        queryset = Repository.objects.all()
+        paginator = EstimatedCountPaginator(queryset, per_page=10)
+
+        # First access
+        count1 = paginator.count
+
+        # Second access should return same cached value
+        count2 = paginator.count
+
+        assert count1 == count2
+        # Check that the value is cached - Django's cached_property stores the value
+        # in the instance dict with the property name
+        assert hasattr(paginator, "__dict__") and "count" in paginator.__dict__
+
+    @patch("shared.django_apps.utils.paginator.connections")
+    def test_different_database_aliases(self, mock_connections: MagicMock) -> None:
+        """Test that paginator uses correct database alias from queryset."""
+        queryset = Repository.objects.using("default").all()
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.side_effect = [
+            [False],  # is_partitioned check returns False
+            [500],  # reltuples returns 500
+        ]
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+
+        paginator = EstimatedCountPaginator(queryset, per_page=10)
+        count = paginator.count
+
+        # Verify the correct database was accessed
+        mock_connections.__getitem__.assert_called_with("default")
+        assert count == 500
+
+    @patch("shared.django_apps.utils.paginator.connections")
+    def test_float_estimate_converted_to_int(self, mock_connections: MagicMock) -> None:
+        """Test that float estimates from database are properly converted to integers."""
+        queryset = Repository.objects.all()
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.side_effect = [
+            [False],  # is_partitioned check returns False
+            [1000.75],  # reltuples returns a float
+        ]
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+
+        paginator = EstimatedCountPaginator(queryset, per_page=10)
+        count = paginator.count
+
+        assert count == 1000
+        assert isinstance(count, int)


### PR DESCRIPTION
* Modified the existing estimated count paginator to support partitioned tables and then moved it to shared
* Used the paginator on all admin models that are slow in production
* Reduced upload breadcrumbs sorting options
* Removed date hierarchy from upload breadcrumbs that adds a ton of extra Queries
