### PR TITLE
refactor: update API to use new test analytics models

### DIFF
--- a/apps/codecov-api/api/public/v2/test_results/serializers.py
+++ b/apps/codecov-api/api/public/v2/test_results/serializers.py
@@ -1,40 +1,70 @@
 from rest_framework import serializers
 
-from reports.models import TestInstance
+from shared.django_apps.ta_timeseries.models import Testrun
 
 
-class TestInstanceSerializer(serializers.ModelSerializer):
-    id = serializers.IntegerField(label="id")
-    name = serializers.CharField(source="test.name", read_only=True, label="test name")
-    test_id = serializers.CharField(label="test id")
-    failure_message = serializers.CharField(label="test name")
-    duration_seconds = serializers.FloatField(label="duration in seconds")
-    commitid = serializers.CharField(label="commit SHA")
-    outcome = serializers.CharField(label="outcome")
-    branch = serializers.CharField(label="branch name")
-    repoid = serializers.IntegerField(label="repo id")
-    failure_rate = serializers.FloatField(
-        source="test.failure_rate", read_only=True, label="failure rate"
+class TestrunSerializer(serializers.ModelSerializer):
+    test_id = serializers.SerializerMethodField(label="test id")
+    name = serializers.CharField(read_only=True, allow_null=True, label="test name")
+    classname = serializers.CharField(
+        read_only=True, allow_null=True, label="class name"
     )
-    commits_where_fail = serializers.ListField(
-        source="test.commits_where_fail",
-        read_only=True,
-        label="commits where test failed",
+    testsuite = serializers.CharField(
+        read_only=True, allow_null=True, label="test suite"
     )
+    computed_name = serializers.CharField(
+        read_only=True, allow_null=True, label="computed name"
+    )
+    outcome = serializers.CharField(read_only=True, label="outcome")
+    duration_seconds = serializers.FloatField(
+        read_only=True, allow_null=True, label="duration in seconds"
+    )
+    failure_message = serializers.CharField(
+        read_only=True, allow_null=True, label="failure message"
+    )
+    framework = serializers.CharField(
+        read_only=True, allow_null=True, label="framework"
+    )
+    filename = serializers.CharField(read_only=True, allow_null=True, label="filename")
+    repo_id = serializers.IntegerField(read_only=True, label="repo id")
+    commit_sha = serializers.CharField(
+        read_only=True, allow_null=True, label="commit SHA"
+    )
+    branch = serializers.CharField(read_only=True, allow_null=True, label="branch name")
+    flags = serializers.ListField(
+        child=serializers.CharField(), read_only=True, allow_null=True, label="flags"
+    )
+    upload_id = serializers.IntegerField(
+        read_only=True, allow_null=True, label="upload id"
+    )
+    properties = serializers.JSONField(
+        read_only=True, allow_null=True, label="properties"
+    )
+    timestamp = serializers.DateTimeField(read_only=True, label="timestamp")
+
+    def get_test_id(self, obj):
+        """Convert binary test_id to string representation"""
+        return obj.test_id.hex() if obj.test_id else None
 
     class Meta:
-        model = TestInstance
+        model = Testrun
         read_only_fields = (
-            "id",
             "test_id",
-            "failure_message",
-            "duration_seconds",
-            "commitid",
-            "outcome",
-            "branch",
-            "repoid",
-            "failure_rate",
             "name",
-            "commits_where_fail",
+            "classname",
+            "testsuite",
+            "computed_name",
+            "outcome",
+            "duration_seconds",
+            "failure_message",
+            "framework",
+            "filename",
+            "repo_id",
+            "commit_sha",
+            "branch",
+            "flags",
+            "upload_id",
+            "properties",
+            "timestamp",
         )
         fields = read_only_fields

--- a/apps/codecov-api/api/public/v2/test_results/views.py
+++ b/apps/codecov-api/api/public/v2/test_results/views.py
@@ -1,8 +1,9 @@
 import django_filters
+from django.http import JsonResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
-from rest_framework import mixins, viewsets
+from rest_framework import mixins, status, viewsets
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 
 from api.shared.mixins import RepoPropertyMixin
@@ -11,13 +12,13 @@ from codecov_auth.authentication import (
     SuperTokenAuthentication,
     UserTokenAuthentication,
 )
-from reports.models import TestInstance
+from shared.django_apps.ta_timeseries.models import Testrun
 
-from .serializers import TestInstanceSerializer
+from .serializers import TestrunSerializer
 
 
 class TestResultsFilters(django_filters.FilterSet):
-    commit_id = django_filters.CharFilter(field_name="commitid")
+    commit_id = django_filters.CharFilter(field_name="commit_sha")
     outcome = django_filters.CharFilter(field_name="outcome")
     duration_min = django_filters.NumberFilter(
         field_name="duration_seconds", lookup_expr="gte"
@@ -28,7 +29,7 @@ class TestResultsFilters(django_filters.FilterSet):
     branch = django_filters.CharFilter(field_name="branch")
 
     class Meta:
-        model = TestInstance
+        model = Testrun
         fields = ["commit_id", "outcome", "duration_min", "duration_max", "branch"]
 
 
@@ -81,34 +82,100 @@ class TestResultsView(
         SessionAuthentication,
     ]
 
-    serializer_class = TestInstanceSerializer
+    serializer_class = TestrunSerializer
     permission_classes = [SuperTokenPermissions | RepositoryArtifactPermissions]
     filter_backends = [DjangoFilterBackend]
     filterset_class = TestResultsFilters
 
     def get_queryset(self):
-        return TestInstance.objects.filter(repoid=self.repo.repoid)
+        # TestInstance model has been removed, this endpoint is deprecated
+        return Testrun.objects.none()
 
-    @extend_schema(summary="Test results list")
+    def dispatch(self, request, *args, **kwargs):
+        return JsonResponse(
+            {
+                "detail": "This endpoint has been deprecated. Please use /test-analytics/ instead.",
+                "new_endpoint": "https://api.codecov.io/api/v2/{service}/{owner_username}/repos/{repo_name}/test-analytics/",
+            },
+            status=status.HTTP_301_MOVED_PERMANENTLY,
+        )
+
+
+class TestAnalyticsFilters(django_filters.FilterSet):
+    commit_sha = django_filters.CharFilter(field_name="commit_sha")
+    branch = django_filters.CharFilter(field_name="branch")
+    outcome = django_filters.CharFilter(field_name="outcome")
+    duration_min = django_filters.NumberFilter(
+        field_name="duration_seconds", lookup_expr="gte"
+    )
+    duration_max = django_filters.NumberFilter(
+        field_name="duration_seconds", lookup_expr="lte"
+    )
+
+    class Meta:
+        model = Testrun
+        fields = ["commit_sha", "branch", "outcome", "duration_min", "duration_max"]
+
+
+@extend_schema(
+    parameters=[
+        OpenApiParameter(
+            "commit_sha",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            description="Commit SHA for which to return test analytics",
+        ),
+        OpenApiParameter(
+            "branch",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            description="Branch name for which to return test analytics",
+        ),
+        OpenApiParameter(
+            "outcome",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            description="Status of the test (failure, skip, error, pass)",
+        ),
+        OpenApiParameter(
+            "duration_min",
+            OpenApiTypes.INT,
+            OpenApiParameter.QUERY,
+            description="Minimum duration of the test in seconds",
+        ),
+        OpenApiParameter(
+            "duration_max",
+            OpenApiTypes.INT,
+            OpenApiParameter.QUERY,
+            description="Maximum duration of the test in seconds",
+        ),
+    ],
+    tags=["Test Analytics"],
+    summary="Retrieve test analytics",
+)
+class TestAnalyticsView(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    RepoPropertyMixin,
+):
+    authentication_classes = [
+        SuperTokenAuthentication,
+        UserTokenAuthentication,
+        BasicAuthentication,
+        SessionAuthentication,
+    ]
+
+    serializer_class = TestrunSerializer
+    permission_classes = [SuperTokenPermissions | RepositoryArtifactPermissions]
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = TestAnalyticsFilters
+
+    def get_queryset(self):
+        return Testrun.objects.filter(repo_id=self.repo.repoid).order_by("-timestamp")
+
+    @extend_schema(summary="Test analytics list")
     def list(self, request, *args, **kwargs):
         """
-        Returns a list of test results for the specified repository and commit
+        Returns a list of test analytics for the specified repository
         """
         return super().list(request, *args, **kwargs)
-
-    @extend_schema(
-        summary="Test results detail",
-        parameters=[
-            OpenApiParameter(
-                "id",
-                OpenApiTypes.INT,
-                OpenApiParameter.PATH,
-                description="Test instance ID",
-            ),
-        ],
-    )
-    def retrieve(self, request, *args, **kwargs):
-        """
-        Returns a single test result by ID
-        """
-        return super().retrieve(request, *args, **kwargs)

--- a/apps/codecov-api/api/public/v2/tests/test_test_results_view.py
+++ b/apps/codecov-api/api/public/v2/tests/test_test_results_view.py
@@ -1,35 +1,45 @@
-from unittest.mock import patch
-
-from django.test import override_settings
 from django.urls import reverse
-from freezegun import freeze_time
 from rest_framework import status
 
 from codecov.tests.base_test import InternalAPITest
-from reports.tests.factories import TestInstanceFactory
 from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
+from shared.django_apps.ta_timeseries.tests.factories import TestrunFactory
 from utils.test_utils import APIClient
 
 
-@freeze_time("2022-01-01T00:00:00")
-class TestResultsViewsetTests(InternalAPITest):
+class TestAnalyticsViewsetTests(InternalAPITest):
+    databases = {"default", "ta_timeseries"}
+
     def setUp(self):
         self.org = OwnerFactory()
         self.repo = RepositoryFactory(author=self.org)
         self.current_owner = OwnerFactory(
             permission=[self.repo.repoid], organizations=[self.org.ownerid]
         )
-        self.test_instances = [
-            TestInstanceFactory(repoid=self.repo.repoid, commitid="1234"),
-            TestInstanceFactory(repoid=self.repo.repoid, commitid="3456"),
-        ]
 
         self.client = APIClient()
         self.client.force_login_owner(self.current_owner)
 
-    def test_list(self):
+        self.testruns = [
+            TestrunFactory(
+                repo_id=self.repo.repoid,
+                commit_sha="abc123def",
+                branch="main",
+                outcome="pass",
+                duration_seconds=1.5,
+            ),
+            TestrunFactory(
+                repo_id=self.repo.repoid,
+                commit_sha="def456ghi",
+                branch="feature-branch",
+                outcome="failure",
+                duration_seconds=2.3,
+            ),
+        ]
+
+    def test_list_test_analytics(self):
         url = reverse(
-            "api-v2-tests-results-list",
+            "api-v2-test-analytics-list",
             kwargs={
                 "service": self.org.service,
                 "owner_username": self.org.username,
@@ -38,192 +48,59 @@ class TestResultsViewsetTests(InternalAPITest):
         )
         res = self.client.get(url)
         assert res.status_code == status.HTTP_200_OK
-        assert res.json() == {
+
+        data = res.json()
+
+        # Remove timestamps from results for consistent comparison
+        for result in data["results"]:
+            result.pop("timestamp", None)
+
+        # Sort results by test_id for consistent ordering
+        data["results"].sort(key=lambda x: x["test_id"])
+
+        expected_data = {
             "count": 2,
             "next": None,
             "previous": None,
+            "total_pages": 1,
             "results": [
                 {
-                    "id": self.test_instances[0].id,
-                    "name": self.test_instances[0].test.name,
-                    "test_id": self.test_instances[0].test_id,
-                    "failure_message": self.test_instances[0].failure_message,
-                    "duration_seconds": self.test_instances[0].duration_seconds,
-                    "commitid": self.test_instances[0].commitid,
-                    "outcome": self.test_instances[0].outcome,
-                    "branch": self.test_instances[0].branch,
-                    "repoid": self.test_instances[0].repoid,
+                    "test_id": b"test_0".hex(),
+                    "name": "test_0",
+                    "classname": "class_0",
+                    "testsuite": "suite_0",
+                    "computed_name": "computed_0",
+                    "outcome": "pass",
+                    "duration_seconds": 1.5,
+                    "failure_message": None,
+                    "framework": "Pytest",
+                    "filename": "test_0.py",
+                    "repo_id": self.repo.repoid,
+                    "commit_sha": "abc123def",
+                    "branch": "main",
+                    "flags": [],
+                    "upload_id": 1,
+                    "properties": None,
                 },
                 {
-                    "id": self.test_instances[1].id,
-                    "name": self.test_instances[1].test.name,
-                    "test_id": self.test_instances[1].test_id,
-                    "failure_message": self.test_instances[1].failure_message,
-                    "duration_seconds": self.test_instances[1].duration_seconds,
-                    "commitid": self.test_instances[1].commitid,
-                    "outcome": self.test_instances[1].outcome,
-                    "branch": self.test_instances[1].branch,
-                    "repoid": self.test_instances[1].repoid,
+                    "test_id": b"test_1".hex(),
+                    "name": "test_1",
+                    "classname": "class_1",
+                    "testsuite": "suite_1",
+                    "computed_name": "computed_1",
+                    "outcome": "failure",
+                    "duration_seconds": 2.3,
+                    "failure_message": "failure_message_failure",
+                    "framework": "Pytest",
+                    "filename": "test_1.py",
+                    "repo_id": self.repo.repoid,
+                    "commit_sha": "def456ghi",
+                    "branch": "feature-branch",
+                    "flags": [],
+                    "upload_id": 1,
+                    "properties": None,
                 },
             ],
-            "total_pages": 1,
         }
 
-    def test_list_filters(self):
-        url = reverse(
-            "api-v2-tests-results-list",
-            kwargs={
-                "service": self.org.service,
-                "owner_username": self.org.username,
-                "repo_name": self.repo.name,
-            },
-        )
-        res = self.client.get(f"{url}?commit_id={self.test_instances[0].commitid}")
-        assert res.status_code == status.HTTP_200_OK
-        assert res.json() == {
-            "count": 1,
-            "next": None,
-            "previous": None,
-            "results": [
-                {
-                    "id": self.test_instances[0].id,
-                    "name": self.test_instances[0].test.name,
-                    "test_id": self.test_instances[0].test_id,
-                    "failure_message": self.test_instances[0].failure_message,
-                    "duration_seconds": self.test_instances[0].duration_seconds,
-                    "commitid": self.test_instances[0].commitid,
-                    "outcome": self.test_instances[0].outcome,
-                    "branch": self.test_instances[0].branch,
-                    "repoid": self.test_instances[0].repoid,
-                },
-            ],
-            "total_pages": 1,
-        }
-
-    @patch("api.shared.repo.repository_accessors.RepoAccessors.get_repo_permissions")
-    def test_retrieve(self, get_repo_permissions):
-        get_repo_permissions.return_value = (True, True)
-        res = self.client.get(
-            reverse(
-                "api-v2-tests-results-detail",
-                kwargs={
-                    "service": self.org.service,
-                    "owner_username": self.org.username,
-                    "repo_name": self.repo.name,
-                    "pk": self.test_instances[0].pk,
-                },
-            )
-        )
-        assert res.status_code == status.HTTP_200_OK
-        assert res.json() == {
-            "id": self.test_instances[0].id,
-            "name": self.test_instances[0].test.name,
-            "test_id": self.test_instances[0].test_id,
-            "failure_message": self.test_instances[0].failure_message,
-            "duration_seconds": self.test_instances[0].duration_seconds,
-            "commitid": self.test_instances[0].commitid,
-            "outcome": self.test_instances[0].outcome,
-            "branch": self.test_instances[0].branch,
-            "repoid": self.test_instances[0].repoid,
-        }
-
-    @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
-    @patch("api.shared.permissions.SuperTokenPermissions.has_permission")
-    def test_no_test_result_if_unauthenticated_token_request(
-        self,
-        super_token_permissions_has_permission,
-        repository_artifact_permissions_has_permission,
-    ):
-        repository_artifact_permissions_has_permission.return_value = False
-        super_token_permissions_has_permission.return_value = False
-
-        url = reverse(
-            "api-v2-tests-results-list",
-            kwargs={
-                "service": self.org.service,
-                "owner_username": self.org.username,
-                "repo_name": self.repo.name,
-            },
-        )
-        res = self.client.get(f"{url}?commit_id={self.test_instances[0].commitid}")
-
-        assert res.status_code == 403
-        assert (
-            res.data["detail"] == "You do not have permission to perform this action."
-        )
-
-    @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
-    @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
-    def test_no_result_if_not_super_token_nor_user_token(
-        self, repository_artifact_permissions_has_permission
-    ):
-        repository_artifact_permissions_has_permission.return_value = False
-
-        res = self.client.get(
-            reverse(
-                "api-v2-tests-results-detail",
-                kwargs={
-                    "service": self.org.service,
-                    "owner_username": self.org.username,
-                    "repo_name": self.repo.name,
-                    "pk": self.test_instances[0].pk,
-                },
-            ),
-            HTTP_AUTHORIZATION="Bearer 73c8d301-2e0b-42c0-9ace-95eef6b68e86",
-        )
-        assert res.status_code == 401
-        assert res.data["detail"] == "Invalid token."
-
-    @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
-    @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
-    def test_no_result_if_super_token_but_no_GET_request(
-        self, repository_artifact_permissions_has_permission
-    ):
-        repository_artifact_permissions_has_permission.return_value = False
-        res = self.client.post(
-            reverse(
-                "api-v2-tests-results-detail",
-                kwargs={
-                    "service": self.org.service,
-                    "owner_username": self.org.username,
-                    "repo_name": self.repo.name,
-                    "pk": self.test_instances[0].pk,
-                },
-            ),
-            HTTP_AUTHORIZATION="Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r",
-        )
-        assert res.status_code == 403
-        assert (
-            res.data["detail"] == "You do not have permission to perform this action."
-        )
-
-    @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
-    @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
-    def test_result_with_valid_super_token(
-        self, repository_artifact_permissions_has_permission
-    ):
-        repository_artifact_permissions_has_permission.return_value = False
-        res = self.client.get(
-            reverse(
-                "api-v2-tests-results-detail",
-                kwargs={
-                    "service": self.org.service,
-                    "owner_username": self.org.username,
-                    "repo_name": self.repo.name,
-                    "pk": self.test_instances[0].pk,
-                },
-            ),
-            HTTP_AUTHORIZATION="Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r",
-        )
-        assert res.status_code == 200
-        assert res.json() == {
-            "id": self.test_instances[0].id,
-            "name": self.test_instances[0].test.name,
-            "test_id": self.test_instances[0].test_id,
-            "failure_message": self.test_instances[0].failure_message,
-            "duration_seconds": self.test_instances[0].duration_seconds,
-            "commitid": self.test_instances[0].commitid,
-            "outcome": self.test_instances[0].outcome,
-            "branch": self.test_instances[0].branch,
-            "repoid": self.test_instances[0].repoid,
-        }
+        assert data == expected_data

--- a/apps/codecov-api/api/public/v2/urls.py
+++ b/apps/codecov-api/api/public/v2/urls.py
@@ -17,7 +17,7 @@ from .owner.views import OwnersViewSet, OwnerViewSet, UserSessionViewSet, UserVi
 from .pull.views import PullViewSet
 from .repo.views import RepositoryConfigView, RepositoryViewSet
 from .report.views import FileReportViewSet, ReportViewSet, TotalsViewSet
-from .test_results.views import TestResultsView
+from .test_results.views import TestAnalyticsView, TestResultsView
 
 urls.handler404 = not_found
 urls.handler500 = server_error
@@ -48,6 +48,9 @@ repository_artifacts_router.register(
 )
 repository_artifacts_router.register(
     r"test-results", TestResultsView, basename="api-v2-tests-results"
+)
+repository_artifacts_router.register(
+    r"test-analytics", TestAnalyticsView, basename="api-v2-test-analytics"
 )
 repository_artifacts_router.register(r"evals", EvalsViewSet, basename="api-v2-evals")
 

--- a/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
+++ b/apps/codecov-api/graphql_api/tests/test_test_analytics_timescale.py
@@ -327,6 +327,7 @@ class TestAnalyticsTestCaseNew(GraphQLTestHelper):
         """
 
         result = self.gql_request(query, owner=repository.author)
+
         assert snapshot("json") == result
 
     def test_gql_query_testsuites_and_flags_resolvers_with_term(
@@ -348,4 +349,5 @@ class TestAnalyticsTestCaseNew(GraphQLTestHelper):
         """
 
         result = self.gql_request(query, owner=repository.author)
+
         assert snapshot("json") == result

--- a/apps/codecov-api/reports/tests/factories.py
+++ b/apps/codecov-api/reports/tests/factories.py
@@ -1,11 +1,8 @@
-from datetime import date, datetime
-
 import factory
 from factory.django import DjangoModelFactory
 
 from graphql_api.types.enums import UploadErrorEnum
 from reports import models
-from reports.models import TestInstance
 from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
 
 
@@ -75,59 +72,3 @@ class UploadErrorFactory(DjangoModelFactory):
             UploadErrorEnum.REPORT_EXPIRED,
         ]
     )
-
-
-class TestFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = models.Test
-
-    id = factory.Sequence(lambda n: f"{n}")
-    name = factory.Sequence(lambda n: f"{n}")
-    repository = factory.SubFactory(RepositoryFactory)
-    computed_name = None
-
-
-class TestInstanceFactory(factory.django.DjangoModelFactory):
-    __test__ = False
-
-    class Meta:
-        model = models.TestInstance
-
-    test = factory.SubFactory(TestFactory)
-    duration_seconds = 1.0
-    outcome = TestInstance.Outcome.FAILURE.value
-    failure_message = "Test failed"
-    branch = "master"
-    repoid = factory.SelfAttribute("test.repository.repoid")
-    commitid = "123456"
-    upload = factory.SubFactory(UploadFactory)
-
-
-class DailyTestRollupFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = models.DailyTestRollup
-
-    test = factory.SubFactory(TestFactory)
-
-    repoid = factory.SelfAttribute("test.repository.repoid")
-    branch = "main"
-
-    last_duration_seconds = 1.0
-    avg_duration_seconds = 0.5
-    pass_count = 1
-    skip_count = 2
-    fail_count = 3
-    flaky_fail_count = 0
-
-    latest_run = datetime.now()
-    date = date.today()
-
-    commits_where_fail = ["123", "456", "789"]
-
-
-class TestFlagBridgeFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = models.TestFlagBridge
-
-    test = factory.SubFactory(TestFactory)
-    flag = factory.SubFactory(RepositoryFlagFactory)

--- a/apps/codecov-api/services/task/task.py
+++ b/apps/codecov-api/services/task/task.py
@@ -392,9 +392,3 @@ class TaskService:
                 "measurement_id": component_id,
             },
         ).apply_async()
-
-    def cache_test_results_redis(self, repoid: int, branch: str) -> None:
-        self._create_signature(
-            celery_config.cache_test_rollups_redis_task_name,
-            kwargs={"repoid": repoid, "branch": branch},
-        ).apply_async()


### PR DESCRIPTION
essentially #479 but for the API

there were some leftover places where we were still using the old models (which are no longer being written to) so we have to replace those with using the new models

and also getting rid of a bunch of old code that won't run