### PR TITLE
fix: use list for bundle analysis tasks

### DIFF
--- a/apps/worker/tasks/bundle_analysis_notify.py
+++ b/apps/worker/tasks/bundle_analysis_notify.py
@@ -21,9 +21,9 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
     def run_impl(
         self,
         db_session,
-        # Celery `chain` injects this argument - it's the returned result
-        # from the prior task in the chain
-        previous_result: dict[str, Any],
+        # Celery `chain` injects this argument - it's the list of processing results
+        # from prior processor tasks in the chain
+        previous_result: list[dict[str, Any]],
         *,
         repoid: int,
         commitid: str,
@@ -72,7 +72,7 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
         repoid: int,
         commitid: str,
         commit_yaml: UserYaml,
-        previous_result: dict[str, Any],
+        previous_result: list[dict[str, Any]],
         **kwargs,
     ):
         log.info(
@@ -90,9 +90,11 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
         )
         assert commit, "commit not found"
 
-        # these are the task results from prior processor tasks in the chain
+        # previous_result is the list of processing results from prior processor tasks
         # (they get accumulated as we execute each task in succession)
-        processing_results = previous_result.get("results", [])
+        processing_results = (
+            previous_result if isinstance(previous_result, list) else []
+        )
 
         if all(result["error"] is not None for result in processing_results):
             # every processor errored, nothing to notify on

--- a/apps/worker/tasks/bundle_analysis_processor.py
+++ b/apps/worker/tasks/bundle_analysis_processor.py
@@ -31,9 +31,9 @@ class BundleAnalysisProcessorTask(
     def run_impl(
         self,
         db_session,
-        # Celery `chain` injects this argument - it's the returned result
-        # from the prior task in the chain
-        previous_result: dict[str, Any],
+        # Celery `chain` injects this argument - it's the list of processing results
+        # from prior tasks in the chain (accumulated as each task executes)
+        previous_result: list[dict[str, Any]],
         *args,
         repoid: int,
         commitid: str,
@@ -82,7 +82,7 @@ class BundleAnalysisProcessorTask(
         commitid: str,
         commit_yaml: UserYaml,
         params: UploadArguments,
-        previous_result: dict[str, Any],
+        previous_result: list[dict[str, Any]],
     ):
         log.info(
             "Running bundle analysis processor",
@@ -100,9 +100,11 @@ class BundleAnalysisProcessorTask(
 
         report_service = BundleAnalysisReportService(commit_yaml)
 
-        # these are the task results from prior processor tasks in the chain
+        # previous_result is the list of processing results from prior processor tasks
         # (they get accumulated as we execute each task in succession)
-        processing_results = previous_result.get("results", [])
+        processing_results = (
+            previous_result if isinstance(previous_result, list) else []
+        )
 
         # these are populated in the upload task
         # unless when this task is called on a non-BA upload then we have to create an empty upload
@@ -141,7 +143,7 @@ class BundleAnalysisProcessorTask(
                             "commit": commit.commitid,
                         },
                     )
-                    return {"results": processing_results}
+                    return processing_results
             else:
                 # If the commit report does not exist, we will create a new one
                 commit_report = report_service.initialize_and_save_report(commit)
@@ -240,7 +242,7 @@ class BundleAnalysisProcessorTask(
             },
         )
 
-        return {"results": processing_results}
+        return processing_results
 
 
 RegisteredBundleAnalysisProcessorTask = celery_app.register_task(

--- a/apps/worker/tasks/tests/unit/test_bundle_analysis_notify_task.py
+++ b/apps/worker/tasks/tests/unit/test_bundle_analysis_notify_task.py
@@ -30,7 +30,7 @@ def test_bundle_analysis_notify_task(
 
     result = BundleAnalysisNotifyTask().run_impl(
         dbsession,
-        {"results": [{"error": None}]},
+        [{"error": None}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -47,7 +47,7 @@ def test_bundle_analysis_notify_skips_if_all_processing_fail(dbsession):
     dbsession.flush()
     result = BundleAnalysisNotifyTask().run_impl(
         dbsession,
-        {"results": [{"error": True}]},
+        [{"error": True}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},

--- a/apps/worker/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/apps/worker/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -87,7 +87,7 @@ def test_bundle_analysis_processor_task_success(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -96,17 +96,15 @@ def test_bundle_analysis_processor_task_success(
             "commit": commit.commitid,
         },
     )
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": None,
-                "session_id": 123,
-                "upload_id": upload.id_,
-                "bundle_name": "bundle1",
-            },
-        ],
-    }
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": None,
+            "session_id": 123,
+            "upload_id": upload.id_,
+            "bundle_name": "bundle1",
+        },
+    ]
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -149,7 +147,7 @@ def test_bundle_analysis_processor_task_error(
 
     result = task.run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -158,20 +156,18 @@ def test_bundle_analysis_processor_task_error(
             "commit": commit.commitid,
         },
     )
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": {
-                    "code": "file_not_in_storage",
-                    "params": {"location": "invalid-storage-path"},
-                },
-                "session_id": None,
-                "upload_id": upload.id_,
-                "bundle_name": None,
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": {
+                "code": "file_not_in_storage",
+                "params": {"location": "invalid-storage-path"},
             },
