### PR TITLE
feat: only make all tests passed comment after the failed tests comment

### DIFF
--- a/apps/worker/services/test_analytics/ta_finish_upload.py
+++ b/apps/worker/services/test_analytics/ta_finish_upload.py
@@ -222,13 +222,24 @@ def ta_finish_upload(
             "queue_notify": True,
         }
     elif summary["failed"] == 0 and num_testruns > 0:
-        log.info("No failures, posting all passed comment", extra=extra)
-        notifier.all_passed_comment()
-        return {
-            "notify_attempted": True,
-            "notify_succeeded": True,
-            "queue_notify": True,
-        }
+        if pull.database_pull.commentid is not None:
+            log.info("No failures, editing existing all passed comment", extra=extra)
+            notifier.all_passed_comment()
+            return {
+                "notify_attempted": True,
+                "notify_succeeded": True,
+                "queue_notify": True,
+            }
+        else:
+            log.info(
+                "No failures but no existing comment, skipping comment update",
+                extra=extra,
+            )
+            return {
+                "notify_attempted": False,
+                "notify_succeeded": True,
+                "queue_notify": True,
+            }
 
     with read_failures_summary.labels(impl="new").time():
         failures = get_pr_comment_failures(repoid, commitid)

--- a/apps/worker/services/test_analytics/tests/test_ta_finish_upload.py
+++ b/apps/worker/services/test_analytics/tests/test_ta_finish_upload.py
@@ -234,6 +234,45 @@ def test_ta_finish_upload(
     assert_tasks([])
     assert_comment_snapshot()
 
+    mock_pull(
+        mocker.Mock(
+            spec=EnrichedPull,
+            provider_pull={
+                "author": {
+                    "username": "test-user",
+                },
+            },
+            database_pull=PullFactory(
+                repository=repo,
+                author=commit.repository.author,
+                commentid=None,  # No existing comment
+            ),
+        )
+    )
+
+    result = run_task()
+
+    assert_result(False, True, True)
+    assert_tasks([])
+    mock_repo_provider_comments.edit_comment.assert_not_called()
+    mock_repo_provider_comments.post_comment.assert_not_called()
+
+    mock_pull(
+        mocker.Mock(
+            spec=EnrichedPull,
+            provider_pull={
+                "author": {
+                    "username": "test-user",
+                },
+            },
+            database_pull=PullFactory(
+                repository=repo,
+                author=commit.repository.author,
+                commentid=1,
+            ),
+        )
+    )
+
     # no flake detection
 
     testrun.outcome = "failure"


### PR DESCRIPTION
we're currently always making the all tests passed comment, even when there haven't already been failures, which is not the goal of this comment, it's there to wipe away the failed tests comment for users only using TA and not coverage.

To achieve this i'm making it so we can only make the all tests passed comment if we've already made some comment. We have to queue the notify afterwards because it's possible we have a coverage comment that we're editing and we've accidentally overwritten that