### PR TITLE
feat: add check to process flakes using accounts if existing

### DIFF
--- a/apps/worker/services/test_results.py
+++ b/apps/worker/services/test_results.py
@@ -498,7 +498,11 @@ class TestResultsNotifier[T: (str, bytes)](BaseNotifier):
 
 
 def not_private_and_free_or_team(repo: Repository):
-    plan = Plan.objects.select_related("tier").get(name=repo.author.plan)
+    plan_name = repo.author.plan
+    if repo.author.account:
+        plan_name = repo.author.account.plan
+
+    plan = Plan.objects.select_related("tier").get(name=plan_name)
 
     return not (
         repo.private


### PR DESCRIPTION
This PR adds a check in the processing flakes logic that uses an account's plan if the owner has an account. We should be using the account's plan if an account exists rather than the owner's plan. 

https://linear.app/getsentry/issue/CCMRG-1902/ta-add-accounts-for-flake-processing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Determine flake detection eligibility using the account’s plan when available, with tests covering account vs owner plan scenarios.
> 
> - **Services**:
>   - Update `not_private_and_free_or_team` in `apps/worker/services/test_results.py` to prefer `repo.author.account.plan` over owner plan when present; affects `should_do_flaky_detection` gating for private repos on free/team tiers.
> - **Tests**:
>   - Add parametrized tests in `apps/worker/services/tests/test_test_results.py` to verify flake detection behavior when account and owner plans differ.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49527528cb5e1e4cc63ace56a19fbb3985bafe37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->