### PR TITLE
[CCMRG-1743] Implement graceful shutdown handling in worker script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
 
   api:
     image: ${AR_REPO_PREFIX-codecov}/api
-    entrypoint: sh -c "/devenv-scripts/start.sh codecov-api"
+    entrypoint: sh -c "exec /devenv-scripts/start.sh codecov-api"
     environment:
       - RUN_ENV=DEV
       - CELERY_BROKER_URL=redis://redis:6379/0
@@ -87,7 +87,7 @@ services:
 
   worker:
     image: ${AR_REPO_PREFIX-codecov}/worker
-    entrypoint: sh -c "/devenv-scripts/start.sh worker"
+    entrypoint: sh -c "exec /devenv-scripts/start.sh worker"
     environment:
       - RUN_ENV=DEV
       - CELERY_BROKER_URL=redis://redis:6379/0

--- a/tools/devenv/scripts/start.sh
+++ b/tools/devenv/scripts/start.sh
@@ -1,6 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Signal handling for graceful shutdown
+shutdown_in_progress=false
+shutdown() {
+  # Prevent duplicate shutdown attempts (in case both shell and process receive signal)
+  if [[ "$shutdown_in_progress" == "true" ]]; then
+    return 0
+  fi
+  shutdown_in_progress=true
+  
+  echo "Received SIGTERM, shutting down gracefully..."
+  if [[ -n "${app_pid:-}" ]]; then
+    # Send SIGTERM to the app process
+    kill -TERM "$app_pid" 2>/dev/null || true
+    
+    # Wait for graceful shutdown with timeout
+    local timeout=${SHUTDOWN_TIMEOUT:-25}
+    local count=0
+    
+    while kill -0 "$app_pid" 2>/dev/null && [[ $count -lt $timeout ]]; do
+      sleep 1
+      ((count++))
+    done
+    
+    # If process is still running, force kill
+    if kill -0 "$app_pid" 2>/dev/null; then
+      echo "App did not shutdown gracefully after ${timeout}s, forcing shutdown..."
+      kill -KILL "$app_pid" 2>/dev/null || true
+      wait "$app_pid" 2>/dev/null || true
+    else
+      echo "App shutdown complete"
+    fi
+  fi
+  exit 0
+}
+
+# Trap SIGTERM and SIGINT
+trap shutdown SIGTERM SIGINT
+
 app=""
 if [[ "$1" == "codecov-api" ]]; then
   app="codecov-api"
@@ -34,15 +72,24 @@ export CODECOV_WRAPPER_IGNORE_MIGRATE=true
 case "$app" in
 codecov-api)
   # We override the run command to be able to execute our custom commands before starting the server
-  bash "$ENTRYPOINT" python manage.py insert_data_to_db_from_csv core/management/commands/codecovTiers-Jan25.csv --model tiers &&
-    python manage.py insert_data_to_db_from_csv core/management/commands/codecovPlans-Jan25.csv --model plans &&
-    $CODECOV_WRAPPER python manage.py runserver 0.0.0.0:8000
+  (
+    bash "$ENTRYPOINT" python manage.py insert_data_to_db_from_csv core/management/commands/codecovTiers-Jan25.csv --model tiers &&
+      python manage.py insert_data_to_db_from_csv core/management/commands/codecovPlans-Jan25.csv --model plans &&
+      $CODECOV_WRAPPER python manage.py runserver 0.0.0.0:8000
+  ) &
+  app_pid=$!
+  echo "codecov-api started with PID $app_pid"
   ;;
 worker)
-  bash "$ENTRYPOINT"
+  bash "$ENTRYPOINT" &
+  app_pid=$!
+  echo "worker started with PID $app_pid"
   ;;
 *)
   echo "Unknown app: $app"
   exit 1
   ;;
 esac
+
+# Wait for the app process
+wait "$app_pid"


### PR DESCRIPTION
Added signal handling for SIGTERM and SIGINT to ensure the worker process shuts down gracefully. The script now captures the worker's PID and waits for it to terminate, with a timeout for forced shutdown if necessary.

Process 1, being a shell script, does not trap the SIGTERM sent by kubelet when the pod is requested to be deleted. This results in the celery worker continuing to accept new work until the SIGKILL is sent at the end of the graceful termination counter.

This change adds a signal trap handler, so that the celery worker performs a clean shutdown, ensuring all work completes before the pod is SIGKILL'ed.

Tested locally and both api and worker shutdown and exited cleanly