### PR TITLE
refactor: Notifier class supports `TAUploadContext`

### DIFF
--- a/apps/worker/helpers/notifier.py
+++ b/apps/worker/helpers/notifier.py
@@ -6,14 +6,20 @@ from typing import Literal
 from asgiref.sync import async_to_sync
 
 from database.models import Commit
+from database.models import Repository as SQLAlchemyRepository
 from services.repository import (
     EnrichedPull,
     fetch_and_update_pull_request_information_from_commit,
+    fetch_pull_request_information,
     get_repo_provider_service,
 )
 from services.yaml import UserYaml
+from shared.django_apps.core.models import Repository
+from shared.django_apps.test_analytics.models import TAPullComment
 from shared.torngit.base import TorngitBaseAdapter
 from shared.torngit.exceptions import TorngitClientError
+from shared.torngit.response_types import ProviderPull
+from shared.upload.types import TAUploadContext
 
 log = logging.getLogger(__name__)
 
@@ -27,51 +33,110 @@ class NotifierResult(Enum):
 
 @dataclass
 class BaseNotifier:
-    commit: Commit
+    """
+    Base class for notifiers
+
+    This class is responsible for building and sending notifications related to
+    a specific commit.
+
+    Note that `commit` supports both a Commit object and a TAUploadContext
+    object so that it can be used in the new TA pipeline that is compliant with
+    Sentry's retention policies. Depending on which is passed in, a slightly
+    different code path is taken. Repository is also required as a parameter
+    since it is not given with TAUploadContext like it is with Commit.
+    """
+
+    repo: Repository | SQLAlchemyRepository
+    # TODO: Deprecate database-reliant code path after old TA pipeline is removed
+    commit: Commit | TAUploadContext
     commit_yaml: UserYaml | None
-    _pull: EnrichedPull | None | Literal[False] = False
+    _pull: EnrichedPull | ProviderPull | None | Literal[False] = False
     _repo_service: TorngitBaseAdapter | None = None
 
-    def get_pull(self, do_log=True) -> EnrichedPull | None:
+    def get_pull(self, do_log=True) -> EnrichedPull | ProviderPull | None:
         repo_service = self.get_repo_service()
 
         if self._pull is False:
-            self._pull = async_to_sync(
-                fetch_and_update_pull_request_information_from_commit
-            )(repo_service, self.commit, self.commit_yaml)
+            if isinstance(self.commit, Commit):
+                self._pull = async_to_sync(
+                    fetch_and_update_pull_request_information_from_commit
+                )(repo_service, self.commit, self.commit_yaml)
+            else:
+                self._pull = async_to_sync(fetch_pull_request_information)(
+                    repo_service,
+                    self.repo.repoid,
+                    self.commit["commit_sha"],
+                    self.commit["branch"],
+                    self.commit["pull_id"],
+                )
 
         if self._pull is None and do_log:
             log.info(
                 "Not notifying since there is no pull request associated with this commit",
-                extra={"commitid": self.commit.commitid},
+                extra={
+                    "commitid": self.commit.commitid
+                    if isinstance(self.commit, Commit)
+                    else self.commit["commit_sha"],
+                    "repoid": self.repo.repoid,
+                },
             )
 
         return self._pull
 
     def get_repo_service(self) -> TorngitBaseAdapter:
         if self._repo_service is None:
-            self._repo_service = get_repo_provider_service(self.commit.repository)
+            self._repo_service = get_repo_provider_service(self.repo)
 
         return self._repo_service
 
-    def send_to_provider(self, pull: EnrichedPull, message: str) -> bool:
+    def send_to_provider(self, pull: EnrichedPull | ProviderPull, message: str) -> bool:
+        """
+        Send a notification message to the appropriate provider for the given
+        pull request.
+
+        Note that `pull` can be either an `EnrichedPull` or a `ProviderPull`
+        object. This allows for a Sentry-compliant code path that stores no
+        user event data.
+        """
         repo_service = self.get_repo_service()
         assert repo_service
 
-        pullid = pull.database_pull.pullid
         try:
-            comment_id = pull.database_pull.commentid
+            # TODO: Deprecate EnrichedPull-reliant code path after old TA pipeline is removed
+            if isinstance(pull, EnrichedPull):
+                pullid = pull.database_pull.pullid
+                comment_id = pull.database_pull.commentid
+            else:
+                pullid = pull.id
+                try:
+                    comment_id = TAPullComment.objects.get(
+                        repo_id=self.repo.repoid, pull_id=pullid
+                    ).comment_id
+                except TAPullComment.DoesNotExist:
+                    comment_id = None
+
             if comment_id:
                 async_to_sync(repo_service.edit_comment)(pullid, comment_id, message)
             else:
                 res = async_to_sync(repo_service.post_comment)(pullid, message)
