### PR TITLE
Remove unused Europe West3 Codecov configuration from CI workflow

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -104,9 +104,6 @@ jobs:
           - codecov_url_secret: CODECOV_PUBLIC_QA_URL
             codecov_token_secret: CODECOV_PUBLIC_QA_TOKEN
             name: public qa
-          - codecov_url_secret: CODECOV_EUROPE_WEST3_URL
-            codecov_token_secret: CODECOV_EUROPE_WEST3_TOKEN
-            name: europe-west3
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the `europe-west3` Codecov upload target from the CI workflow matrix in `.github/workflows/_run-tests.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f415b073a174fdf90e11d622524ea38ee956737f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->