### PR TITLE
feat: restore TA GQL resolvers to defaulting to all branches

### DIFF
--- a/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__gql_query_flake_aggregates_timescale__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/flake_aggregates_timescale__TestFlakeAggregatesTimescale__gql_query_flake_aggregates_timescale__0.json
@@ -5,8 +5,8 @@
         "flakeAggregates": {
           "flakeRate": 0.5,
           "flakeCount": 1,
-          "flakeRatePercentChange": 0.0,
-          "flakeCountPercentChange": 0.0
+          "flakeRatePercentChange": -0.5,
+          "flakeCountPercentChange": -0.6666666666666666
         }
       }
     }

--- a/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__gql_query_test_results_aggregates_timescale__0.json
+++ b/apps/codecov-api/graphql_api/tests/snapshots/results_aggregates_timescale__TestTestResultsAggregatesTimescale__gql_query_test_results_aggregates_timescale__0.json
@@ -8,10 +8,10 @@
           "totalFails": 1,
           "totalSkips": 0,
           "totalSlowTests": 1,
-          "totalDurationPercentChange": 0.0,
-          "slowestTestsDurationPercentChange": 0.0,
+          "totalDurationPercentChange": -0.42857142857142855,
+          "slowestTestsDurationPercentChange": -0.4444444444444444,
           "totalFailsPercentChange": 0.0,
-          "totalSkipsPercentChange": 0.0,
+          "totalSkipsPercentChange": -1.0,
           "totalSlowTestsPercentChange": 0.0
         }
       }

--- a/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
+++ b/apps/codecov-api/graphql_api/types/test_analytics/test_analytics.py
@@ -175,7 +175,7 @@ async def resolve_test_results_aggregates(
     start_date = end_date - timedelta(days=measurement_interval.value)
     return await sync_to_async(get_test_results_aggregates)(
         repoid=repository.repoid,
-        branch=repository.branch,
+        branch=branch,
         start_date=start_date,
         end_date=end_date,
     )
@@ -194,7 +194,7 @@ async def resolve_flake_aggregates(
     start_date = end_date - timedelta(days=measurement_interval.value)
     return await sync_to_async(get_flake_aggregates)(
         repoid=repository.repoid,
-        branch=repository.branch,
+        branch=branch,
         start_date=start_date,
         end_date=end_date,
     )


### PR DESCRIPTION
we needed to update the UI to always pass the branch param, even when  the branch is the default branch, and now that that is done, we can  safely set the default here to be “all branches"

also refs the measurement interval code in test analytics