### PR TITLE
feat: add TA dashboard link to prevent comments

### DIFF
--- a/apps/worker/services/tests/snapshots/results__build_message_for_prevent__0.txt
+++ b/apps/worker/services/tests/snapshots/results__build_message_for_prevent__0.txt
@@ -13,3 +13,5 @@
 > </details>
 
 </details>
+
+To view more test analytics, go to the [Prevent Tests Dashboard](https://testaccount.sentry.io/prevent/tests/?preventPeriod=30d&integratedOrgName=username&repository=name&branch=thing%2Fthing)

--- a/apps/worker/services/tests/test_test_results.py
+++ b/apps/worker/services/tests/test_test_results.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from database.models import Account
 from database.tests.factories import CommitFactory, OwnerFactory, RepositoryFactory
 from helpers.notifier import NotifierResult
 from services.repository import EnrichedPull
@@ -246,6 +247,7 @@ def test_build_message_for_prevent(snapshot):
         repository__author__service="github",
         repository__name="name",
     )
+    commit.repository.author.account = Account(name="testaccount", is_active=True)
     tn = TestResultsNotifier(
         commit.repository, commit, None, None, None, payload, for_prevent=True
     )


### PR DESCRIPTION
we previously weren't able to do this because the link required having access to an ID that is specific to Sentry Integrations, but now we can because the link uses the name of the github org instead.

we generate the link by using the Account name which maps to the sentry account's name, the owner's name, which maps to the github org's name and the repo name and branch names.