### PR TITLE
fix: don't check TA if TA is disabled in notify

### DIFF
--- a/apps/worker/helpers/ta_status.py
+++ b/apps/worker/helpers/ta_status.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+
+from services.test_analytics.ta_timeseries import get_pr_comment_agg
+
+
+def get_test_status(repo_id: int, commit_sha: str) -> tuple[bool, bool]:
+    if not settings.TA_TIMESERIES_ENABLED:
+        return False, False
+
+    pr_comment_agg = get_pr_comment_agg(repo_id, commit_sha)
+    failed = pr_comment_agg.get("failed", 0)
+    passed = pr_comment_agg.get("passed", 0)
+
+    any_failures = failed > 0
+    all_passed = passed > 0 and failed == 0
+
+    return any_failures, all_passed

--- a/apps/worker/helpers/tests/test_ta_status.py
+++ b/apps/worker/helpers/tests/test_ta_status.py
@@ -1,0 +1,82 @@
+import pytest
+from django.test import override_settings
+
+from database.tests.factories import CommitFactory, RepositoryFactory
+from helpers.ta_status import get_test_status
+from shared.django_apps.ta_timeseries.tests.factories import TestrunFactory
+
+
+@pytest.fixture
+def setup_testruns(dbsession):
+    def _setup(*outcomes):
+        repository = RepositoryFactory.create()
+        dbsession.add(repository)
+        dbsession.flush()
+
+        commit = CommitFactory.create(
+            repository=repository, commitid="test_commit_123", branch="main"
+        )
+        dbsession.add(commit)
+        dbsession.flush()
+
+        for outcome in outcomes:
+            TestrunFactory.create(
+                repo_id=repository.repoid,
+                commit_sha=commit.commitid,
+                outcome=outcome,
+            )
+
+        return repository, commit
+
+    return _setup
+
+
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
+def test_get_test_status_with_failures_no_passes(dbsession, setup_testruns):
+    repository, commit = setup_testruns("failure", "failure")
+
+    any_failures, all_passed = get_test_status(repository.repoid, commit.commitid)
+
+    assert any_failures is True
+    assert all_passed is False
+
+
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
+def test_get_test_status_with_passes_no_failures(dbsession, setup_testruns):
+    repository, commit = setup_testruns("pass", "pass")
+
+    any_failures, all_passed = get_test_status(repository.repoid, commit.commitid)
+
+    assert any_failures is False
+    assert all_passed is True
+
+
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
+def test_get_test_status_with_passes_and_failures(dbsession, setup_testruns):
+    repository, commit = setup_testruns("pass", "failure")
+
+    any_failures, all_passed = get_test_status(repository.repoid, commit.commitid)
+
+    assert any_failures is True
+    assert all_passed is False
+
+
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
+def test_get_test_status_no_tests(dbsession, setup_testruns):
+    repository, commit = setup_testruns()
+
+    any_failures, all_passed = get_test_status(repository.repoid, commit.commitid)
+
+    assert any_failures is False
+    assert all_passed is False
+
+
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
+@override_settings(TA_TIMESERIES_ENABLED=False)
+def test_get_test_status_when_ta_timeseries_disabled(dbsession, setup_testruns):
+    repository, commit = setup_testruns("failure", "pass")
+
+    any_failures, all_passed = get_test_status(repository.repoid, commit.commitid)
+
+    assert any_failures is False
+    assert all_passed is False

--- a/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__2.txt
+++ b/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__2.txt
@@ -4,7 +4,7 @@
 | 1 | 1 | 0 | 0 |
 <details><summary>View the top 1 failed test(s) by shortest run time</summary>
 
-> <pre><code class="language-python">computed_6</code></pre>
+> <pre><code class="language-python">computed_0</code></pre>
 > <details><summary>Stack Traces | 100s run time</summary>
 > 
 > > <pre><code class="language-python">No failure message available</code></pre>

--- a/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__3.txt
+++ b/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__3.txt
@@ -4,7 +4,7 @@
 | 1 | 1 | 0 | 0 |
 <details><summary>View the full list of 1 :snowflake: flaky tests</summary>
 
-> <pre><code class="language-python">computed_6</code></pre>
+> <pre><code class="language-python">computed_0</code></pre>
 > **Flake rate in main:** 100.00% (Passed 0 times, Failed 10 times)
 > <details><summary>Stack Traces | 100s run time</summary>
 > 

--- a/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__4.txt
+++ b/apps/worker/services/test_analytics/tests/snapshots/ta_finish_upload__ta_finish_upload__4.txt
@@ -4,7 +4,7 @@
 | 1 | 1 | 0 | 0 |
 <details><summary>View the full list of 1 :snowflake: flaky tests</summary>
 
-> <pre><code class="language-python">computed_6</code></pre>
+> <pre><code class="language-python">computed_0</code></pre>
 > **Flake rate in main:** 100.00% (Passed 0 times, Failed 10 times)
 > <details><summary>Stack Traces | 100s run time</summary>
 > 

--- a/apps/worker/services/test_analytics/tests/test_ta_finish_upload.py
+++ b/apps/worker/services/test_analytics/tests/test_ta_finish_upload.py
@@ -55,6 +55,8 @@ def prepopulate(dbsession):
     )
     django_upload.save()
 
+    TestrunFactory.reset_sequence()
+
     testrun = TestrunFactory(
         repo_id=django_upload.report.commit.repository.repoid,
         commit_sha=django_upload.report.commit.commitid,

--- a/apps/worker/tasks/notify.py
+++ b/apps/worker/tasks/notify.py
@@ -19,6 +19,7 @@ from helpers.comparison import minimal_totals
 from helpers.exceptions import NoConfiguredAppsAvailable, RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
 from helpers.save_commit_error import save_commit_error
+from helpers.ta_status import get_test_status
 from services.activation import activate_user
 from services.commit_status import RepositoryCIFilter
 from services.comparison import (
@@ -38,7 +39,6 @@ from services.repository import (
     fetch_and_update_pull_request_information_from_commit,
     get_repo_provider_service,
 )
-from services.test_analytics.ta_timeseries import get_pr_comment_agg
 from services.yaml import get_current_yaml, read_yaml_field
 from shared.bots.github_apps import (
     get_github_app_token,
@@ -65,17 +65,6 @@ from tasks.upload_processor import UPLOAD_PROCESSING_LOCK_NAME
 log = logging.getLogger(__name__)
 
 GENERIC_TA_ERROR_MSG = "Test Analytics upload error: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."
-
-
-def get_test_status(repo_id: int, commit_sha: str) -> tuple[bool, bool]:
-    pr_comment_agg = get_pr_comment_agg(repo_id, commit_sha)
-    failed = pr_comment_agg.get("failed", 0)
-    passed = pr_comment_agg.get("passed", 0)
-
-    any_failures = failed > 0
-    all_passed = passed > 0 and failed == 0
-
-    return any_failures, all_passed
 
 
 class NotifyTask(BaseCodecovTask, name=notify_task_name):


### PR DESCRIPTION
we need to make sure we don't try getting data from the TA database is TA is not enabled for the entire codecov instance, which I wasn't doing.

I also do some light refactoring of the source code and the tests.
entry's choice of terms.
