### PR TITLE
fix: sync pull task calling process flakes task

### DIFF
--- a/apps/worker/tasks/sync_pull.py
+++ b/apps/worker/tasks/sync_pull.py
@@ -24,6 +24,7 @@ from services.repository import (
     fetch_and_update_pull_request_information,
     get_repo_provider_service,
 )
+from services.test_analytics.ta_process_flakes import KEY_NAME
 from services.test_results import should_do_flaky_detection
 from services.yaml.reader import read_yaml_field
 from shared.celery_config import (
@@ -556,6 +557,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         if should_do_flaky_detection(repository, current_yaml):
             redis_client = get_redis_connection()
             redis_client.set(f"flake_uploads:{repository.repoid}", 0)
+            redis_client.lpush(KEY_NAME.format(repository.repoid), pull_head)
             self.app.tasks[process_flakes_task_name].apply_async(
                 kwargs={"repo_id": repository.repoid, "commit_id": pull_head}
             )

--- a/apps/worker/tasks/tests/unit/test_sync_pull.py
+++ b/apps/worker/tasks/tests/unit/test_sync_pull.py
@@ -10,7 +10,6 @@ from redis.exceptions import LockError
 
 from database.models import Commit, Pull, Repository
 from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
-from database.tests.factories.reports import TestFactory
 from helpers.exceptions import NoConfiguredAppsAvailable, RepositoryWithoutValidBotError
 from services.repository import EnrichedPull
 from services.yaml import UserYaml
@@ -557,10 +556,6 @@ def test_trigger_process_flakes(dbsession, mocker, flake_detection, repository):
     apply_async: MagicMock = mocker.patch.object(
         task.app.tasks["app.tasks.flakes.ProcessFlakesTask"], "apply_async"
     )
-
-    if flake_detection:
-        TestFactory.create(repository=repository)
-        dbsession.flush()
 
     task.trigger_process_flakes(
         dbsession,


### PR DESCRIPTION
we made a change a while ago where the process flakes task consumes from a list in redis and we forgot to push the commit sha onto that list when we queue up the task in the sync pulls task
