### PR TITLE
feat: create migration utils for timescale

### DIFF
--- a/libs/shared/shared/django_apps/migration_utils.py
+++ b/libs/shared/shared/django_apps/migration_utils.py
@@ -219,7 +219,10 @@ def ts_create_index(
     the state will diverge: the index will be created in the DB, but Django will not
     know about it. You should use ts_create_index_managed_hypertable instead.
     """
-    column_exprs: list[str] = [str(col) for col in columns]
+    column_exprs: list[str] = [
+        (str(col)[1:] + " DESC") if str(col).startswith("-") else str(col)
+        for col in columns
+    ]
 
     cols_sql = ", ".join(column_exprs)
     forward_sql = f"CREATE INDEX IF NOT EXISTS {index_name} ON {table_name} ({cols_sql}) WITH (timescaledb.transaction_per_chunk);"
@@ -238,7 +241,10 @@ def ts_create_index_managed_hypertable(
     Create an index on a table that is managed by Django. This will ensure that the
     index is created in the DB and Django will know about it.
     """
-    column_exprs: list[str] = [str(col) for col in columns]
+    column_exprs: list[str] = [
+        (str(col)[1:] + " DESC") if str(col).startswith("-") else str(col)
+        for col in columns
+    ]
 
     cols_sql = ", ".join(column_exprs)
     forward_sql = f"CREATE INDEX IF NOT EXISTS {index_name} ON {table_name} ({cols_sql}) WITH (timescaledb.transaction_per_chunk);"


### PR DESCRIPTION
it’s a pain to re-write the same SQL for defining timescale hypertables  and CAs all the time so I’m adding some useful utility functions to migration_utils for common timescale operations like creating a CA,  refreshing it, adding a retention policy, etc.