### PR TITLE
feat: create index for faster public ui fetching

### DIFF
--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0036_testrun_ta_ts__repo_id_idx.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0036_testrun_ta_ts__repo_id_idx.py
@@ -2,6 +2,8 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
+    atomic = False
+
     dependencies = [
         ("ta_timeseries", "0035_alter_branch_test_aggregate_daily_policy"),
     ]


### PR DESCRIPTION
This migration adds an index to the testrun table to help speed up public api with a specific repoid calls to this model

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add migration creating `ta_ts__repo_id_idx` on `ta_timeseries_testrun(repo_id)` (TimescaleDB per-chunk) with reversible drop.
> 
> - **Migration (Django/TimescaleDB)**:
>   - Create index `ta_ts__repo_id_idx` on `ta_timeseries_testrun (repo_id)` with `timescaledb.transaction_per_chunk`.
>   - Non-atomic migration; reversible via `DROP INDEX IF EXISTS ta_ts__repo_id_idx`.
>   - Depends on `ta_timeseries` migration `0035_alter_branch_test_aggregate_daily_policy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34acd10ee70975f62c80463b4a3581c319d9ee15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->