### PR TITLE
fix: move the error to occur after all retries

### DIFF
--- a/apps/worker/services/report/__init__.py
+++ b/apps/worker/services/report/__init__.py
@@ -559,7 +559,6 @@ class ReportService(BaseReportService):
             raw_report = self.parse_raw_report_from_storage(commit.repository, upload)
             raw_report_info.raw_report = raw_report
         except FileNotInStorageError as e:
-            sentry_sdk.capture_exception(e)
             log.info(
                 "Raw report file was not found",
                 extra={


### PR DESCRIPTION
<!-- Describe your PR here. -->

Currently we inflate our FileNotInStorage errors due to retries. This moves the error logic into Sentry at a later time (when retries have been exhausted). This will help better gauge how many instances we actually have.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defers Sentry reporting for `FILE_NOT_IN_STORAGE` until after retry attempts, adding contextual capture in the task and removing early capture in report parsing.
> 
> - **Worker Upload Processing**:
>   - On retryable `FILE_NOT_IN_STORAGE`, schedule a retry; after `MAX_FILE_NOT_FOUND_RETRIES`, capture `FileNotInStorageError` to Sentry with detailed context.
>   - Introduces `MAX_FILE_NOT_FOUND_RETRIES = 1`.
> - **Report Service**:
>   - Stops capturing `FileNotInStorageError` to Sentry when reading raw report; logs and returns a retryable `ProcessingError` instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 630cb6dfc69f9903c12d637334560ee20352135b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->