### PR TITLE
fix: add select_related to repo for author

### DIFF
--- a/apps/codecov-api/services/task/task_router.py
+++ b/apps/codecov-api/services/task/task_router.py
@@ -61,7 +61,7 @@ def _get_ownerid_from_ownerid(ownerid, *args, **kwargs) -> int:
 
 
 def _get_ownerid_from_repoid(repoid, *args, **kwargs) -> int | None:
-    repo = Repository.objects.filter(repoid=repoid).first()
+    repo = Repository.objects.filter(repoid=repoid).select_related("author").first()
     if repo and repo.author:
         return repo.author.ownerid
     return None


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixes an N+1 query with pulling the `author`
https://codecov.sentry.io/issues/6880410464/?environment=production&project=5215654&query=is%3Aunresolved&referrer=issue-stream&sort=freq

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use select_related("author") for repo-based plan/owner lookups to reduce extra DB queries.
> 
> - **Services / task routing**:
>   - Optimize repo-based lookups by adding `select_related("author")` in `apps/codecov-api/services/task/task_router.py`:
>     - `_get_user_plan_from_repoid`
>     - `_get_ownerid_from_repoid`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d652f5047f4e80f5c42081e49121c17407286d43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->