### PR TITLE
Add Sentry tracing to the run method

### DIFF
--- a/apps/worker/tasks/base.py
+++ b/apps/worker/tasks/base.py
@@ -241,6 +241,7 @@ class BaseCodecovTask(celery_app.Task):
             )  # TODO is None a valid label value
             time_in_queue_timer.observe(delta.total_seconds())
 
+    @sentry_sdk.trace
     def run(self, *args, **kwargs):
         with self.task_full_runtime.time():  # Timer isn't tested
             db_session = get_db_session()


### PR DESCRIPTION
<!-- Describe your PR here. -->

Instrument the worker tasks earlier in the process for more complete trace data.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
