### PR TITLE
fix: Add guard incase admin object is None

### DIFF
--- a/apps/codecov-api/billing/helpers.py
+++ b/apps/codecov-api/billing/helpers.py
@@ -18,7 +18,8 @@ def get_admins_for_owners(owners: QuerySet[Owner]) -> list[Owner]:
     owner_ids: set[int] = set()
     for owner in owners:
         owner_ids.add(owner.ownerid)
-        owner_ids.update(owner.admins)
+        if owner.admins:
+            owner_ids.update(owner.admins)
 
     if not owner_ids:
         return []


### PR DESCRIPTION
This PR fixes https://codecov.sentry.io/issues/6818916968/?environment=production&project=5215654&query=is%3Aunresolved%20billing&referrer=issue-stream which occurs when owners.admins is None.

Owners.admins can either be None of an iterable with at least 1 element, and set.update() requires a non-None value to work

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
