### PR TITLE
fix: Bypass Sync-Teams when using integration for sync repos

### DIFF
--- a/apps/codecov-api/services/task/task.py
+++ b/apps/codecov-api/services/task/task.py
@@ -197,9 +197,15 @@ class TaskService:
         If running both tasks on new worker, we create a chain with sync_teams to run
         first so that when sync_repos starts it has the most up to date teams/groups
         data for the user. Otherwise, we may miss some repos.
+
+        When using_integration=True (e.g. Sentry integration), we skip sync_teams because:
+        1. It requires user OAuth tokens which may not be available with app installations
+        2. Team membership tracking isn't needed when permissions are handled externally
         """
         chain_to_call = []
-        if sync_teams:
+        # Skip sync_teams when using integration since it requires user OAuth tokens
+        # and team membership isn't needed for integration-based syncs
+        if sync_teams and not using_integration:
             chain_to_call.append(
                 self._create_signature(
                     celery_config.sync_teams_task_name,


### PR DESCRIPTION
This bug stems from situations when we call sync repos from the Sentry app, which involves using the API Bridge that sets the "current user" to effectively be the user's org, which does _not_ have an OAUTH token set, and errors out with an "OwnerWithoutValidBot" error.

We actually don't even need to sync teams because we made a design decision when doing the merge to allow all users to access all repositories that the organization has given us access to, so the fix here was to just bypass syncing teams in the event it comes from the "uses integration" codepath.

https://console.cloud.google.com/logs/query;query=%22merge-api%22%0Aseverity%3D%22ERROR%22;summaryFields=jsonPayload%252Fcontext%252Fowner_username:false:32:beginning;cursorTimestamp=2025-10-24T22:41:14.485805471Z;duration=P4D?project=genuine-polymer-165712


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip `sync_teams` in `TaskService.refresh` when `using_integration=True`, and add a test to ensure only `sync_repos` runs.
> 
> - **Backend**
>   - Update `TaskService.refresh` in `apps/codecov-api/services/task/task.py` to bypass `sync_teams` when `using_integration=True`; only enqueue `sync_repos`.
> - **Tests**
>   - Add `test_refresh_task_skips_sync_teams_when_using_integration` in `apps/codecov-api/services/tests/test_task.py` verifying only `sync_repos` signature is created and `chain` is called once.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2243c46933432fa3b4bea920f11ab3c8cee9f9b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->