### PR TITLE
Fix 

### DIFF
--- a/apps/worker/tasks/bundle_analysis_processor.py
+++ b/apps/worker/tasks/bundle_analysis_processor.py
@@ -141,7 +141,7 @@ class BundleAnalysisProcessorTask(
                             "commit": commit.commitid,
                         },
                     )
-                    return processing_results
+                    return {"results": processing_results}
             else:
                 # If the commit report does not exist, we will create a new one
                 commit_report = report_service.initialize_and_save_report(commit)


### PR DESCRIPTION
<!-- Describe your PR here. -->
Ensures the BundleAnalysisProcessorTask will always return a dictionary with a results key rather than a list.

https://codecov.sentry.io/issues/6100733786/?project=4165036&query=is%3Aunresolved&referrer=issue-stream