### PR TITLE
fix: Update plan when calling account link endpoint

### DIFF
--- a/apps/codecov-api/api/sentry/tests/test_views.py
+++ b/apps/codecov-api/api/sentry/tests/test_views.py
@@ -83,9 +83,9 @@ class AccountLinkViewTests(TestCase):
 
         # Verify existing account was used
         account = Account.objects.get(sentry_org_id="123456789")
-        self.assertEqual(account.plan, PlanName.SENTRY_MERGE_PLAN.value)
         self.assertEqual(account.id, existing_account.id)
         self.assertEqual(account.name, "Existing Sentry Org")  # Name should not change
+        self.assertEqual(account.plan, PlanName.USERS_DEVELOPER.value)
 
         # Verify Owner was created and linked to existing account
         owner = Owner.objects.get(service_id="456789123", service="github")

--- a/apps/codecov-api/api/sentry/tests/test_views.py
+++ b/apps/codecov-api/api/sentry/tests/test_views.py
@@ -10,6 +10,7 @@ from rest_framework.test import APIClient
 from codecov_auth.models import Account
 from shared.django_apps.codecov_auth.models import GithubAppInstallation, Owner
 from shared.django_apps.codecov_auth.tests.factories import AccountFactory, OwnerFactory
+from shared.plan.constants import PlanName
 
 
 class AccountLinkViewTests(TestCase):
@@ -56,6 +57,7 @@ class AccountLinkViewTests(TestCase):
 
         # Verify Account was created
         account = Account.objects.get(sentry_org_id="123456789")
+        self.assertEqual(account.plan, PlanName.SENTRY_MERGE_PLAN.value)
         self.assertEqual(account.name, "Test Sentry Org")
 
         # Verify Owner was created
@@ -81,6 +83,7 @@ class AccountLinkViewTests(TestCase):
 
         # Verify existing account was used
         account = Account.objects.get(sentry_org_id="123456789")
+        self.assertEqual(account.plan, PlanName.SENTRY_MERGE_PLAN.value)
         self.assertEqual(account.id, existing_account.id)
         self.assertEqual(account.name, "Existing Sentry Org")  # Name should not change
 
@@ -104,6 +107,7 @@ class AccountLinkViewTests(TestCase):
 
         # Verify account was created
         account = Account.objects.get(sentry_org_id="123456789")
+        self.assertEqual(account.plan, PlanName.SENTRY_MERGE_PLAN.value)
 
         # Verify existing owner was updated to link to new account
         existing_owner.refresh_from_db()

--- a/apps/codecov-api/api/sentry/views.py
+++ b/apps/codecov-api/api/sentry/views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from codecov_auth.models import Account
 from codecov_auth.permissions import JWTAuthenticationPermission
 from shared.django_apps.codecov_auth.models import GithubAppInstallation, Owner, Service
+from shared.plan.constants import PlanName
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +58,8 @@ def account_link(request, *args, **kwargs):
     sentry_org_name = serializer.validated_data["sentry_org_name"]
 
     account, _created = Account.objects.get_or_create(
-        sentry_org_id=sentry_org_id, defaults={"name": sentry_org_name}
+        sentry_org_id=sentry_org_id,
+        defaults={"name": sentry_org_name, "plan": PlanName.SENTRY_MERGE_PLAN.value},
     )
 
     for org_data in serializer.validated_data["organizations"]:


### PR DESCRIPTION
This PR updates the account link code to use the new sentry merge plan rather than the default plan since that's the one we'll be using for now to determine which users are sentry account users.

Relates to https://linear.app/getsentry/issue/CCMRG-1331/sentry-hook-into-sentry-github-app-install-to-call-codecov


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
