### PR TITLE
chore(security): bump starlette to >=0.49.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ codecov-api = [
     "gunicorn>=22.0.0",
     "idna>=3.7",
     "simplejson>=3.17.2",
-    "starlette>=0.40.0",
+    "starlette>=0.49.1",
     "whitenoise>=5.2.0",
     { include-group = "shared" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2330,14 +2330,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.46.2"
+version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
 ]
 
 [[package]]
@@ -2777,7 +2777,7 @@ codecov-api = [
     { name = "shared", editable = "libs/shared" },
     { name = "simplejson", specifier = ">=3.17.2" },
     { name = "sqlalchemy", specifier = "<2" },
-    { name = "starlette", specifier = ">=0.40.0" },
+    { name = "starlette", specifier = ">=0.49.1" },
     { name = "stripe", specifier = ">=11.4.1" },
     { name = "urllib3", specifier = "==1.26.20" },
     { name = "whitenoise", specifier = ">=5.2.0" },
@@ -2871,7 +2871,7 @@ prod = [
     { name = "simplejson", specifier = ">=3.17.2" },
     { name = "sqlalchemy", specifier = "<2" },
     { name = "sqlparse", specifier = ">=0.5.0" },
-    { name = "starlette", specifier = ">=0.40.0" },
+    { name = "starlette", specifier = ">=0.49.1" },
     { name = "statsd", specifier = ">=3.3.0" },
     { name = "stripe", specifier = ">=11.4.1" },
     { name = "test-results-parser", git = "https://github.com/codecov/test-results-parser?rev=accbb7f63cc973ee9809b181a5cf67f1f8f13ecd" },


### PR DESCRIPTION
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `starlette` requirement to `>=0.49.1` and updates lockfile to `0.50.0` across dependency groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e895fcab3891ec942cd5f63b747cae452a86b73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->