### PR TITLE
fix: Account link should respect existing owners seat counts

### DIFF
--- a/apps/codecov-api/api/sentry/tests/test_views.py
+++ b/apps/codecov-api/api/sentry/tests/test_views.py
@@ -34,13 +34,11 @@ class AccountLinkViewTests(TestCase):
         }
 
     def _make_authenticated_request(self, url=None, data=None, jwt_payload=None):
-        """Helper method to make an authenticated request with JWT payload"""
         if data is None:
             data = self.valid_data
         if url is None:
             url = self.url
 
-        # Mock the JWT authentication by setting the payload on the request
         with patch(
             "codecov_auth.permissions.get_sentry_jwt_payload"
         ) as mock_get_payload:
@@ -53,29 +51,23 @@ class AccountLinkViewTests(TestCase):
             )
 
     def test_account_link_success_new_account(self):
-        """Test successful account linking with new account creation"""
         response = self._make_authenticated_request(data=self.valid_data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Verify Account was created
         account = Account.objects.get(sentry_org_id="123456789")
         self.assertEqual(account.plan, PlanName.SENTRY_MERGE_PLAN.value)
         self.assertEqual(account.name, "Test Sentry Org")
 
-        # Verify Owner was created
         owner = Owner.objects.get(service_id="456789123", service="github")
         self.assertEqual(owner.account, account)
         self.assertEqual(owner.name, "test-org")
         self.assertEqual(owner.username, "test-org")
 
-        # Verify GithubAppInstallation was created
         installation = GithubAppInstallation.objects.get(installation_id="987654321")
         self.assertEqual(installation.owner, owner)
 
     def test_account_link_success_existing_account(self):
-        """Test successful account linking with existing account"""
-        # Create existing account
         existing_account = AccountFactory(
             sentry_org_id="123456789",
             name="Existing Sentry Org",
@@ -86,21 +78,15 @@ class AccountLinkViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Verify existing account was used and updated
         account = Account.objects.get(sentry_org_id="123456789")
         self.assertEqual(account.id, existing_account.id)
-        self.assertEqual(
-            account.name, "Test Sentry Org"
-        )  # Name should be updated from request
+        self.assertEqual(account.name, "Test Sentry Org")
         self.assertEqual(account.plan, PlanName.SENTRY_MERGE_PLAN.value)
 
-        # Verify Owner was created and linked to existing account
         owner = Owner.objects.get(service_id="456789123", service="github")
         self.assertEqual(owner.account, existing_account)
 
     def test_account_link_success_existing_owner(self):
-        """Test successful account linking with existing owner"""
-        # Create existing owner
         existing_owner = OwnerFactory(
             service_id="456789123",
             service="github",
@@ -112,19 +98,15 @@ class AccountLinkViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Verify account was created
         account = Account.objects.get(sentry_org_id="123456789")
         self.assertEqual(account.plan, PlanName.SENTRY_MERGE_PLAN.value)
 
-        # Verify existing owner was updated to link to new account
         existing_owner.refresh_from_db()
         self.assertEqual(existing_owner.account_id, account.id)
         self.assertEqual(existing_owner.name, "existing-org")
         self.assertEqual(existing_owner.username, "existing-org")
 
     def test_account_link_success_existing_owner_with_different_account(self):
-        """Test successful account linking when owner has different account"""
-        # Create existing account and owner
         old_account = AccountFactory(name="Old Account")
         existing_owner = OwnerFactory(
             service_id="456789123",
@@ -151,17 +133,13 @@ class AccountLinkViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Verify new account was created
         new_account = Account.objects.get(sentry_org_id="123456789")
 
-        # Verify existing owner was updated to link to new account
         existing_owner.refresh_from_db()
         self.assertEqual(existing_owner.account, new_account)
         self.assertNotEqual(existing_owner.account, old_account)
 
     def test_account_link_success_existing_installation(self):
-        """Test successful account linking with existing installation"""
-        # Create existing installation
         existing_account = AccountFactory(sentry_org_id="123456789")
         existing_owner = OwnerFactory(
             service_id="456789123", service="github", account=existing_account
@@ -190,12 +168,10 @@ class AccountLinkViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Verify installation was not duplicated
         installations = GithubAppInstallation.objects.filter(installation_id=987654321)
         self.assertEqual(installations.count(), 1)
 
     def test_account_link_authentication_failure(self):
-        """Test account linking fails without proper authentication"""
         response = self.client.post(
             self.url, data=json.dumps(self.valid_data), content_type="application/json"
         )
@@ -203,7 +179,6 @@ class AccountLinkViewTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_account_link_invalid_jwt(self):
-        """Test account linking fails with invalid JWT"""
         with patch(
             "codecov_auth.permissions.get_sentry_jwt_payload"
         ) as mock_get_payload:
@@ -218,7 +193,6 @@ class AccountLinkViewTests(TestCase):
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_account_link_expired_jwt(self):
-        """Test account linking fails with expired JWT"""
         with patch(
             "codecov_auth.permissions.get_sentry_jwt_payload"
         ) as mock_get_payload:
@@ -233,7 +207,6 @@ class AccountLinkViewTests(TestCase):
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_account_link_missing_sentry_org_id(self):
-        """Test account linking fails with missing sentry_org_id"""
         data = {
             "sentry_org_name": "Test Sentry Org",
             "organizations": [
@@ -252,7 +225,6 @@ class AccountLinkViewTests(TestCase):
         self.assertIn("sentry_org_id", response.data)
 
     def test_account_link_missing_sentry_org_name(self):
-        """Test account linking fails with missing sentry_org_name"""
         data = {
             "sentry_org_id": "123456789",
             "organizations": [
@@ -271,7 +243,6 @@ class AccountLinkViewTests(TestCase):
         self.assertIn("sentry_org_name", response.data)
 
     def test_account_link_missing_organizations(self):
-        """Test account linking fails with missing organizations"""
         data = {"sentry_org_id": "123456789", "sentry_org_name": "Test Sentry Org"}
 
         response = self._make_authenticated_request(data=data)
@@ -280,7 +251,6 @@ class AccountLinkViewTests(TestCase):
         self.assertIn("organizations", response.data)
 
     def test_account_link_invalid_organization_data(self):
-        """Test account linking fails with invalid organization data"""
         data = {
             "sentry_org_id": "123456789",
             "sentry_org_name": "Test Sentry Org",
@@ -300,13 +270,11 @@ class AccountLinkViewTests(TestCase):
         self.assertIn("provider", response.data["organizations"][0])
 
     def test_account_link_invalid_json(self):
-        """Test account linking fails with invalid JSON"""
         response = self._make_authenticated_request(data="invalid json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_account_link_settings_integration(self):
-        """Test that the endpoint uses the correct settings for GithubAppInstallation"""
         with (
             patch("django.conf.settings.GITHUB_SENTRY_APP_NAME", "test-app-name"),
             patch("django.conf.settings.GITHUB_SENTRY_APP_ID", "12345"),
@@ -315,7 +283,6 @@ class AccountLinkViewTests(TestCase):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-            # Verify installation was created with correct settings
             installation = GithubAppInstallation.objects.get(
                 installation_id="987654321"
             )
@@ -323,7 +290,6 @@ class AccountLinkViewTests(TestCase):
             self.assertEqual(installation.app_id, 12345)
 
     def test_account_link_skips_non_github_organizations(self):
-        """Test that non-GitHub organizations are skipped and logged"""
         data = {
             "sentry_org_id": "123456789",
             "sentry_org_name": "Test Sentry Org",
@@ -354,10 +320,8 @@ class AccountLinkViewTests(TestCase):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-            # Verify only GitHub organization was processed
             account = Account.objects.get(sentry_org_id="123456789")
 
-            # Should only have one owner (GitHub)
             owners = Owner.objects.filter(account=account)
             self.assertEqual(owners.count(), 1)
             owner = owners.first()
@@ -365,17 +329,14 @@ class AccountLinkViewTests(TestCase):
             self.assertEqual(owner.service, "github")
             self.assertEqual(owner.name, "github-org")
 
-            # Should only have one installation (GitHub)
             installations = GithubAppInstallation.objects.filter(owner__account=account)
             self.assertEqual(installations.count(), 1)
             installation = installations.first()
             self.assertIsNotNone(installation)
             self.assertEqual(installation.installation_id, 987654321)
 
-            # Verify warning logs were called for non-GitHub orgs
             self.assertEqual(mock_log.warning.call_count, 2)
 
-            # Check the warning messages
             warning_calls = mock_log.warning.call_args_list
             self.assertIn("gitlab-org", str(warning_calls[0]))
             self.assertIn("bitbucket-org", str(warning_calls[1]))
@@ -383,7 +344,6 @@ class AccountLinkViewTests(TestCase):
             self.assertIn("not a GitHub organization", str(warning_calls[1]))
 
     def test_account_link_only_github_organizations(self):
-        """Test that only GitHub organizations are processed when mixed with others"""
         data = {
             "sentry_org_id": "123456789",
             "sentry_org_name": "Test Sentry Org",
@@ -414,10 +374,8 @@ class AccountLinkViewTests(TestCase):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-            # Verify account was created
             account = Account.objects.get(sentry_org_id="123456789")
 
-            # Should have two owners (both GitHub)
             owners = Owner.objects.filter(account=account)
             self.assertEqual(owners.count(), 2)
 
@@ -425,7 +383,6 @@ class AccountLinkViewTests(TestCase):
             self.assertIn("github-org-1", owner_names)
             self.assertIn("github-org-2", owner_names)
 
-            # Should have two installations (both GitHub)
             installations = GithubAppInstallation.objects.filter(owner__account=account)
             self.assertEqual(installations.count(), 2)
 
@@ -433,7 +390,6 @@ class AccountLinkViewTests(TestCase):
             self.assertIn(987654321, installation_ids)
             self.assertIn(987654322, installation_ids)
 
-            # Verify warning log was called for non-GitHub org
             mock_log.warning.assert_called_once()
             warning_call = mock_log.warning.call_args[0][0]
             self.assertIn("gitlab-org", warning_call)
@@ -509,21 +465,74 @@ class AccountLinkViewTests(TestCase):
         self.assertTrue(existing_account.is_active)
         self.assertEqual(str(existing_account.sentry_org_id), "999999999")
 
+    def test_account_link_preserves_highest_seat_count_from_multiple_owners(self):
+        OwnerFactory(
+            service_id="456789123",
+            service="github",
+            name="owner1",
+            username="owner1",
+            plan_user_count=5,
+        )
+        OwnerFactory(
+            service_id="456789124",
+            service="github",
+            name="owner2",
+            username="owner2",
+            plan_user_count=15,
+        )
+        OwnerFactory(
+            service_id="456789125",
+            service="github",
+            name="owner3",
+            username="owner3",
+            plan_user_count=8,
+        )
+
+        data = {
+            "sentry_org_id": "123456789",
+            "sentry_org_name": "Test Sentry Org",
+            "organizations": [
+                {
+                    "installation_id": "987654321",
+                    "service_id": "456789123",
+                    "slug": "test-org-1",
+                    "provider": "github",
+                },
+                {
+                    "installation_id": "987654322",
+                    "service_id": "456789124",
+                    "slug": "test-org-2",
+                    "provider": "github",
+                },
+                {
+                    "installation_id": "987654323",
+                    "service_id": "456789125",
+                    "slug": "test-org-3",
+                    "provider": "github",
+                },
+            ],
+        }
+
+        response = self._make_authenticated_request(data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        account = Account.objects.get(sentry_org_id="123456789")
+
+        self.assertEqual(account.plan_seat_count, 15)
+
 
 class AccountUnlinkViewTests(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.url = reverse("account-unlink")
 
-        # Sample valid data for unlinking
         self.valid_data = {"sentry_org_ids": ["123456789"]}
 
     def _make_authenticated_request(self, data, jwt_payload=None):
-        """Helper method to make an authenticated request with JWT payload"""
         if data is None:
             data = self.valid_data
 
-        # Mock the JWT authentication by setting the payload on the request
         with patch(
             "codecov_auth.permissions.get_sentry_jwt_payload"
         ) as mock_get_payload:
@@ -536,7 +545,6 @@ class AccountUnlinkViewTests(TestCase):
             )
 
     def test_account_unlink_success(self):
-        """Test successful account unlinking"""
         account = AccountFactory(
             sentry_org_id="123456789", name="Test Sentry Org", is_active=True
         )
@@ -557,15 +565,13 @@ class AccountUnlinkViewTests(TestCase):
 
         account.refresh_from_db()
         self.assertFalse(account.is_active)
-        self.assertEqual(str(account.sentry_org_id), "123456789")  # Should be preserved
+        self.assertEqual(str(account.sentry_org_id), "123456789")
         self.assertEqual(account.name, "Test Sentry Org")
 
-        # Verify owner relationship is still intact
         owner.refresh_from_db()
         self.assertEqual(owner.account, account)
 
     def test_account_unlink_not_found(self):
-        """Test unlinking when account doesn't exist (should succeed with warning log)"""
         response = self._make_authenticated_request(data=self.valid_data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -574,8 +580,6 @@ class AccountUnlinkViewTests(TestCase):
         self.assertEqual(response.data["total_requested"], 1)
 
     def test_account_unlink_mixed_existing_and_nonexisting(self):
-        """Test unlinking mix of existing and non-existing organizations"""
-        # Create only one account
         account = AccountFactory(
             sentry_org_id="123456789", name="Test Sentry Org", is_active=True
         )
@@ -587,7 +591,6 @@ class AccountUnlinkViewTests(TestCase):
             username="test-org",
         )
 
-        # Try to unlink existing and non-existing organizations
         unlink_data = {"sentry_org_ids": ["123456789", "999999999", "888888888"]}
 
         with patch("api.sentry.views.log") as mock_log:
@@ -598,15 +601,12 @@ class AccountUnlinkViewTests(TestCase):
             self.assertEqual(response.data["successfully_unlinked"], 1)
             self.assertEqual(response.data["total_requested"], 3)
 
-            # Verify existing account is now inactive
             account.refresh_from_db()
             self.assertFalse(account.is_active)
 
-            # Verify owner relationship is still intact
             owner.refresh_from_db()
             self.assertEqual(owner.account, account)
 
-            # Verify warning logs were called for non-existing accounts
             self.assertEqual(mock_log.warning.call_count, 2)
             warning_calls = mock_log.warning.call_args_list
             self.assertIn("999999999", str(warning_calls[0]))
@@ -615,8 +615,6 @@ class AccountUnlinkViewTests(TestCase):
             self.assertIn("not found", str(warning_calls[1]))
 
     def test_account_unlink_multiple_organizations_success(self):
-        """Test successful unlinking of multiple organizations"""
-        # Create multiple accounts
         account1 = AccountFactory(
             sentry_org_id="123456789", name="Test Sentry Org 1", is_active=True
         )
@@ -627,7 +625,6 @@ class AccountUnlinkViewTests(TestCase):
             sentry_org_id="555666777", name="Test Sentry Org 3", is_active=True
         )
 
-        # Unlink multiple organizations
         unlink_data = {"sentry_org_ids": ["123456789", "987654321", "555666777"]}
         response = self._make_authenticated_request(data=unlink_data)
 
@@ -636,7 +633,6 @@ class AccountUnlinkViewTests(TestCase):
         self.assertEqual(response.data["successfully_unlinked"], 3)
         self.assertEqual(response.data["total_requested"], 3)
 
-        # Verify all accounts are now inactive
         account1.refresh_from_db()
         account2.refresh_from_db()
         account3.refresh_from_db()
@@ -646,7 +642,6 @@ class AccountUnlinkViewTests(TestCase):
         self.assertFalse(account3.is_active)
 
     def test_account_unlink_authentication_failure(self):
-        """Test account unlinking fails without proper authentication"""
         response = self.client.post(
             self.url, data=json.dumps(self.valid_data), content_type="application/json"
         )

--- a/apps/codecov-api/api/sentry/views.py
+++ b/apps/codecov-api/api/sentry/views.py
@@ -137,6 +137,7 @@ def account_link(request, *args, **kwargs):
             account.is_active = True
             account.save()
 
+    max_seat_count = account.plan_seat_count
     for org_data in github_orgs:
         owner, _owner_created = Owner.objects.get_or_create(
             service_id=org_data["service_id"],
@@ -147,6 +148,14 @@ def account_link(request, *args, **kwargs):
                 "username": org_data["slug"],
             },
         )
+
+        # If the owner already exists and has a higher seat count, we need to preserve it (since the account seats is the SOT)
+        if (
+            not _owner_created
+            and owner.plan_user_count
+            and owner.plan_user_count > max_seat_count
+        ):
+            max_seat_count = owner.plan_user_count
 
         owner.account = account
         owner.save()
@@ -161,6 +170,11 @@ def account_link(request, *args, **kwargs):
                 "app_id": settings.GITHUB_SENTRY_APP_ID,
             },
         )
+
+    # Updates the account seat count if we found a higher value from existing owners
+    if max_seat_count > account.plan_seat_count:
+        account.plan_seat_count = max_seat_count
+        account.save()
 
     return Response(
         {


### PR DESCRIPTION
This PR aims to fix a bug where user who were installing the sentry GH app and having an account linked were inadvertently having their seat counts set to 1 due to the Account being the source of truth for seats if one exists.

We will now look to see if the owner having an account created for them has seats already and use that, and if there are multiple owners, to use the one with the most amount of seats. 

Also gets rid of a bunch of AI comments

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
