### PR TITLE
feat: only process webhook if account associated with service

### DIFF
--- a/apps/codecov-api/webhook_handlers/helpers.py
+++ b/apps/codecov-api/webhook_handlers/helpers.py
@@ -1,0 +1,70 @@
+import logging
+from enum import Enum
+
+from codecov_auth.models import Owner
+from webhook_handlers.constants import GitHubWebhookEvents
+
+log = logging.getLogger(__name__)
+
+
+def resolve_owner_from_webhook(data, service_name: str) -> Owner | None:
+    repo_data = data.get("repository", {})
+    if repo_data:
+        owner_service_id = repo_data.get("owner", {}).get("id")
+        if owner_service_id:
+            try:
+                return Owner.objects.get(
+                    service=service_name, service_id=owner_service_id
+                )
+            except Owner.DoesNotExist:
+                pass
+
+    installation_data = data.get("installation", {})
+    if installation_data:
+        account_data = installation_data.get("account", {})
+        owner_service_id = account_data.get("id")
+        if owner_service_id:
+            try:
+                return Owner.objects.get(
+                    service=service_name, service_id=owner_service_id
+                )
+            except Owner.DoesNotExist:
+                pass
+
+    org_data = data.get("organization", {})
+    if org_data:
+        owner_service_id = org_data.get("id")
+        if owner_service_id:
+            try:
+                return Owner.objects.get(
+                    service=service_name, service_id=owner_service_id
+                )
+            except Owner.DoesNotExist:
+                pass
+
+    return None
+
+
+def is_installation_event(event: str) -> bool:
+    installation_events = [
+        GitHubWebhookEvents.INSTALLATION,
+        GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
+    ]
+    return event in installation_events
+
+
+class HANDLER(Enum):
+    GITHUB = "github"
+    SENTRY = "sentry"
+
+
+def should_process(data, event: str, service_name: str) -> set[HANDLER]:
+    if is_installation_event(event):
+        return {HANDLER.GITHUB, HANDLER.SENTRY}
+
+    owner = resolve_owner_from_webhook(data, service_name)
+
+    if owner and owner.account and owner.account.sentry_org_id:
+        return {HANDLER.SENTRY}
+
+    return {HANDLER.GITHUB}

--- a/apps/codecov-api/webhook_handlers/tests/test_helpers.py
+++ b/apps/codecov-api/webhook_handlers/tests/test_helpers.py
@@ -1,0 +1,74 @@
+import pytest
+
+from shared.django_apps.codecov_auth.tests.factories import AccountFactory, OwnerFactory
+from webhook_handlers.helpers import (
+    HANDLER,
+    is_installation_event,
+    resolve_owner_from_webhook,
+    should_process,
+)
+
+
+@pytest.mark.django_db
+class TestResolveOwnerFromWebhook:
+    def test_resolve_owner_from_repository_owner_id(self):
+        owner = OwnerFactory(service="github")
+        data = {"repository": {"owner": {"id": owner.service_id}}}
+        result = resolve_owner_from_webhook(data, "github")
+        assert result is not None
+        assert result.ownerid == owner.ownerid
+
+    def test_resolve_owner_from_installation_account_id(self):
+        owner = OwnerFactory(service="github")
+        data = {"installation": {"account": {"id": owner.service_id}}}
+        result = resolve_owner_from_webhook(data, "github")
+        assert result is not None
+        assert result.ownerid == owner.ownerid
+
+    def test_resolve_owner_from_organization_id(self):
+        owner = OwnerFactory(service="github")
+        data = {"organization": {"id": owner.service_id}}
+        result = resolve_owner_from_webhook(data, "github")
+        assert result is not None
+        assert result.ownerid == owner.ownerid
+
+    def test_resolve_owner_none_when_no_match(self):
+        data = {
+            "repository": {"owner": {"id": 1}},
+            "installation": {"account": {"id": 2}},
+            "organization": {"id": 3},
+        }
+        result = resolve_owner_from_webhook(data, "github")
+        assert result is None
+
+
+class TestIsInstallationEvent:
+    def test_true_for_installation(self):
+        assert is_installation_event("installation") is True
+
+    def test_true_for_installation_repositories(self):
+        assert is_installation_event("installation_repositories") is True
+
+    def test_false_for_other_events(self):
+        assert is_installation_event("repository") is False
+
+
+@pytest.mark.django_db
+class TestShouldProcess:
+    def test_installation_events_process_both_handlers(self):
+        data = {"installation": {"account": {"id": 123}}}
+        result = should_process(data, "installation", "github")
+        assert result == {HANDLER.GITHUB, HANDLER.SENTRY}
+
+    def test_non_installation_with_sentry_account_processes_sentry_only(self):
+        account = AccountFactory(sentry_org_id=123456789)
+        owner = OwnerFactory(service="github", account=account)
+        data = {"repository": {"owner": {"id": owner.service_id}}}
+        result = should_process(data, "repository", "github")
+        assert result == {HANDLER.SENTRY}
+
+    def test_non_installation_without_sentry_account_processes_github_only(self):
+        owner = OwnerFactory(service="github")
+        data = {"repository": {"owner": {"id": owner.service_id}}}
+        result = should_process(data, "repository", "github")
+        assert result == {HANDLER.GITHUB}

--- a/apps/codecov-api/webhook_handlers/views/github.py
+++ b/apps/codecov-api/webhook_handlers/views/github.py
@@ -31,6 +31,7 @@ from webhook_handlers.constants import (
     GitHubWebhookEvents,
     WebhookHandlerErrorMessages,
 )
+from webhook_handlers.helpers import HANDLER, should_process
 
 from . import WEBHOOKS_ERRORED, WEBHOOKS_RECEIVED
 
@@ -709,6 +710,10 @@ class GithubWebhookHandler(APIView):
             },
         )
         self.validate_signature(request)
+
+        handlers = should_process(request.data, self.event, self.service_name)
+        if HANDLER.GITHUB not in handlers:
+            return Response()
 
         if handler := getattr(self, self.event, None):
             self._inc_recv()

--- a/apps/codecov-api/webhook_handlers/views/sentry.py
+++ b/apps/codecov-api/webhook_handlers/views/sentry.py
@@ -10,6 +10,7 @@ from codecov_auth.permissions import JWTAuthenticationPermission
 from rollouts import ROLLBACK_SENTRY_WEBHOOK
 from shared.metrics import Counter
 from webhook_handlers.constants import GitHubHTTPHeaders
+from webhook_handlers.helpers import HANDLER, should_process
 from webhook_handlers.views.github import GithubWebhookHandler
 
 from . import WEBHOOKS_RECEIVED
@@ -61,6 +62,12 @@ class SentryWebhookHandler(APIView):
             raise ParseError("Missing event header")
 
         action = request.data.get("action", "")
+
+        handlers = should_process(
+            request.data, event, self.github_webhook_handler.service_name
+        )
+        if HANDLER.SENTRY not in handlers:
+            return Response()
 
         handler = self.event_handlers.get(event)
         if handler is None:


### PR DESCRIPTION
if we receive a sentry webhook for an installation where we know the  owner is not linked to a sentry or vice versa, we want to block  processing that webhook

this is to avoid double processing webhooks: if a user has linked their  sentry account then we only need to process their sentry webhooks and  ignore webhooks that come from the codecov app
