### PR TITLE
fix(worker): Prevent infinite retry loops when max retries exceeded

### DIFF
--- a/libs/shared/tests/unit/test_celery_config.py
+++ b/libs/shared/tests/unit/test_celery_config.py
@@ -53,7 +53,7 @@ def test_celery_config():
         "app.tasks.timeseries.*",
         "app.tasks.upload.*",
     ]
-    assert config.broker_transport_options == {"visibility_timeout": 900}
+    assert config.broker_transport_options == {"visibility_timeout": 300}
     assert config.result_extended is True
     assert config.imports == ("tasks",)
     assert config.task_serializer == "json"


### PR DESCRIPTION
CCMRG-1914: Fix infinite retry bug where tasks would loop at retry 5
and never exceed max retries.

Changes:
- Add MaxRetriesExceededError import to upload_finisher.py
- Capture MaxRetriesExceededError to Sentry when retries >= MAX_RETRIES
- Return early to prevent calling self.retry() which causes infinite loops
- Preserve LockManager's existing error logging
- Update test_celery_config.py to expect new visibility timeout default (300)

This ensures tasks properly stop retrying when max retries is reached,
and errors are properly logged to Sentry for visibility.