### PR TITLE
feat: Add billing rate and base unit price fields to account details scheduledPhase payload

### DIFF
--- a/apps/codecov-api/api/internal/owner/serializers.py
+++ b/apps/codecov-api/api/internal/owner/serializers.py
@@ -213,6 +213,7 @@ class StripeScheduledPhaseSerializer(serializers.Serializer):
     plan = serializers.SerializerMethodField()
     quantity = serializers.SerializerMethodField()
     billing_rate = serializers.SerializerMethodField()
+    base_unit_price = serializers.SerializerMethodField()
 
     def _get_plan_object(self, phase: dict[str, Any]) -> Plan | None:
         """Helper method to get and cache the Plan object."""
@@ -240,6 +241,10 @@ class StripeScheduledPhaseSerializer(serializers.Serializer):
     def get_billing_rate(self, phase: dict[str, Any]) -> str | None:
         plan = self._get_plan_object(phase)
         return plan.billing_rate if plan else None
+
+    def get_base_unit_price(self, phase: dict[str, Any]) -> int | None:
+        plan = self._get_plan_object(phase)
+        return plan.base_unit_price if plan else None
 
 
 class ScheduleDetailSerializer(serializers.Serializer):

--- a/apps/codecov-api/api/internal/tests/views/test_account_viewset.py
+++ b/apps/codecov-api/api/internal/tests/views/test_account_viewset.py
@@ -300,6 +300,7 @@ class AccountViewSetTests(APITestCase):
                     "plan": "Pro",
                     "quantity": schedule_params["quantity"],
                     "billing_rate": "annually",
+                    "base_unit_price": 10,
                 },
             },
             "student_count": 0,
@@ -446,6 +447,7 @@ class AccountViewSetTests(APITestCase):
                     "quantity": schedule_params["quantity"],
                     "start_date": schedule_params["start_date"],
                     "billing_rate": "annually",
+                    "base_unit_price": 10,
                 },
             },
             "uses_invoice": False,
@@ -585,6 +587,7 @@ class AccountViewSetTests(APITestCase):
                 "plan": None,
                 "quantity": schedule_params["quantity"],
                 "billing_rate": None,
+                "base_unit_price": None,
             },
         }
         log_mock.warning.assert_called_once()


### PR DESCRIPTION
Adding "billing rate" and "base unit price" fields to the account-details endpoint's `scheduledPhase` payload to give frontend the necessary information to fix https://linear.app/getsentry/issue/CCMRG-1859/billing-display-mismatch with an accurate calculation. To fix the calculation for the cases where the upcoming plan has a different billing rate or price (like if they switch plans), we will need to use the next billing cycle's billing rate and price in the calculation. We are currently incorrectly using the current plan's information instead of upcoming.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `billing_rate` and `base_unit_price` to `schedule_detail.scheduled_phase`, caches plan lookups, and gracefully handles missing plans with a warning; updates tests accordingly.
> 
> - **API/Serializers**:
>   - `StripeScheduledPhaseSerializer`:
>     - Add `billing_rate` field derived from `Plan.billing_rate`.
>     - Add `base_unit_price` field derived from `Plan.base_unit_price`.
>     - Refactor to cache `Plan` lookup via `_get_plan_object`.
>     - Return `None` for `plan` and `billing_rate` if Stripe plan not found; log warning.
> - **Tests**:
>   - Update account retrieval tests to expect `billing_rate` in `schedule_detail.scheduled_phase`.
>   - Add test to verify behavior when scheduled phase references a nonexistent plan (returns `None` fields and logs warning).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 522d998997418fe4ccf5e1462cafda33d7844446. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->