-                pull.database_pull.commentid = res["id"]
+
+                if isinstance(pull, EnrichedPull):
+                    pull.database_pull.commentid = res["id"]
+                else:
+                    TAPullComment.objects.create(
+                        repo_id=self.repo.repoid,
+                        pull_id=pullid,
+                        comment_id=res["id"],
+                    )
             return True
+
         except TorngitClientError:
             log.error(
                 "Error creating/updating PR comment",
                 extra={
-                    "commitid": self.commit.commitid,
+                    "commitid": self.commit.commitid
+                    if isinstance(self.commit, Commit)
+                    else self.commit["commit_sha"],
                     "pullid": pullid,
                 },
             )

--- a/apps/worker/services/test_analytics/ta_finish_upload.py
+++ b/apps/worker/services/test_analytics/ta_finish_upload.py
@@ -202,6 +202,7 @@ def new_impl(
         }
 
     notifier = TestResultsNotifier(
+        repo,
         commit,
         commit_yaml,
         _pull=pull,

--- a/apps/worker/services/test_analytics/tests/test_ta_finish_upload.py
+++ b/apps/worker/services/test_analytics/tests/test_ta_finish_upload.py
@@ -10,6 +10,7 @@ from database.tests.factories import (
     PullFactory,
     UploadFactory,
 )
+from services.repository import EnrichedPull
 from services.test_analytics.ta_finish_upload import FinisherResult, new_impl
 from services.yaml import UserYaml
 from shared.django_apps.core.models import Commit as DjangoCommit
@@ -203,6 +204,7 @@ def test_ta_finish_upload(
 
     mock_pull(
         mocker.Mock(
+            spec=EnrichedPull,
             provider_pull={
                 "author": {
                     "username": "test-user",

--- a/apps/worker/services/urls.py
+++ b/apps/worker/services/urls.py
@@ -171,9 +171,9 @@ def get_plan_url(pull: Pull) -> str:
     )
 
 
-def get_test_analytics_url(repo: Repository, commit: Commit) -> str:
-    if commit.branch is not None:
-        branch_name = quote_plus(commit.branch)
+def get_test_analytics_url(repo: Repository, commit_branch: str | None) -> str:
+    if commit_branch is not None:
+        branch_name = quote_plus(commit_branch)
     else:
         branch_name = quote_plus(repo.branch)
     return SiteUrls.test_analytics_url.get_url(

--- a/apps/worker/tasks/notify_error.py
+++ b/apps/worker/tasks/notify_error.py
@@ -77,6 +77,7 @@ class NotifyErrorTask(BaseCodecovTask, name=notify_error_task_name):
         )
 
         error_notifier = ErrorNotifier(
+            commit.repository,
             commit,
             commit_yaml,
             failed_upload=num_failed_upload,

--- a/apps/worker/tasks/test_results_finisher.py
+++ b/apps/worker/tasks/test_results_finisher.py
@@ -300,6 +300,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
                     failed_tests, passed_tests, skipped_tests, None
                 )
                 notifier = TestResultsNotifier(
+                    repo,
                     commit,
                     commit_yaml,
                     payload=payload,
@@ -353,7 +354,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
 
             if should_show_upgrade_message:
                 notifier = TestResultsNotifier(
-                    commit, commit_yaml, _pull=pull, _repo_service=repo_service
+                    repo, commit, commit_yaml, _pull=pull, _repo_service=repo_service
                 )
                 success, reason = notifier.upgrade_comment()
 
@@ -377,6 +378,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
                 failed_tests, passed_tests, skipped_tests, info
             )
             notifier = TestResultsNotifier(
+                repo,
                 commit,
                 commit_yaml,
                 payload=payload,

--- a/apps/worker/tasks/tests/unit/test_notify_error_task.py
+++ b/apps/worker/tasks/tests/unit/test_notify_error_task.py
@@ -33,7 +33,11 @@ def test_error_notifier():
     total_upload = 2
 
     e = ErrorNotifier(
-        commit, None, failed_upload=failed_upload, total_upload=total_upload
+        commit.repository,
+        commit,
+        None,
+        failed_upload=failed_upload,
+        total_upload=total_upload,
     )
 
     assert (


### PR DESCRIPTION
No longer need to interact with the database to use the notifier class. This is required for the new notifier task that will come in a subsequent PR.

The type-based code paths are far from my favourite solution but it was the easiest way to add the functionality in a backwards-compatible way while also preventing a bunch of parameters becoming optional and having to do lots of checking for different code paths (e.g. `if self.commit is None and self.upload_context` ...)
