### PR TITLE
fix(prevent) - query data equal or greater than for starting date

### DIFF
--- a/apps/codecov-api/utils/ta_timescale/utils.py
+++ b/apps/codecov-api/utils/ta_timescale/utils.py
@@ -41,25 +41,25 @@ def get_daily_aggregate_querysets(
     if branch is None:
         test_data = TestAggregateDaily.objects.filter(  # type: ignore[attr-defined]
             repo_id=repoid,
-            bucket_daily__gt=start_date,
+            bucket_daily__gte=start_date,
             bucket_daily__lte=end_date,
         )
         repo_data = AggregateDaily.objects.filter(  # type: ignore[attr-defined]
             repo_id=repoid,
-            bucket_daily__gt=start_date,
+            bucket_daily__gte=start_date,
             bucket_daily__lte=end_date,
         )
     else:
         test_data = BranchTestAggregateDaily.objects.filter(  # type: ignore[attr-defined]
             repo_id=repoid,
             branch=branch,
-            bucket_daily__gt=start_date,
+            bucket_daily__gte=start_date,
             bucket_daily__lte=end_date,
         )
         repo_data = BranchAggregateDaily.objects.filter(  # type: ignore[attr-defined]
             repo_id=repoid,
             branch=branch,
-            bucket_daily__gt=start_date,
+            bucket_daily__gte=start_date,
             bucket_daily__lte=end_date,
         )
 


### PR DESCRIPTION
This PR adjusts the start date condition to include bucket data that belongs to the day of. When you don't do gte, if there is no exact match for the data in the bucket, the query will not account for data in the rest of the bucket, responding with null