### PR TITLE
fix: Also check if upload is in started state for manual trigger

### DIFF
--- a/apps/worker/tasks/manual_trigger.py
+++ b/apps/worker/tasks/manual_trigger.py
@@ -95,7 +95,11 @@ class ManualTriggerTask(
 
         still_processing = 0
         for upload in uploads:
-            if not upload.state or upload.state_id == UploadState.UPLOADED.db_id:
+            if (
+                not upload.state
+                or upload.state == "started"
+                or upload.state_id == UploadState.UPLOADED.db_id
+            ):
                 still_processing += 1
 
         if still_processing == 0:


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1916/state-started-with-no-state-id-should-be-still-processing. Addresses a "manual trigger" problem where it is possibly prematurely sending the GH comment when not all of the uploads are processed yet. Two out of the ten uploads for commit becd4ee1962d197e8344e7582bdcebde7c0e7fa8 show as state "started" in the DB.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Considers uploads with state "started" as still processing to prevent premature notifications.
> 
> - **Worker**
>   - Update `apps/worker/tasks/manual_trigger.py` to count uploads with `state == "started"` as still processing, alongside missing `state` or `state_id == UploadState.UPLOADED.db_id`, delaying notifications until all uploads complete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13116c11878474ad3e92aa1065f0cc6a6d1a5bd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->