-        ],
-    }
+            "session_id": None,
+            "upload_id": upload.id_,
+            "bundle_name": None,
+        },
+    ]
 
     assert commit.state == "error"
     assert upload.state == "error"
@@ -223,7 +219,7 @@ def test_bundle_analysis_processor_task_general_error(
     with pytest.raises(Exception):
         task.run_impl(
             dbsession,
-            {"results": [{"previous": "result"}]},
+            [{"previous": "result"}],
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={},
@@ -275,7 +271,7 @@ def test_bundle_analysis_process_upload_general_error(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -285,23 +281,21 @@ def test_bundle_analysis_process_upload_general_error(
         },
     )
 
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": {
-                    "code": "parser_error",
-                    "params": {
-                        "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite",
-                        "plugin_name": "unknown",
-                    },
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": {
+                "code": "parser_error",
+                "params": {
+                    "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite",
+                    "plugin_name": "unknown",
                 },
-                "session_id": None,
-                "upload_id": upload.id_,
-                "bundle_name": None,
             },
-        ],
-    }
+            "session_id": None,
+            "upload_id": upload.id_,
+            "bundle_name": None,
+        },
+    ]
 
     assert not retry.called
     assert upload.state == "error"
@@ -349,7 +343,7 @@ def test_bundle_analysis_processor_task_locked(
 
     result = task.run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -402,7 +396,7 @@ def test_bundle_analysis_process_upload_rate_limit_error(
 
     result = task.run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -411,22 +405,20 @@ def test_bundle_analysis_process_upload_rate_limit_error(
             "commit": commit.commitid,
         },
     )
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": {
-                    "code": "rate_limit_error",
-                    "params": {
-                        "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite"
-                    },
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": {
+                "code": "rate_limit_error",
+                "params": {
+                    "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite"
                 },
-                "session_id": None,
-                "upload_id": upload.id_,
-                "bundle_name": None,
             },
-        ],
-    }
+            "session_id": None,
+            "upload_id": upload.id_,
+            "bundle_name": None,
+        },
+    ]
 
     assert commit.state == "error"
     assert upload.state == "error"
