### PR TITLE
fix: check token_to_use for "key"

### DIFF
--- a/libs/shared/shared/torngit/github.py
+++ b/libs/shared/shared/torngit/github.py
@@ -764,10 +764,10 @@ class Github(TorngitBaseAdapter):
             "Accept": "application/json",
             "User-Agent": os.getenv("USER_AGENT", "Default"),
         }
-        bot = ''
+        bot = ""
         if token_to_use is not None:
-            bot = token_to_use.get('username', '')
-            if 'key' in token_to_use:
+            bot = token_to_use.get("username", "")
+            if "key" in token_to_use:
                 _headers["Authorization"] = "token {}".format(token_to_use["key"])
         _headers.update(headers or {})
         log_dict = {}


### PR DESCRIPTION
<!-- Describe your PR here. -->

fixes https://codecov.sentry.io/issues/7024653310/events/9c6afd78685f441e97e85d13991696ad/
Seeing an issue where`token_to_use['key']` throws a KeyError, this safely checks for it

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make token handling robust by guarding against None/missing fields when setting Authorization and logging bot, and by checking for None in loggable_token.
> 
> - **GitHub adapter (`libs/shared/shared/torngit/github.py`)**:
>   - `make_http_call`:
>     - Safely derive `bot` from `token_to_use` and update log context.
>     - Set `Authorization` header only if `token_to_use` contains `key`.
>   - `loggable_token`:
>     - Guard against `None` token before accessing `username`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6388fb342ddfbc401793571e422c679fc610611. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->