### PR TITLE
fix: aggregate file not in storage errors

### DIFF
--- a/apps/worker/tasks/upload_processor.py
+++ b/apps/worker/tasks/upload_processor.py
@@ -125,7 +125,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 and self.request.retries >= MAX_FILE_NOT_FOUND_RETRIES
             ):
                 sentry_sdk.capture_exception(
-                    FileNotInStorageError(f"File not found in storage"),
+                    FileNotInStorageError("File not found in storage"),
                     contexts={
                         "upload_details": {
                             "repoid": repoid,


### PR DESCRIPTION
<!-- Describe your PR here. -->

Aggregate the errors better on Sentry


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes Sentry "file not in storage" exceptions to a generic message while keeping specifics in contexts for aggregation.
> 
> - **Worker**
>   - `apps/worker/tasks/upload_processor.py`:
>     - Standardizes Sentry reporting for retry-exhausted `FILE_NOT_IN_STORAGE` by sending `FileNotInStorageError("File not in storage")` and placing details in `contexts.upload_details` to improve aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b71a0fa2b2971d3b1a9539321a4354575b96cafc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->