### PR TITLE
Fix Codecov's response header to include CSP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ codecov-api = [
     "certifi>=2024.7.4",
     "django-autocomplete-light>=3.11.0",
     "django-cors-headers>=3.7.0",
-    "django-csp>=3.8.0",
+    "django-csp==3.8.0",
     "django-cursor-pagination>=0.3.0",
     "django-filter>=2.4.0",
     "djangorestframework>=3.15.2",

--- a/uv.lock
+++ b/uv.lock
@@ -494,15 +494,14 @@ wheels = [
 
 [[package]]
 name = "django-csp"
-version = "4.0"
+version = "3.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
-    { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/db/23567744dff2169aadb095f726088074476b24dfff5a759ffcf6389cf401/django_csp-4.0.tar.gz", hash = "sha256:b27010bb702eb20a3dad329178df2b61a2b82d338b70fbdc13c3a3bd28712833", size = 20028, upload-time = "2025-04-02T16:41:46.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/16/c3c65ad59997284402e54d00797c7aca96572df911aede3e1f2cc2e029f8/django_csp-3.8.tar.gz", hash = "sha256:ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0", size = 13341, upload-time = "2024-03-01T14:00:30.013Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/a4/736ab90ee527a23e194d1ce7358c6bcced66381ced83c28268b4aea236f7/django_csp-4.0-py3-none-any.whl", hash = "sha256:d5a0a05463a6b75a4f1fc1828c58c89af8db9364d09fc6e12f122b4d7f3d00dc", size = 25689, upload-time = "2025-04-02T16:41:45.689Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ff/2c7a4b6706125a17bd0071802e4894c28772cfcdea20a086a2be3c5fafda/django_csp-3.8-py3-none-any.whl", hash = "sha256:19b2978b03fcd73517d7d67acbc04fbbcaec0facc3e83baa502965892d1e0719", size = 17410, upload-time = "2024-03-01T14:00:28.135Z" },
 ]
 
 [[package]]
@@ -2740,7 +2739,7 @@ codecov-api = [
     { name = "django-autocomplete-light", specifier = ">=3.11.0" },
     { name = "django-better-admin-arrayfield", specifier = ">=1.4.2" },
     { name = "django-cors-headers", specifier = ">=3.7.0" },
-    { name = "django-csp", specifier = ">=3.8.0" },
+    { name = "django-csp", specifier = "==3.8.0" },
     { name = "django-cursor-pagination", specifier = ">=0.3.0" },
     { name = "django-filter", specifier = ">=2.4.0" },
     { name = "django-model-utils", specifier = ">=4.5.1" },
@@ -2829,7 +2828,7 @@ prod = [
     { name = "django-autocomplete-light", specifier = ">=3.11.0" },
     { name = "django-better-admin-arrayfield", specifier = ">=1.4.2" },
     { name = "django-cors-headers", specifier = ">=3.7.0" },
-    { name = "django-csp", specifier = ">=3.8.0" },
+    { name = "django-csp", specifier = "==3.8.0" },
     { name = "django-cursor-pagination", specifier = ">=0.3.0" },
     { name = "django-filter", specifier = ">=2.4.0" },
     { name = "django-model-utils", specifier = ">=4.5.1" },


### PR DESCRIPTION
It looks like the `django-csp` library was upgraded to 4.x, which is not backwards compatible with the way that the CSP is currently configured. Downgrading to 3.8 fixes the issue with the CSP not being configured for responses.

I tested this locally and was able to see the `content-security-header` being populated for requests.

This fixes half of: CCMRG-1609


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
