### PR TITLE
fix: Perm classes for account link/unlink endpoints

### DIFF
--- a/apps/codecov-api/api/sentry/tests/test_views.py
+++ b/apps/codecov-api/api/sentry/tests/test_views.py
@@ -200,7 +200,7 @@ class AccountLinkViewTests(TestCase):
             self.url, data=json.dumps(self.valid_data), content_type="application/json"
         )
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_account_link_invalid_jwt(self):
         """Test account linking fails with invalid JWT"""
@@ -215,7 +215,7 @@ class AccountLinkViewTests(TestCase):
                 content_type="application/json",
             )
 
-            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_account_link_expired_jwt(self):
         """Test account linking fails with expired JWT"""
@@ -230,7 +230,7 @@ class AccountLinkViewTests(TestCase):
                 content_type="application/json",
             )
 
-            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_account_link_missing_sentry_org_id(self):
         """Test account linking fails with missing sentry_org_id"""
@@ -651,4 +651,4 @@ class AccountUnlinkViewTests(TestCase):
             self.url, data=json.dumps(self.valid_data), content_type="application/json"
         )
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/codecov-api/api/sentry/urls.py
+++ b/apps/codecov-api/api/sentry/urls.py
@@ -4,5 +4,5 @@ from .views import account_link, account_unlink
 
 urlpatterns = [
     path("internal/account/link/", account_link, name="account-link"),
-    path("internal/account/unlink", account_unlink, name="account-unlink"),
+    path("internal/account/unlink/", account_unlink, name="account-unlink"),
 ]

--- a/apps/codecov-api/api/sentry/views.py
+++ b/apps/codecov-api/api/sentry/views.py
@@ -2,7 +2,11 @@ import logging
 
 from django.conf import settings
 from rest_framework import serializers, status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
 from rest_framework.response import Response
 
 from codecov_auth.models import Account
@@ -59,6 +63,7 @@ class SentryAccountUnlinkSerializer(serializers.Serializer):
 
 
 @api_view(["POST"])
+@authentication_classes([])
 @permission_classes([JWTAuthenticationPermission])
 def account_link(request, *args, **kwargs):
     serializer = SentryAccountLinkSerializer(data=request.data)
@@ -165,6 +170,7 @@ def account_link(request, *args, **kwargs):
 
 
 @api_view(["POST"])
+@authentication_classes([])
 @permission_classes([JWTAuthenticationPermission])
 def account_unlink(request, *args, **kwargs):
     serializer = SentryAccountUnlinkSerializer(data=request.data)


### PR DESCRIPTION
Updates the perm classes to none because the Sentry JWT auth covers authentication, and this route isn't exposed in sentry

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
