### PR TITLE
CCMRG-1896: Add lock duration to release lock log message

### DIFF
--- a/apps/worker/services/lock_manager.py
+++ b/apps/worker/services/lock_manager.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import time
 from contextlib import contextmanager
 from enum import Enum
 
@@ -61,6 +62,7 @@ class LockManager:
             with self.redis_connection.lock(
                 lock_name, timeout=self.lock_timeout, blocking_timeout=5
             ):
+                lock_acquired_time = time.time()
                 log.info(
                     "Acquired lock",
                     extra={
@@ -70,12 +72,14 @@ class LockManager:
                     },
                 )
                 yield
+                lock_duration = time.time() - lock_acquired_time
                 log.info(
                     "Releasing lock",
                     extra={
                         "repoid": self.repoid,
                         "commitid": self.commitid,
                         "lock_name": lock_name,
+                        "lock_duration_seconds": lock_duration,
                     },
                 )
         except LockError:


### PR DESCRIPTION
This PR adds logging for the duration a lock was held in the 'release lock' log message in lock_manager.py. The duration is tracked from lock acquisition to release and included as 'lock_duration_seconds' in the log extra fields.