@@ -472,7 +464,7 @@ def test_bundle_analysis_process_associate_no_parent_commit_id(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -525,7 +517,7 @@ def test_bundle_analysis_process_associate_no_parent_commit_object(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -582,7 +574,7 @@ def test_bundle_analysis_process_associate_no_parent_commit_report_object(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -645,7 +637,7 @@ def test_bundle_analysis_process_associate_called(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -719,7 +711,7 @@ def test_bundle_analysis_process_associate_called_two(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -789,7 +781,7 @@ def test_bundle_analysis_processor_associate_custom_compare_sha(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -864,7 +856,7 @@ def test_bundle_analysis_processor_task_cache_config_not_saved(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -873,17 +865,15 @@ def test_bundle_analysis_processor_task_cache_config_not_saved(
             "commit": commit.commitid,
         },
     )
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": None,
-                "session_id": 123,
-                "upload_id": upload.id_,
-                "bundle_name": "BundleA",
-            },
-        ],
-    }
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": None,
+            "session_id": 123,
+            "upload_id": upload.id_,
+            "bundle_name": "BundleA",
+        },
+    ]
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -943,7 +933,7 @@ def test_bundle_analysis_processor_task_cache_config_saved(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -952,17 +942,15 @@ def test_bundle_analysis_processor_task_cache_config_saved(
             "commit": commit.commitid,
         },
     )
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": None,
-                "session_id": 123,
-                "upload_id": upload.id_,
-                "bundle_name": "BundleA",
-            },
-        ],
-    }
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": None,
+            "session_id": 123,
+            "upload_id": upload.id_,
+            "bundle_name": "BundleA",
+        },
+    ]
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1031,7 +1019,7 @@ def test_bundle_analysis_processor_not_caching_previous_report(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1040,17 +1028,15 @@ def test_bundle_analysis_processor_not_caching_previous_report(
             "commit": commit.commitid,
         },
     )
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": None,
-                "session_id": 123,
-                "upload_id": upload.id_,
-                "bundle_name": "BundleA",
-            },
-        ],
-    }
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": None,
+            "session_id": 123,
+            "upload_id": upload.id_,
+            "bundle_name": "BundleA",
+        },
+    ]
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1121,7 +1107,7 @@ def test_bundle_analysis_processor_not_caching_previous_report_two(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1130,17 +1116,15 @@ def test_bundle_analysis_processor_not_caching_previous_report_two(
             "commit": commit.commitid,
         },
     )
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": None,
-                "session_id": 123,
-                "upload_id": upload.id_,
-                "bundle_name": "BundleA",
-            },
-        ],
-    }
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": None,
+            "session_id": 123,
+            "upload_id": upload.id_,
+            "bundle_name": "BundleA",
+        },
+    ]
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1211,7 +1195,7 @@ def test_bundle_analysis_processor_caching_previous_report(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1220,17 +1204,15 @@ def test_bundle_analysis_processor_caching_previous_report(
             "commit": commit.commitid,
         },
     )
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": None,
-                "session_id": 123,
-                "upload_id": upload.id_,
-                "bundle_name": "BundleA",
-            },
-        ],
-    }
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": None,
+            "session_id": 123,
+            "upload_id": upload.id_,
+            "bundle_name": "BundleA",
+        },
+    ]
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1261,7 +1243,7 @@ def test_bundle_analysis_processor_task_no_upload(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1277,17 +1259,15 @@ def test_bundle_analysis_processor_task_no_upload(
     upload = dbsession.query(Upload).filter_by(report_id=commit_report.id).first()
     assert upload is not None
 
-    assert result == {
-        "results": [
-            {"previous": "result"},
-            {
-                "error": None,
-                "session_id": None,
-                "upload_id": upload.id_,
-                "bundle_name": None,
-            },
-        ],
-    }
+    assert result == [
+        {"previous": "result"},
+        {
+            "error": None,
+            "session_id": None,
+            "upload_id": upload.id_,
+            "bundle_name": None,
+        },
+    ]
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1331,7 +1311,7 @@ def test_bundle_analysis_processor_task_carryforward(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1391,7 +1371,7 @@ def test_bundle_analysis_processor_task_carryforward_error(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        {"results": [{"previous": "result"}]},
+        [{"previous": "result"}],
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},

--- a/apps/worker/tasks/tests/unit/test_upload_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_task.py
@@ -365,7 +365,7 @@ class TestUploadTaskIntegration:
         assert len(uploads) == 1
         upload = dbsession.query(Upload).filter_by(report_id=commit_report.id).first()
         processor_sig = bundle_analysis_processor_task.s(
-            {},
+            [],
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},
@@ -482,7 +482,7 @@ class TestUploadTaskIntegration:
         assert commit_report.commit == commit
 
         processor_sig = bundle_analysis_processor_task.s(
-            {},
+            [],
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},

--- a/apps/worker/tasks/upload.py
+++ b/apps/worker/tasks/upload.py
@@ -943,7 +943,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             )
             for params in argument_list
         ]
-        task_signatures[0].args = ({},)  # this is the first `previous_result`
+        task_signatures[0].args = ([],)  # this is the first `previous_result`
 
         # it might make sense to eventually have a "finisher" task that
         # does whatever extra stuff + enqueues a notify


### PR DESCRIPTION
<!-- Describe your PR here. -->

Switch to using a list here as `processing_results` returns back a list. There is no need to wrap things in a dict to unwrap them later

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch bundle analysis task chain to pass/return a plain list of processing results instead of a dict wrapper, updating task logic, scheduling, and tests.
> 
> - **Worker tasks (Bundle Analysis)**
>   - Change `previous_result` type to `list[dict]` in `tasks/bundle_analysis_processor.py` and `tasks/bundle_analysis_notify.py`.
>   - Extract processing results directly from the list; stop using `{"results": ...}` wrapper.
>   - Return processing results as a list from processor; notify reads the list and skips when all have errors.
>   - Update upload scheduler to seed first processor with `[]` for `previous_result`.
> - **Tests**
>   - Update all unit tests to pass/expect a list for `previous_result` and processor returns (list of results).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02fdc905917178c99e182d0a5ff4dd60946c2e2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->