### PR TITLE
Add show_patch_table configuration option for PR comments

### DIFF
--- a/apps/worker/services/notification/notifiers/mixins/message/sections.py
+++ b/apps/worker/services/notification/notifiers/mixins/message/sections.py
@@ -55,7 +55,9 @@ def get_message_layout(
         sections.insert(0, "condensed_header")
 
     # append the `newfiles` section if there is a `files` or `tree` section
-    if "files" in sections or "tree" in sections:
+    # and show_patch_table is not explicitly set to False
+    show_patch_table = settings.get("show_patch_table", True)
+    if show_patch_table and ("files" in sections or "tree" in sections):
         sections.append("newfiles")
 
     upper: SectionList = []

--- a/libs/shared/shared/validation/user_schema.py
+++ b/libs/shared/shared/validation/user_schema.py
@@ -206,6 +206,7 @@ coverage_comment_config = {
     "show_carryforward_flags": {"type": "boolean"},
     "hide_comment_details": {"type": "boolean"},
     "hide_project_coverage": {"type": "boolean"},
+    "show_patch_table": {"type": "boolean", "default": True},
 }
 
 bundle_analysis_comment_config = {


### PR DESCRIPTION
## Summary

This PR adds a new boolean configuration option `show_patch_table` under the `comment` section of `codecov.yml` that controls whether the patch coverage table is automatically added to PR comments when using the `files` or `tree` layout components.

## Problem

Currently, when users specify `layout: "files"` or `layout: "tree"` in their codecov.yml, the system automatically injects the `newfiles` section, which displays a "Patch %" table showing patch coverage information. This behavior is hardcoded at lines 57-59 in `apps/worker/services/notification/notifiers/mixins/message/sections.py`:

```python
# append the `newfiles` section if there is a `files` or `tree` section
if "files" in sections or "tree" in sections:
    sections.append("newfiles")
```

There is no way for users to disable this automatic injection, even if they only want to see the overall coverage delta per file (the "Coverage Δ" table) without the patch-specific information.

## Solution

This PR introduces a new configuration option `show_patch_table` (defaults to `true` to maintain backward compatibility) that controls whether the automatic injection occurs.

### Changes Made

1. **Schema Update** (`libs/shared/shared/validation/user_schema.py`):
   - Added `show_patch_table` as a boolean field with default value `True`

2. **Logic Update** (`apps/worker/services/notification/notifiers/mixins/message/sections.py`):
   - Modified the auto-injection logic to check the `show_patch_table` setting before adding `newfiles`

### Example Usage

Users can now configure their PR comments to show only the files coverage delta table:

```yaml
comment:
  layout: "condensed_header, files, condensed_footer"
  show_patch_table: false  # Show only Coverage Δ table, not Patch % table
```

## Use Case

This feature is valuable for teams that:
- Want concise PR comments focused on overall coverage changes
- Find the patch coverage table redundant with their existing coverage requirements
- Prefer to keep PR comments minimal while still showing per-file coverage deltas

## Backward Compatibility

By defaulting `show_patch_table` to `true`, all existing configurations will continue to work exactly as before. Only users who explicitly set `show_patch_table: false` will see the new behavior.

## Testing

The changes are minimal and focused:
- The schema validation will automatically handle the new boolean field
- The logic change is a simple conditional check that defaults to existing behavior
- No breaking changes to existing functionality

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>