### PR TITLE
fix(report): remove Sentry capture for empty report uploads

### DIFF
--- a/apps/worker/helpers/exceptions.py
+++ b/apps/worker/helpers/exceptions.py
@@ -13,12 +13,28 @@ class ReportExpiredException(Exception):
 
 
 class ReportEmptyError(Exception):
-    def __init__(self, archive_path=None, reportid=None) -> None:
-        message = "No files found in report."
+    def __init__(
+        self,
+        archive_path=None,
+        reportid=None,
+        empty_files: list[str] | None = None,
+        total_files: int | None = None,
+    ) -> None:
+        # Build a more informative message
+        if total_files == 0:
+            message = "No coverage files found in upload."
+        elif empty_files:
+            message = f"No coverage data extracted. {len(empty_files)} of {total_files} file(s) were empty: {', '.join(empty_files[:5])}"
+            if len(empty_files) > 5:
+                message += f" (and {len(empty_files) - 5} more)"
+        else:
+            message = "No coverage data found in report."
         super().__init__(message)
         self.message = message
         self.archive_path = archive_path
         self.reportid = reportid
+        self.empty_files = empty_files or []
+        self.total_files = total_files
 
 
 class CorruptRawReportError(Exception):

--- a/apps/worker/helpers/exceptions.py
+++ b/apps/worker/helpers/exceptions.py
@@ -18,17 +18,20 @@ class ReportEmptyError(Exception):
         archive_path=None,
         reportid=None,
         empty_files: list[str] | None = None,
-        total_files: int | None = None,
+        total_files: int = 0,
     ) -> None:
         # Build a more informative message
-        if total_files == 0:
+        if total_files == 0 or (empty_files and len(empty_files) == total_files):
+            # No files at all, or all files were empty
             message = "No coverage files found in upload."
         elif empty_files:
-            message = f"No coverage data extracted. {len(empty_files)} of {total_files} file(s) were empty: {', '.join(empty_files[:5])}"
+            # Some files were empty, list them
+            files_list = ", ".join(empty_files[:5])
             if len(empty_files) > 5:
-                message += f" (and {len(empty_files) - 5} more)"
+                files_list += f", (and {len(empty_files) - 5} more)"
+            message = f"No coverage data extracted. {len(empty_files)} of {total_files} file(s) were empty: {files_list}"
         else:
-            message = "No coverage data found in report."
+            message = "No files found in report."
         super().__init__(message)
         self.message = message
         self.archive_path = archive_path

--- a/apps/worker/helpers/tests/unit/test_exceptions.py
+++ b/apps/worker/helpers/tests/unit/test_exceptions.py
@@ -1,0 +1,52 @@
+from helpers.exceptions import ReportEmptyError
+
+
+class TestReportEmptyError:
+    def test_default_message(self):
+        """Test default message when no details provided."""
+        error = ReportEmptyError()
+        assert str(error) == "No coverage files found in upload."
+        assert error.empty_files == []
+        assert error.total_files == 0
+
+    def test_with_archive_path(self):
+        """Test that archive_path is stored."""
+        error = ReportEmptyError(archive_path="/path/to/archive")
+        assert error.archive_path == "/path/to/archive"
+
+    def test_all_files_empty(self):
+        """When all files are empty, use simplified message."""
+        error = ReportEmptyError(
+            empty_files=["file1.xml", "file2.xml"],
+            total_files=2,
+        )
+        assert str(error) == "No coverage files found in upload."
+        assert error.empty_files == ["file1.xml", "file2.xml"]
+        assert error.total_files == 2
+
+    def test_some_files_empty(self):
+        """When some files are empty, list them."""
+        error = ReportEmptyError(
+            empty_files=["empty1.xml", "empty2.xml"],
+            total_files=5,
+        )
+        assert "2 of 5 file(s) were empty" in str(error)
+        assert "empty1.xml" in str(error)
+        assert "empty2.xml" in str(error)
+
+    def test_many_empty_files_truncated(self):
+        """When more than 5 files empty, truncate the list."""
+        empty_files = [f"file{i}.xml" for i in range(10)]
+        error = ReportEmptyError(
+            empty_files=empty_files,
+            total_files=15,
+        )
+        message = str(error)
+        assert "10 of 15 file(s) were empty" in message
+        # First 5 files should be listed
+        assert "file0.xml" in message
+        assert "file4.xml" in message
+        # 6th file should not be in the list
+        assert "file5.xml" not in message
+        # Should indicate there are more
+        assert "(and 5 more)" in message

