### PR TITLE
fix: Enhance ReportEmptyError with additional context

### DIFF
--- a/apps/worker/helpers/exceptions.py
+++ b/apps/worker/helpers/exceptions.py
@@ -13,7 +13,12 @@ class ReportExpiredException(Exception):
 
 
 class ReportEmptyError(Exception):
-    pass
+    def __init__(self, archive_path=None, reportid=None) -> None:
+        message = "No files found in report."
+        super().__init__(message)
+        self.message = message
+        self.archive_path = archive_path
+        self.reportid = reportid
 
 
 class CorruptRawReportError(Exception):

--- a/apps/worker/services/report/__init__.py
+++ b/apps/worker/services/report/__init__.py
@@ -673,8 +673,15 @@ class ReportService(BaseReportService):
             raw_report_info.error = result.error
             return result
         except ReportEmptyError as e:
+            e.reportid = reportid
             sentry_sdk.capture_exception(e)
-            log.warning("Report is empty", extra={"reportid": reportid})
+            log.warning(
+                "Report is empty",
+                extra={
+                    "reportid": e.reportid,
+                    "archive_path": e.archive_path or archive_url,
+                },
+            )
             result.error = ProcessingError(code=UploadErrorCode.REPORT_EMPTY, params={})
             raw_report_info.error = result.error
             return result

--- a/apps/worker/services/report/raw_upload_processor.py
+++ b/apps/worker/services/report/raw_upload_processor.py
@@ -87,7 +87,7 @@ def process_raw_upload(
             report.merge(report_from_file)
 
     if not report:
-        raise ReportEmptyError("No files found in report.")
+        raise ReportEmptyError(archive_path=session.archive)
 
     _sessionid, session = report.add_session(session, use_id_from_session=True)
     session.totals = report.totals


### PR DESCRIPTION
- Updated ReportEmptyError to include archive_path and reportid for better error handling.
- Modified exception handling in ReportService to log detailed information about empty reports.
- Adjusted raw_upload_processor to raise ReportEmptyError with the session archive path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds context (archive_path, reportid) to ReportEmptyError, propagates it to Sentry/logs, and raises it with the session archive when no files are found.
> 
> - **Worker/Report processing**
>   - **ReportEmptyError**: Now carries `archive_path` and `reportid`; sets a default message.
>   - **Logging/Sentry**: In `services/report/__init__.py`, on `ReportEmptyError` capture to Sentry and log `reportid` and `archive_path` (fallbacks to `upload.storage_path`).
>   - **Raw upload**: In `raw_upload_processor.process_raw_upload`, raise `ReportEmptyError` with `archive_path=session.archive` when the merged report is empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf34e7ad2d523819f0abaeea4f33fb24e5c24250. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->