### PR TITLE
fix: sentry github app installation logic

### DIFF
--- a/apps/codecov-api/webhook_handlers/tests/test_github.py
+++ b/apps/codecov-api/webhook_handlers/tests/test_github.py
@@ -1087,7 +1087,9 @@ class GithubWebhookHandlerTests(APITestCase):
         assert mock_refresh.call_count == 0
 
     @override_settings(
-        GITHUB_SENTRY_APP_ID=424242, GITHUB_SENTRY_APP_PEM="/tmp/sentry_app.pem"
+        GITHUB_SENTRY_APP_NAME="sentry_app",
+        GITHUB_SENTRY_APP_ID=424242,
+        GITHUB_SENTRY_APP_PEM="/tmp/sentry_app.pem",
     )
     @patch(
         "services.task.TaskService.refresh",
@@ -1130,8 +1132,9 @@ class GithubWebhookHandlerTests(APITestCase):
         )
         assert ghapp_installations_set.count() == 1
         installation = ghapp_installations_set.first()
+        assert installation.name == "sentry_app"
         assert installation.app_id == 424242
-        assert installation.pem_path == "/tmp/sentry_app.pem"
+        assert installation.pem_path is None
 
     @patch("services.task.TaskService.refresh")
     def test_organization_with_removed_action_removes_user_from_org_and_activated_user_list(

--- a/apps/codecov-api/webhook_handlers/views/github.py
+++ b/apps/codecov-api/webhook_handlers/views/github.py
@@ -497,12 +497,12 @@ class GithubWebhookHandler(APIView):
                         ghapp_installation, owner, request, app_id, installation_id
                     )
 
+            # handle sentry app specifically
             sentry_app_id = settings.GITHUB_SENTRY_APP_ID
             if sentry_app_id is not None and ghapp_installation.app_id == sentry_app_id:
                 ghapp_installation.app_id = app_id
-                ghapp_installation.pem_path = settings.GITHUB_SENTRY_APP_PEM
+                ghapp_installation.name = settings.GITHUB_SENTRY_APP_NAME
 
-            # Either update or set
             ghapp_installation.name = self._decide_app_name(ghapp_installation)
 
             log.info(

--- a/libs/shared/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
+++ b/libs/shared/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from django.db import IntegrityError
 from django.forms import ValidationError
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase, TransactionTestCase, override_settings
 from pytest import LogCaptureFixture
 
 from shared.django_apps.codecov_auth.models import (
@@ -771,6 +771,7 @@ class TestGitHubAppInstallationNoDefaultAppIdConfig(TestCase):
     def mock_no_default_app_id(self, mocker):
         mock_config_helper(mocker, configs={"github.integration.id": None})
 
+    @override_settings(GITHUB_SENTRY_APP_ID=None)
     def test_is_configured_no_default(self):
         owner = OwnerFactory()
         installation_default = GithubAppInstallationFactory(


### PR DESCRIPTION
the code was previously not setting the name correctly. This isn't the greatest
approach since we're handling the sentry github app case specifically and
ideally we'd have a "system" for discerning between "default apps" and
"custom apps" but for now this hard coded handling will have to do.

This commit also updates the logic to no longer set the pem path (because it's
no longer needed) and to make that possible without breaking the existing
behaviour we have to update the definition of the is_configured method on the
github app installation model so it considers a list of default app IDs instead
of just the one.
