### PR TITLE
feat: allow sentry-merge plans to do flakes

### DIFF
--- a/apps/worker/services/test_results.py
+++ b/apps/worker/services/test_results.py
@@ -24,7 +24,7 @@ from services.repository import EnrichedPull
 from services.urls import get_members_url, get_test_analytics_url
 from services.yaml import read_yaml_field
 from shared.django_apps.codecov_auth.models import Plan
-from shared.plan.constants import TierName
+from shared.plan.constants import PlanName, TierName
 from shared.yaml import UserYaml
 
 
@@ -501,6 +501,8 @@ def not_private_and_free_or_team(repo: Repository):
     plan_name = repo.author.plan
     if repo.author.account:
         plan_name = repo.author.account.plan
+        if plan_name == PlanName.SENTRY_MERGE_PLAN.value:
+            return True
 
     plan = Plan.objects.select_related("tier").get(name=plan_name)
 


### PR DESCRIPTION
This PR adds a check to always allow owners with the sentry-merge account to return true. This is an explicit return that doesn't follow the Plan django logic since the sentry-merge plan is a temporary DB field 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always allow flaky detection when the repository owner’s account plan is `SENTRY_MERGE_PLAN`.
> 
> - **Test Analytics eligibility**:
>   - Update `not_private_and_free_or_team` in `apps/worker/services/test_results.py` to early-return `True` when `repo.author.account.plan == PlanName.SENTRY_MERGE_PLAN.value`.
>   - Import `PlanName` alongside `TierName` to support the new check.
> - **Tests**:
>   - Add `test_should_do_flake_detection_with_sentry_merge_account` verifying the new allowance.
>   - Update test imports to include `PlanName`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80a6fe8f712cc007ec087936539f3559e723a8a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->