### PR TITLE
Mark the Alter Type migration to be risky

### DIFF
--- a/libs/shared/shared/django_apps/codecov_auth/migrations/0073_alter_owner_service.py
+++ b/libs/shared/shared/django_apps/codecov_auth/migrations/0073_alter_owner_service.py
@@ -2,6 +2,8 @@
 
 from django.db import migrations, models
 
+from shared.django_apps.migration_utils import RiskyRunSQL
+
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -9,7 +11,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL(
+        RiskyRunSQL(
             sql="ALTER TYPE service ADD VALUE IF NOT EXISTS 'to_be_deleted';",
             reverse_sql=migrations.RunSQL.noop,
         ),


### PR DESCRIPTION
This migration isn't _actually_ risky. However, the production service user doesn't have permissions to modify the DB types, so we'll run this manually, and will need to mark the migration as "complete".

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
