### PR TITLE
Revert "fix: use list for bundle analysis tasks"

### DIFF
--- a/apps/worker/tasks/bundle_analysis_notify.py
+++ b/apps/worker/tasks/bundle_analysis_notify.py
@@ -21,9 +21,9 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
     def run_impl(
         self,
         db_session,
-        # Celery `chain` injects this argument - it's the list of processing results
-        # from prior processor tasks in the chain
-        previous_result: list[dict[str, Any]],
+        # Celery `chain` injects this argument - it's the returned result
+        # from the prior task in the chain
+        previous_result: dict[str, Any],
         *,
         repoid: int,
         commitid: str,
@@ -72,7 +72,7 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
         repoid: int,
         commitid: str,
         commit_yaml: UserYaml,
-        previous_result: list[dict[str, Any]],
+        previous_result: dict[str, Any],
         **kwargs,
     ):
         log.info(
@@ -90,11 +90,9 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
         )
         assert commit, "commit not found"
 
-        # previous_result is the list of processing results from prior processor tasks
+        # these are the task results from prior processor tasks in the chain
         # (they get accumulated as we execute each task in succession)
-        processing_results = (
-            previous_result if isinstance(previous_result, list) else []
-        )
+        processing_results = previous_result.get("results", [])
 
         if all(result["error"] is not None for result in processing_results):
             # every processor errored, nothing to notify on

--- a/apps/worker/tasks/tests/unit/test_bundle_analysis_notify_task.py
+++ b/apps/worker/tasks/tests/unit/test_bundle_analysis_notify_task.py
@@ -30,7 +30,7 @@ def test_bundle_analysis_notify_task(
 
     result = BundleAnalysisNotifyTask().run_impl(
         dbsession,
-        [{"error": None}],
+        {"results": [{"error": None}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -47,7 +47,7 @@ def test_bundle_analysis_notify_skips_if_all_processing_fail(dbsession):
     dbsession.flush()
     result = BundleAnalysisNotifyTask().run_impl(
         dbsession,
-        [{"error": True}],
+        {"results": [{"error": True}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},

--- a/apps/worker/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/apps/worker/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -87,7 +87,7 @@ def test_bundle_analysis_processor_task_success(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -96,15 +96,17 @@ def test_bundle_analysis_processor_task_success(
             "commit": commit.commitid,
         },
     )
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": None,
-            "session_id": 123,
-            "upload_id": upload.id_,
-            "bundle_name": "bundle1",
-        },
-    ]
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": None,
+                "session_id": 123,
+                "upload_id": upload.id_,
+                "bundle_name": "bundle1",
+            },
+        ],
+    }
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -147,7 +149,7 @@ def test_bundle_analysis_processor_task_error(
 
     result = task.run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -156,18 +158,20 @@ def test_bundle_analysis_processor_task_error(
             "commit": commit.commitid,
         },
     )
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": {
-                "code": "file_not_in_storage",
-                "params": {"location": "invalid-storage-path"},
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": {
+                    "code": "file_not_in_storage",
+                    "params": {"location": "invalid-storage-path"},
+                },
+                "session_id": None,
+                "upload_id": upload.id_,
+                "bundle_name": None,
             },
-            "session_id": None,
-            "upload_id": upload.id_,
-            "bundle_name": None,
-        },
-    ]
+        ],
+    }
 
     assert commit.state == "error"
     assert upload.state == "error"
@@ -219,7 +223,7 @@ def test_bundle_analysis_processor_task_general_error(
     with pytest.raises(Exception):
         task.run_impl(
             dbsession,
-            [{"previous": "result"}],
+            {"results": [{"previous": "result"}]},
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={},
@@ -271,7 +275,7 @@ def test_bundle_analysis_process_upload_general_error(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -281,21 +285,23 @@ def test_bundle_analysis_process_upload_general_error(
         },
     )
 
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": {
-                "code": "parser_error",
-                "params": {
-                    "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite",
-                    "plugin_name": "unknown",
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": {
+                    "code": "parser_error",
+                    "params": {
+                        "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite",
+                        "plugin_name": "unknown",
+                    },
                 },
+                "session_id": None,
+                "upload_id": upload.id_,
+                "bundle_name": None,
             },
-            "session_id": None,
-            "upload_id": upload.id_,
-            "bundle_name": None,
-        },
-    ]
+        ],
+    }
 
     assert not retry.called
     assert upload.state == "error"
@@ -343,7 +349,7 @@ def test_bundle_analysis_processor_task_locked(
 
     result = task.run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -396,7 +402,7 @@ def test_bundle_analysis_process_upload_rate_limit_error(
 
     result = task.run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -405,20 +411,22 @@ def test_bundle_analysis_process_upload_rate_limit_error(
             "commit": commit.commitid,
         },
     )
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": {
-                "code": "rate_limit_error",
-                "params": {
-                    "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite"
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": {
+                    "code": "rate_limit_error",
+                    "params": {
+                        "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite"
+                    },
                 },
+                "session_id": None,
+                "upload_id": upload.id_,
+                "bundle_name": None,
             },
-            "session_id": None,
-            "upload_id": upload.id_,
-            "bundle_name": None,
-        },
-    ]
+        ],
+    }
 
     assert commit.state == "error"
     assert upload.state == "error"
