### PR TITLE
fix: update commit status comparison

### DIFF
--- a/apps/worker/services/bundle_analysis/notify/contexts/__init__.py
+++ b/apps/worker/services/bundle_analysis/notify/contexts/__init__.py
@@ -32,7 +32,7 @@ class CommitStatusLevel(Enum):
     ERROR = auto()
 
     def to_str(self) -> Literal["success"] | Literal["failure"]:
-        if self.value == "ERROR":
+        if self == CommitStatusLevel.ERROR:
             return "failure"
         return "success"
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Bundle Analysis notify comparison should compare to the enum itself not `value`, since value is `auto()`

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes commit status mapping by comparing `CommitStatusLevel` to the enum member instead of its `value` when determining success/failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2913a16257c5b340c25419a9b08676059977303. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->