### PR TITLE
Adrian/add ta data export script

### DIFF
--- a/apps/codecov-api/api/sentry/views.py
+++ b/apps/codecov-api/api/sentry/views.py
@@ -270,6 +270,11 @@ def test_analytics_eu(request, *args, **kwargs):
 
     integration_names = serializer.validated_data["integration_names"]
 
+    log.info(
+        "Starting data export for the following integrations",
+        extra={"integrations": integration_names},
+    )
+
     # For every integration name, determine if an Owner record exist by filtering by name and service=github
     test_runs_per_integration = {}
     for name in integration_names:


### PR DESCRIPTION
Add info log line

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add info-level log in `test_analytics_eu` to record integration names at data export start.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61cff0bf00c46887df1163ac6cda1509e1dc58cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->