@@ -464,7 +472,7 @@ def test_bundle_analysis_process_associate_no_parent_commit_id(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -517,7 +525,7 @@ def test_bundle_analysis_process_associate_no_parent_commit_object(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -574,7 +582,7 @@ def test_bundle_analysis_process_associate_no_parent_commit_report_object(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -637,7 +645,7 @@ def test_bundle_analysis_process_associate_called(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -711,7 +719,7 @@ def test_bundle_analysis_process_associate_called_two(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -781,7 +789,7 @@ def test_bundle_analysis_processor_associate_custom_compare_sha(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -856,7 +864,7 @@ def test_bundle_analysis_processor_task_cache_config_not_saved(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -865,15 +873,17 @@ def test_bundle_analysis_processor_task_cache_config_not_saved(
             "commit": commit.commitid,
         },
     )
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": None,
-            "session_id": 123,
-            "upload_id": upload.id_,
-            "bundle_name": "BundleA",
-        },
-    ]
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": None,
+                "session_id": 123,
+                "upload_id": upload.id_,
+                "bundle_name": "BundleA",
+            },
+        ],
+    }
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -933,7 +943,7 @@ def test_bundle_analysis_processor_task_cache_config_saved(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -942,15 +952,17 @@ def test_bundle_analysis_processor_task_cache_config_saved(
             "commit": commit.commitid,
         },
     )
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": None,
-            "session_id": 123,
-            "upload_id": upload.id_,
-            "bundle_name": "BundleA",
-        },
-    ]
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": None,
+                "session_id": 123,
+                "upload_id": upload.id_,
+                "bundle_name": "BundleA",
+            },
+        ],
+    }
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1019,7 +1031,7 @@ def test_bundle_analysis_processor_not_caching_previous_report(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1028,15 +1040,17 @@ def test_bundle_analysis_processor_not_caching_previous_report(
             "commit": commit.commitid,
         },
     )
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": None,
-            "session_id": 123,
-            "upload_id": upload.id_,
-            "bundle_name": "BundleA",
-        },
-    ]
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": None,
+                "session_id": 123,
+                "upload_id": upload.id_,
+                "bundle_name": "BundleA",
+            },
+        ],
+    }
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1107,7 +1121,7 @@ def test_bundle_analysis_processor_not_caching_previous_report_two(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1116,15 +1130,17 @@ def test_bundle_analysis_processor_not_caching_previous_report_two(
             "commit": commit.commitid,
         },
     )
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": None,
-            "session_id": 123,
-            "upload_id": upload.id_,
-            "bundle_name": "BundleA",
-        },
-    ]
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": None,
+                "session_id": 123,
+                "upload_id": upload.id_,
+                "bundle_name": "BundleA",
+            },
+        ],
+    }
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1195,7 +1211,7 @@ def test_bundle_analysis_processor_caching_previous_report(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1204,15 +1220,17 @@ def test_bundle_analysis_processor_caching_previous_report(
             "commit": commit.commitid,
         },
     )
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": None,
-            "session_id": 123,
-            "upload_id": upload.id_,
-            "bundle_name": "BundleA",
-        },
-    ]
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": None,
+                "session_id": 123,
+                "upload_id": upload.id_,
+                "bundle_name": "BundleA",
+            },
+        ],
+    }
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1243,7 +1261,7 @@ def test_bundle_analysis_processor_task_no_upload(
 
     result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1259,15 +1277,17 @@ def test_bundle_analysis_processor_task_no_upload(
     upload = dbsession.query(Upload).filter_by(report_id=commit_report.id).first()
     assert upload is not None
 
-    assert result == [
-        {"previous": "result"},
-        {
-            "error": None,
-            "session_id": None,
-            "upload_id": upload.id_,
-            "bundle_name": None,
-        },
-    ]
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": None,
+                "session_id": None,
+                "upload_id": upload.id_,
+                "bundle_name": None,
+            },
+        ],
+    }
 
     assert commit.state == "complete"
     assert upload.state == "processed"
@@ -1311,7 +1331,7 @@ def test_bundle_analysis_processor_task_carryforward(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},
@@ -1371,7 +1391,7 @@ def test_bundle_analysis_processor_task_carryforward_error(
 
     BundleAnalysisProcessorTask().run_impl(
         dbsession,
-        [{"previous": "result"}],
+        {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
         commitid=commit.commitid,
         commit_yaml={},

--- a/apps/worker/tasks/tests/unit/test_upload_task.py
+++ b/apps/worker/tasks/tests/unit/test_upload_task.py
@@ -365,7 +365,7 @@ class TestUploadTaskIntegration:
         assert len(uploads) == 1
         upload = dbsession.query(Upload).filter_by(report_id=commit_report.id).first()
         processor_sig = bundle_analysis_processor_task.s(
-            [],
+            {},
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},
@@ -482,7 +482,7 @@ class TestUploadTaskIntegration:
         assert commit_report.commit == commit
 
         processor_sig = bundle_analysis_processor_task.s(
-            [],
+            {},
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},

--- a/apps/worker/tasks/upload.py
+++ b/apps/worker/tasks/upload.py
@@ -943,7 +943,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             )
             for params in argument_list
         ]
-        task_signatures[0].args = ([],)  # this is the first `previous_result`
+        task_signatures[0].args = ({},)  # this is the first `previous_result`
 
         # it might make sense to eventually have a "finisher" task that
         # does whatever extra stuff + enqueues a notify


### PR DESCRIPTION
Reverts codecov/umbrella#565

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch bundle-analysis processor/notify tasks to pass a dict payload `{"results": [...]}` through the Celery chain and update scheduling/tests accordingly.
> 
> - **Bundle Analysis (BA) tasks**:
>   - Change chained `previous_result` from list to dict with `"results"` key in `tasks/bundle_analysis_processor.py` and `tasks/bundle_analysis_notify.py`.
>   - Processor now returns `{"results": processing_results}`; Notify reads results via `previous_result.get("results", [])`.
> - **Task scheduling**:
>   - In `tasks/upload.py`, initialize first BA task arg to `{}` (instead of `[]`).
> - **Tests**:
>   - Update BA processor/notify tests and upload task tests to use the new dict payload and expected return shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fcde6f5e7c4c83965d22019f15df5109eb71c56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->