### PR TITLE
feat: use testrun models in notify task instead of old TA models

### DIFF
--- a/apps/worker/services/test_analytics/ta_timeseries.py
+++ b/apps/worker/services/test_analytics/ta_timeseries.py
@@ -102,6 +102,7 @@ def get_pr_comment_failures(repo_id: int, commit_sha: str) -> list[FailedTestIns
             FROM ta_timeseries_testrun
             WHERE repo_id = %s AND commit_sha = %s AND outcome IN ('failure', 'flaky_fail')
             GROUP BY test_id
+            ORDER BY LAST(computed_name, timestamp) ASC
             """,
             [repo_id, commit_sha],
         )

--- a/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__2.txt
+++ b/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__2.txt
@@ -4,7 +4,7 @@
 | 1 | 1 | 0 | 0 |
 <details><summary>View the top 1 failed test(s) by shortest run time</summary>
 
-> <pre><code class="language-python">computed_0</code></pre>
+> <pre><code class="language-python">computed_6</code></pre>
 > <details><summary>Stack Traces | 100s run time</summary>
 > 
 > > <pre><code class="language-python">No failure message available</code></pre>

--- a/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__3.txt
+++ b/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__3.txt
@@ -4,7 +4,7 @@
 | 1 | 1 | 0 | 0 |
 <details><summary>View the full list of 1 :snowflake: flaky tests</summary>
 
-> <pre><code class="language-python">computed_0</code></pre>
+> <pre><code class="language-python">computed_6</code></pre>
 > **Flake rate in main:** 100.00% (Passed 0 times, Failed 10 times)
 > <details><summary>Stack Traces | 100s run time</summary>
 > 

--- a/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__4.txt
+++ b/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__4.txt
@@ -4,7 +4,7 @@
 | 1 | 1 | 0 | 0 |
 <details><summary>View the full list of 1 :snowflake: flaky tests</summary>
 
-> <pre><code class="language-python">computed_0</code></pre>
+> <pre><code class="language-python">computed_6</code></pre>
 > **Flake rate in main:** 100.00% (Passed 0 times, Failed 10 times)
 > <details><summary>Stack Traces | 100s run time</summary>
 > 

--- a/apps/worker/tasks/tests/integration/test_notify_task.py
+++ b/apps/worker/tasks/tests/integration/test_notify_task.py
@@ -33,7 +33,7 @@ class TestNotifyTask:
         mock_all_plans_and_tiers()
 
     @patch("requests.post")
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases=["default", "ta_timeseries"])
     def test_simple_call_no_notifiers(
         self,
         mock_requests_post,
@@ -156,7 +156,7 @@ class TestNotifyTask:
         }
 
     @patch("requests.post")
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases=["default", "ta_timeseries"])
     def test_simple_call_only_status_notifiers(
         self,
         mock_post_request,
@@ -350,7 +350,7 @@ class TestNotifyTask:
         }
 
     @patch("requests.post")
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases=["default", "ta_timeseries"])
     def test_simple_call_only_status_notifiers_no_pull_request(
         self,
         mock_post_request,
@@ -565,7 +565,7 @@ class TestNotifyTask:
         }
 
     @patch("requests.post")
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases=["default", "ta_timeseries"])
     def test_simple_call_only_status_notifiers_with_pull_request(
         self,
         mock_post_request,
@@ -778,7 +778,7 @@ class TestNotifyTask:
         }
 
     @patch("requests.post")
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases=["default", "ta_timeseries"])
     def test_simple_call_status_and_notifiers(
         self,
         mock_post_request,
@@ -1246,7 +1246,7 @@ class TestNotifyTask:
         pull = dbsession.query(Pull).filter_by(pullid=9, repoid=commit.repoid).first()
         assert pull.commentid == "1699669573"
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases=["default", "ta_timeseries"])
     def test_notifier_call_no_head_commit_report(
         self, dbsession, mocker, codecov_vcr, mock_storage, mock_configuration
     ):
@@ -1301,7 +1301,7 @@ class TestNotifyTask:
         }
         assert result == expected_result
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases=["default", "ta_timeseries"])
     @patch("requests.post")
     def test_notifier_call_no_head_commit_report_empty_upload(
         self,

--- a/apps/worker/tasks/tests/unit/snapshots/notify_task__TestNotifyTask__ta_relevant_context__0.txt
+++ b/apps/worker/tasks/tests/unit/snapshots/notify_task__TestNotifyTask__ta_relevant_context__0.txt
@@ -1,1 +1,0 @@
-Test Analytics upload error: File not in storage


### PR DESCRIPTION
with the recent rollout of timescale based TA we want to fully use the timescale TA models, i missed updating the notify task so im updating it now