--- a/apps/worker/services/report/__init__.py
+++ b/apps/worker/services/report/__init__.py
@@ -673,8 +673,6 @@ class ReportService(BaseReportService):
             raw_report_info.error = result.error
             return result
         except ReportEmptyError as e:
-            # Empty reports are expected user behavior (e.g., no coverage data in upload)
-            # Log as warning only - no need to report to Sentry
             log.warning(
                 "Report is empty",
                 extra={

--- a/apps/worker/services/report/__init__.py
+++ b/apps/worker/services/report/__init__.py
@@ -673,13 +673,16 @@ class ReportService(BaseReportService):
             raw_report_info.error = result.error
             return result
         except ReportEmptyError as e:
-            e.reportid = reportid
-            sentry_sdk.capture_exception(e)
+            # Empty reports are expected user behavior (e.g., no coverage data in upload)
+            # Log as warning only - no need to report to Sentry
             log.warning(
                 "Report is empty",
                 extra={
-                    "reportid": e.reportid,
+                    "reportid": reportid,
                     "archive_path": e.archive_path or archive_url,
+                    "empty_files": e.empty_files[:10] if e.empty_files else [],
+                    "empty_files_count": len(e.empty_files) if e.empty_files else 0,
+                    "total_files_count": e.total_files,
                 },
             )
             result.error = ProcessingError(code=UploadErrorCode.REPORT_EMPTY, params={})

--- a/apps/worker/services/report/raw_upload_processor.py
+++ b/apps/worker/services/report/raw_upload_processor.py
@@ -61,7 +61,8 @@ def process_raw_upload(
         if current_filename in skip_files:
             continue
         if not report_file.contents:
-            empty_files.append(current_filename)
+            if current_filename:
+                empty_files.append(current_filename)
             continue
 
         path_fixer_to_use = path_fixer.get_relative_path_aware_pathfixer(
@@ -80,7 +81,8 @@ def process_raw_upload(
             raise
 
         if not report_from_file:
-            empty_files.append(current_filename)
+            if current_filename:
+                empty_files.append(current_filename)
             continue
         if report.is_empty():
             # if the initial report is empty, we can avoid a costly merge operation


### PR DESCRIPTION
## Summary

Improves error messaging for empty report uploads and removes unnecessary Sentry noise.

## Changes

### 1. Remove Sentry capture for `ReportEmptyError`
Empty reports are expected user behavior (e.g., no coverage data in upload). This was generating ~480K unnecessary Sentry events per month.

### 2. Track which files were empty
When processing an upload with multiple coverage files, we now track which files:
- Had no contents
- Processed but resulted in no coverage data

### 3. Include empty file names in error message and logs

**Before:**
```
ReportEmptyError: No files found in report.
```

**After:**
```
ReportEmptyError: No coverage data extracted. 3 of 20 file(s) were empty: coverage1.xml, coverage2.xml, coverage3.xml
```

The log warning now also includes:
- `empty_files`: list of up to 10 empty file names
- `empty_files_count`: total count of empty files  
- `total_files_count`: total files in upload

## Why This Matters

When a user uploads 20 coverage files and 3 are empty causing the upload to fail, they can now see WHICH files were the problem instead of searching through thousands of lines.

## Impact

- **Fixes [WORKER-WH2](https://codecov.sentry.io/issues/WORKER-WH2)**: ~480K events/month
- Better debugging experience for users with empty uploads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves handling and observability of empty coverage uploads while reducing noise.
> 
> - Enhances `ReportEmptyError` to include `empty_files` and `total_files`, with clearer, contextual messages
> - `process_raw_upload` now tracks files with no contents or no extracted coverage and raises `ReportEmptyError` with details
> - Updates logging in report processing to include `empty_files` (truncated), `empty_files_count`, and `total_files_count`; removes Sentry capture for `ReportEmptyError`
> - Adds unit tests for new error messaging and processing behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8199a1eead415e4816cb83e10f59ed6b672ed214. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->