### PR TITLE
fix: add prefetch_related on commitsuploadsviewset

### DIFF
--- a/apps/codecov-api/api/public/v2/commit/views.py
+++ b/apps/codecov-api/api/public/v2/commit/views.py
@@ -73,9 +73,11 @@ class CommitsUploadsViewSet(
 
     def get_queryset(self):
         commit = self.get_commit(self.kwargs["commitid"])
-        return ReportSession.objects.filter(report__commit=commit.id).select_related(
-            "uploadleveltotals"
-        ).prefetch_related("flags")
+        return (
+            ReportSession.objects.filter(report__commit=commit.id)
+            .select_related("uploadleveltotals")
+            .prefetch_related("flags")
+        )
 
     @extend_schema(summary="Commit uploads", parameters=commits_parameters)
     def list(self, request, *args, **kwargs):


### PR DESCRIPTION
<!-- Describe your PR here. -->

This adds a `prefetch_related` query for `flags` which will reduce the number of database queries when returning the serialized CommitUploadsViewSet

Solves for API-AAB https://codecov.sentry.io/issues/5712850632/?environment=production&project=5215654&query=is%3Aunresolved&referrer=issue-stream&sort=freq

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefetches `flags` in commit uploads queryset to reduce DB queries when listing uploads.
> 
> - **API (Commits uploads)**:
>   - Update `CommitsUploadsViewSet.get_queryset` to prefetch `flags` on `ReportSession` alongside `select_related("uploadleveltotals")` for `report__commit` filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df3a424dff9207db95bbe428a8be732a321ace06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->