### PR TITLE
fix: add checks for admins

### DIFF
--- a/apps/codecov-api/codecov_auth/commands/owner/interactors/get_is_current_user_an_admin.py
+++ b/apps/codecov-api/codecov_auth/commands/owner/interactors/get_is_current_user_an_admin.py
@@ -26,7 +26,9 @@ class GetIsCurrentUserAnAdminInteractor(BaseInteractor):
                     if isAdmin:
                         # save admin provider in admins list
                         owner.add_admin(current_owner)
-                    return isAdmin or (admins is not None and current_owner.ownerid in admins)
+                    return isAdmin or (
+                        admins is not None and current_owner.ownerid in admins
+                    )
                 except Exception as error:
                     capture_exception(error)
                     print("Error Calling Admin Provider " + repr(error))  # noqa: T201


### PR DESCRIPTION
<!-- Describe your PR here. -->


fixes https://codecov.sentry.io/issues/6591813682/?environment=production&project=5215654&query=is%3Aunresolved&referrer=issue-stream&sort=freq

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevent NoneType errors by safely checking `admins` before membership when determining if the current user is an admin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0807955f695bcb0a571901421697b7b10dcd28a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->