### PR TITLE
fix: Unlink Account serializer params

### DIFF
--- a/apps/codecov-api/api/sentry/views.py
+++ b/apps/codecov-api/api/sentry/views.py
@@ -34,7 +34,7 @@ class OrganizationIntegrationSerializer(serializers.Serializer):
 
 
 class SentryAccountLinkSerializer(serializers.Serializer):
-    """Serializer for linking Sentry accounts to Codecov users."""
+    """Serializer for linking Sentry organizations to Codecov organizations"""
 
     sentry_org_id = serializers.CharField(help_text="The Sentry organization ID")
     sentry_org_name = serializers.CharField(
@@ -46,6 +46,12 @@ class SentryAccountLinkSerializer(serializers.Serializer):
         help_text="List of organizations/integrations tied to the account.",
         required=True,
     )
+
+
+class SentryAccountUnlinkSerializer(serializers.Serializer):
+    """Serializer for unlinking Sentry organizations from Codecov organizations."""
+
+    sentry_org_id = serializers.CharField(help_text="The Sentry organization ID")
 
 
 @api_view(["POST"])
@@ -157,7 +163,7 @@ def account_link(request, *args, **kwargs):
 @api_view(["POST"])
 @permission_classes([JWTAuthenticationPermission])
 def account_unlink(request, *args, **kwargs):
-    serializer = SentryAccountLinkSerializer(data=request.data)
+    serializer = SentryAccountUnlinkSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
 
     sentry_org_id = serializer.validated_data["sentry_org_id"]


### PR DESCRIPTION
Realized we don't need a lot of the serializer stuff and we only need the sentry org id to unlink the account. I didn't want to include name in the event sentry org names can change and then we end up either having a missing reference or an unknown reference to update.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
