### PR TITLE
Fix/adding eu

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -108,6 +108,7 @@ jobs:
             codecov_token_secret: CODECOV_EUROPE_WEST3_TOKEN
             name: europe-west3
 
+      
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `europe-west3` target to the Codecov upload matrix in the CI workflow.
> 
> - **CI**:
>   - **Codecov uploads**: Add `europe-west3` matrix entry in `.github/workflows/_run-tests.yml` using `CODECOV_EUROPE_WEST3_URL` and `CODECOV_EUROPE_WEST3_TOKEN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fff8da8b141f7174469bb8eeb3775a9917a30330. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->