### PR TITLE
Disable backpressure handling in Sentry configuration to prevent loss of traces and spans

### DIFF
--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -466,6 +466,7 @@ if SENTRY_DSN is not None:
         ],
         environment=SENTRY_ENV,
         traces_sample_rate=SENTRY_SAMPLE_RATE,
+        enable_backpressure_handling=False,
         profiles_sample_rate=float(
             get_config("services", "sentry", "profile_sample_rate", default="0.01")
         ),


### PR DESCRIPTION
Sentry suport says the worker project inherits from api, so this setting needs to be changed as well

