### PR TITLE
feat: use correct app when user has sentry account linked

### DIFF
--- a/apps/worker/database/models/core.py
+++ b/apps/worker/database/models/core.py
@@ -69,6 +69,7 @@ class Account(CodecovBaseModel, MixinBaseClassNoExternalID):
     free_seat_count = Column(types.SmallInteger, nullable=False, default=0)
     plan_auto_activate = Column(types.Boolean, nullable=False, default=True)
     is_delinquent = Column(types.Boolean, nullable=False, default=False)
+    sentry_org_id = Column(types.BigInteger, nullable=True)
 
     users = relationship(
         "User", secondary="codecov_auth_accountsusers", back_populates="accounts"


### PR DESCRIPTION
When an owner has a sentry_org_id linked through their account,
always use the sentry app installation regardless of the
installation_name parameter passed in.