### PR TITLE
Filter out deleted orgs from showing in user's org lists

### DIFF
--- a/apps/codecov-api/codecov_auth/tests/unit/test_managers.py
+++ b/apps/codecov-api/codecov_auth/tests/unit/test_managers.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from codecov_auth.models import Owner
+from shared.django_apps.codecov_auth.models import Service
 from shared.django_apps.core.tests.factories import OwnerFactory
 
 
@@ -49,3 +50,40 @@ class OwnerManagerTests(TestCase):
             owner_in_org_and_plan_activated_users.delete()
             users_of = Owner.objects.users_of(owner=org)
             self.assertEqual(list(users_of), [])
+
+    def test_orgs_filters_exclude_to_be_deleted_owners(self):
+        """Test that Owner.orgs filtering correctly excludes TO_BE_DELETED service and null username."""
+        normal_org = OwnerFactory(
+            username="normal-org",
+            service=Service.GITHUB.value,
+        )
+        deleted_org = OwnerFactory(
+            username="deleted-org",
+            service=Service.TO_BE_DELETED.value,
+        )
+
+        # Create a test owner with all these organizations
+        test_owner = OwnerFactory(
+            username="test-user",
+            service=Service.GITHUB.value,
+            organizations=[
+                normal_org.ownerid,
+                deleted_org.ownerid,
+            ],
+        )
+
+        # Test the filtering logic directly on the orgs queryset
+        filtered_orgs = test_owner.orgs
+
+        # Should only include the normal organization
+        filtered_org_ids = list(filtered_orgs.values_list("ownerid", flat=True))
+        self.assertIn(normal_org.ownerid, filtered_org_ids)
+        self.assertNotIn(deleted_org.ownerid, filtered_org_ids)
+
+        # Test with term filtering
+        filtered_orgs_with_term = filtered_orgs.filter(username__contains="-org")
+        term_filtered_ids = list(
+            filtered_orgs_with_term.values_list("ownerid", flat=True)
+        )
+        self.assertIn(normal_org.ownerid, term_filtered_ids)
+        self.assertEqual(len(term_filtered_ids), 1)

--- a/libs/shared/shared/django_apps/codecov_auth/models.py
+++ b/libs/shared/shared/django_apps/codecov_auth/models.py
@@ -493,7 +493,9 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
     @property
     def orgs(self):
         if self.organizations:
-            return Owner.objects.filter(ownerid__in=self.organizations)
+            return Owner.objects.filter(ownerid__in=self.organizations).exclude(
+                service=Service.TO_BE_DELETED.value
+            )
         return Owner.objects.none()
 
     @property


### PR DESCRIPTION
This is just to ensure that it doesn't show up in user's orgs lists.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
