### PR TITLE
fix: Remove required end date from start/extend trial action

### DIFF
--- a/apps/codecov-api/codecov_auth/admin.py
+++ b/apps/codecov-api/codecov_auth/admin.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 
 class ExtendTrialForm(forms.Form):
     end_date = forms.DateTimeField(
-        label="Trial End Date (YYYY-MM-DD HH:MM:SS):", required=True
+        label="Trial End Date (YYYY-MM-DD HH:MM:SS):", required=False
     )
 
 


### PR DESCRIPTION
the end date is defaulted to 14 days here: https://github.com/codecov/umbrella/blob/b9a59d7d144ec8fd8f998de8632ea69f91feaf34/libs/shared/shared/plan/service.py#L214-L218

So we don't need the required check


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
