### PR TITLE
fix(worker): cap retry countdown to visibility timeout across all tasks

### DIFF
--- a/apps/worker/services/lock_manager.py
+++ b/apps/worker/services/lock_manager.py
@@ -14,13 +14,12 @@ from database.enums import ReportType
 from shared.celery_config import (
     DEFAULT_BLOCKING_TIMEOUT_SECONDS,
     DEFAULT_LOCK_TIMEOUT_SECONDS,
+    TASK_RETRY_COUNTDOWN_MAX_SECONDS,
 )
 from shared.config import get_config
 from shared.helpers.redis import get_redis_connection  # type: ignore
 
 log = logging.getLogger(__name__)
-
-MAX_RETRY_COUNTDOWN_SECONDS = 60 * 60 * 5
 BASE_RETRY_COUNTDOWN_SECONDS = 200
 RETRY_BACKOFF_MULTIPLIER = 3
 RETRY_COUNTDOWN_RANGE_DIVISOR = 2
@@ -183,8 +182,8 @@ class LockManager:
             max_retry_unbounded = self.base_retry_countdown * (
                 RETRY_BACKOFF_MULTIPLIER**retry_num
             )
-            if max_retry_unbounded >= MAX_RETRY_COUNTDOWN_SECONDS:
-                countdown = MAX_RETRY_COUNTDOWN_SECONDS
+            if max_retry_unbounded >= TASK_RETRY_COUNTDOWN_MAX_SECONDS:
+                countdown = TASK_RETRY_COUNTDOWN_MAX_SECONDS
             else:
                 countdown_unbounded = random.randint(
                     max_retry_unbounded // RETRY_COUNTDOWN_RANGE_DIVISOR,

--- a/apps/worker/services/tests/test_lock_manager.py
+++ b/apps/worker/services/tests/test_lock_manager.py
@@ -7,7 +7,12 @@ import pytest
 from redis.exceptions import LockError
 
 from database.enums import ReportType
-from services.lock_manager import LockManager, LockRetry, LockType
+from services.lock_manager import (
+    LockManager,
+    LockRetry,
+    LockType,
+)
+from shared.celery_config import TASK_RETRY_COUNTDOWN_MAX_SECONDS
 from tasks.base import BaseCodecovTask
 
 
@@ -191,11 +196,11 @@ class TestLockManager:
             with manager.locked(LockType.UPLOAD, retry_num=2):
                 pass
 
-        # retry_num=2: 200 * 3^2 = 1800, so countdown should be between 900-1800
-        assert 900 <= exc_info.value.countdown <= 1800
+        # retry_num=2: 200 * 3^2 = 1800, which exceeds TASK_RETRY_COUNTDOWN_MAX_SECONDS
+        assert exc_info.value.countdown == TASK_RETRY_COUNTDOWN_MAX_SECONDS
 
     def test_locked_exponential_backoff_cap(self, mock_redis):
-        """Test that exponential backoff is capped at 5 hours"""
+        """Test that exponential backoff is capped at TASK_RETRY_COUNTDOWN_MAX_SECONDS"""
         mock_redis.lock.side_effect = LockError()
         mock_redis.incr.return_value = 1
 
@@ -205,8 +210,7 @@ class TestLockManager:
             with manager.locked(LockType.UPLOAD, retry_num=10):
                 pass
 
-        # Cap is 60 * 60 * 5 = 18000 seconds (5 hours)
-        assert exc_info.value.countdown <= 18000
+        assert exc_info.value.countdown == TASK_RETRY_COUNTDOWN_MAX_SECONDS
 
     def test_locked_max_retries_not_provided(self, mock_redis, caplog):
         """Test that max_retries=None doesn't log error"""

--- a/apps/worker/tasks/base.py
+++ b/apps/worker/tasks/base.py
@@ -33,6 +33,9 @@ from helpers.save_commit_error import save_commit_error
 from services.repository import get_repo_provider_service
 from shared.celery_config import (
     TASK_RETRY_BACKOFF_BASE_SECONDS,
+    TASK_RETRY_COUNTDOWN_MAX_SECONDS,
+    TASK_RETRY_MIN_SAFE_WINDOW_SECONDS,
+    TASK_VISIBILITY_TIMEOUT_SECONDS,
     upload_breadcrumb_task_name,
 )
 from shared.celery_router import route_tasks_based_on_user_plan
@@ -202,12 +205,52 @@ class BaseCodecovTask(celery_app.Task):
         cls.task_core_runtime = TASK_CORE_RUNTIME.labels(task=name)
 
     @property
-    def hard_time_limit_task(self):
+    def hard_time_limit_task(self) -> int:
+        """Return the hard time limit for this task execution, in seconds.
+
+        Checked in priority order:
+        1. request.timelimit[0] — set per-execution when a task is dispatched
+           with a custom time limit (e.g. apply_async(time_limit=N)).
+        2. self.time_limit — the class-level hard limit defined on the task.
+        3. app.conf.task_time_limit — the Celery application default.
+
+        Returns 0 if no limit is configured at any level.
+        """
         if self.request.timelimit is not None and self.request.timelimit[0] is not None:
-            return self.request.timelimit[0]
+            return int(self.request.timelimit[0])
         if self.time_limit is not None:
-            return self.time_limit
-        return self.app.conf.task_time_limit or 0
+            return int(self.time_limit)
+        return int(self.app.conf.task_time_limit or 0)
+
+    def clamp_retry_countdown(self, countdown: int) -> int:
+        """Cap a retry countdown to prevent Redis redelivery before the retry fires.
+
+        A task calling retry() may have been running for up to hard_time_limit_task
+        seconds, so the safe ceiling is:
+            TASK_VISIBILITY_TIMEOUT_SECONDS - hard_time_limit_task
+
+        Tasks with no hard limit fall back to TASK_RETRY_COUNTDOWN_MAX_SECONDS.
+
+        When the safe window is smaller than TASK_RETRY_MIN_SAFE_WINDOW_SECONDS
+        (e.g. enterprise tasks with hard_timelimit=2450s >> visibility_timeout=900s),
+        also falls back to TASK_RETRY_COUNTDOWN_MAX_SECONDS.
+        """
+        hard_limit = self.hard_time_limit_task
+        if hard_limit:
+            safe_window = TASK_VISIBILITY_TIMEOUT_SECONDS - hard_limit
+            if safe_window < TASK_RETRY_MIN_SAFE_WINDOW_SECONDS:
+                log.warning(
+                    "Task hard time limit leaves insufficient visibility window for "
+                    "retry clamping — falling back to global max",
+                    extra={
+                        "hard_time_limit_task": hard_limit,
+                        "min_safe_window": TASK_RETRY_MIN_SAFE_WINDOW_SECONDS,
+                        "visibility_timeout": TASK_VISIBILITY_TIMEOUT_SECONDS,
+                    },
+                )
+                return min(countdown, TASK_RETRY_COUNTDOWN_MAX_SECONDS)
+            return min(countdown, safe_window)
+        return min(countdown, TASK_RETRY_COUNTDOWN_MAX_SECONDS)
 
     def get_lock_timeout(self, default_timeout: int) -> int:
         """
@@ -261,7 +304,7 @@ class BaseCodecovTask(celery_app.Task):
         return super().apply_async(args=args, kwargs=kwargs, headers=headers, **options)
 
     def retry(self, max_retries=None, countdown=None, exc=None, **kwargs):
-        """Override Celery's retry to always update attempts header."""
+        """Override Celery's retry to always update attempts header and clamp countdown."""
         request = getattr(self, "request", None)
         current_attempts = self.attempts
         kwargs["headers"] = {
@@ -269,6 +312,9 @@ class BaseCodecovTask(celery_app.Task):
             **(kwargs.get("headers") or {}),
             "attempts": current_attempts + 1,
         }
+
+        if countdown is not None:
+            countdown = self.clamp_retry_countdown(countdown)
 
         return super().retry(
             max_retries=max_retries, countdown=countdown, exc=exc, **kwargs

--- a/apps/worker/tasks/bundle_analysis_notify.py
+++ b/apps/worker/tasks/bundle_analysis_notify.py
@@ -84,7 +84,10 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
                     "notify_attempted": False,
                     "notify_succeeded": None,
                 }
-            self.retry(max_retries=self.max_retries, countdown=retry.countdown)
+            self.retry(
+                max_retries=self.max_retries,
+                countdown=retry.countdown,
+            )
 
     @sentry_sdk.trace
     def process_impl_within_lock(

--- a/apps/worker/tasks/bundle_analysis_processor.py
+++ b/apps/worker/tasks/bundle_analysis_processor.py
@@ -153,7 +153,10 @@ class BundleAnalysisProcessorTask(
                     retry_num=self.request.retries,
                 )
                 return previous_result
-            self.retry(max_retries=self.max_retries, countdown=retry.countdown)
+            self.retry(
+                max_retries=self.max_retries,
+                countdown=retry.countdown,
+            )
 
     @staticmethod
     def _ba_report_already_exists(db_session, repoid: int, commitid: str) -> bool:

--- a/apps/worker/tasks/http_request.py
+++ b/apps/worker/tasks/http_request.py
@@ -66,7 +66,10 @@ class HTTPRequestTask(BaseCodecovTask, name=http_request_task_name):
 
     def _retry_task(self):
         # retry w/ exponential backoff
-        self.retry(max_retries=5, countdown=20 * (2**self.request.retries))
+        self.retry(
+            max_retries=5,
+            countdown=20 * (2**self.request.retries),
+        )
 
 
 RegisteredHTTPRequestTask = celery_app.register_task(HTTPRequestTask())

--- a/apps/worker/tasks/manual_trigger.py
+++ b/apps/worker/tasks/manual_trigger.py
@@ -65,7 +65,10 @@ class ManualTriggerTask(
                     "notifications_called": False,
                     "message": "Unable to acquire lock",
                 }
-            self.retry(max_retries=TASK_MAX_RETRIES_DEFAULT, countdown=retry.countdown)
+            self.retry(
+                max_retries=TASK_MAX_RETRIES_DEFAULT,
+                countdown=retry.countdown,
+            )
 
     def process_impl_within_lock(
         self,

--- a/apps/worker/tasks/preprocess_upload.py
+++ b/apps/worker/tasks/preprocess_upload.py
@@ -92,7 +92,8 @@ class PreProcessUpload(BaseCodecovTask, name=pre_process_upload_task_name):
                 error=Errors.INTERNAL_RETRYING,
             )
             self.retry(
-                max_retries=PREPROCESS_UPLOAD_MAX_RETRIES, countdown=retry.countdown
+                max_retries=PREPROCESS_UPLOAD_MAX_RETRIES,
+                countdown=retry.countdown,
             )
 
     def process_impl_within_lock(self, db_session, repoid, commitid):

--- a/apps/worker/tasks/tests/unit/test_base.py
+++ b/apps/worker/tasks/tests/unit/test_base.py
@@ -22,6 +22,9 @@ from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
 from database.tests.factories.core import OwnerFactory, RepositoryFactory
 from helpers.exceptions import NoConfiguredAppsAvailable, RepositoryWithoutValidBotError
 from shared.celery_config import (
+    TASK_RETRY_COUNTDOWN_MAX_SECONDS,
+    TASK_RETRY_MIN_SAFE_WINDOW_SECONDS,
+    TASK_VISIBILITY_TIMEOUT_SECONDS,
     sync_repos_task_name,
     upload_breadcrumb_task_name,
     upload_task_name,
@@ -29,11 +32,204 @@ from shared.celery_config import (
 from shared.django_apps.upload_breadcrumbs.models import BreadcrumbData, Errors
 from shared.plan.constants import PlanName
 from shared.torngit.exceptions import TorngitClientError
-from tasks.base import BaseCodecovRequest, BaseCodecovTask
+from tasks.base import (
+    BaseCodecovRequest,
+    BaseCodecovTask,
+)
 from tasks.base import celery_app as base_celery_app
 from tests.helpers import mock_all_plans_and_tiers
 
 here = Path(__file__)
+
+
+class TestClampRetryCountdown:
+    # A representative task hard time limit — arbitrary fraction of the visibility
+    # timeout, chosen so the cap math produces non-trivial values in both
+    # the test environment (TASK_VISIBILITY_TIMEOUT_SECONDS=20) and production (900).
+    _HARD_LIMIT = TASK_VISIBILITY_TIMEOUT_SECONDS // 4
+
+    # The safe ceiling: a task may have been running for up to _HARD_LIMIT seconds,
+    # so the countdown must fit within the remaining visibility window.
+    _SAFE_CAP = TASK_VISIBILITY_TIMEOUT_SECONDS - _HARD_LIMIT
+
+    # A countdown larger than any conceivable real cap, to exercise clamping.
+    _COUNTDOWN_EXCEEDING_ANY_CAP = 999_999
+
+    @pytest.mark.parametrize(
+        "hard_limit,countdown,expected",
+        [
+            # below cap → returned as-is
+            (_HARD_LIMIT, 0, 0),
+            (_HARD_LIMIT, _SAFE_CAP, _SAFE_CAP),
+            # 1 above cap → clamped to cap
+            (_HARD_LIMIT, _SAFE_CAP + 1, _SAFE_CAP),
+            # way above cap → clamped to cap
+            (_HARD_LIMIT, _COUNTDOWN_EXCEEDING_ANY_CAP, _SAFE_CAP),
+            # no hard limit, way above max → clamped to max
+            (0, _COUNTDOWN_EXCEEDING_ANY_CAP, TASK_RETRY_COUNTDOWN_MAX_SECONDS),
+            # no hard limit, below max → returned as-is
+            (0, 0, 0),
+        ],
+    )
+    def test_clamp(self, mocker, hard_limit, countdown, expected):
+        mocker.patch.object(
+            BaseCodecovTask,
+            "hard_time_limit_task",
+            new_callable=PropertyMock,
+            return_value=hard_limit,
+        )
+        task = BaseCodecovTask()
+        assert task.clamp_retry_countdown(countdown) == expected
+
+    @pytest.mark.parametrize(
+        "hard_limit",
+        [
+            # safe window is 1 second below the minimum — smallest misconfigured case
+            TASK_VISIBILITY_TIMEOUT_SECONDS - TASK_RETRY_MIN_SAFE_WINDOW_SECONDS + 1,
+            # safe window is 0
+            TASK_VISIBILITY_TIMEOUT_SECONDS,
+            # hard_limit exceeds visibility timeout (e.g. enterprise tasks with hard_timelimit=2450s)
+            TASK_VISIBILITY_TIMEOUT_SECONDS + 10,
+        ],
+    )
+    def test_clamp_falls_back_when_misconfigured(self, mocker, hard_limit):
+        """Falls back to TASK_RETRY_COUNTDOWN_MAX_SECONDS when the safe window is too small."""
+        mocker.patch.object(
+            BaseCodecovTask,
+            "hard_time_limit_task",
+            new_callable=PropertyMock,
+            return_value=hard_limit,
+        )
+        task = BaseCodecovTask()
+        assert task.clamp_retry_countdown(999) == TASK_RETRY_COUNTDOWN_MAX_SECONDS
+
+    def test_hard_time_limit_task_float_is_cast_to_int(self, mocker):
+        """Floats from self.request.timelimit[0] must be cast so math stays integer."""
+        task = BaseCodecovTask()
+        # Mock request so timelimit[0] is a float — exercises the first branch.
+        mock_request = MagicMock()
+        mock_request.timelimit = [600.9, None]
+        mocker.patch.object(
+            BaseCodecovTask,
+            "request",
+            new_callable=PropertyMock,
+            return_value=mock_request,
+        )
+        result = task.hard_time_limit_task
+        assert result == 600
+        assert isinstance(result, int)
+
+    def test_retry_applies_clamping(self, mocker):
+        """retry() must pass a clamped countdown to Celery so we never exceed visibility timeout."""
+        task = BaseCodecovTask()
+        hard_limit = TASK_VISIBILITY_TIMEOUT_SECONDS // 4
+        mocker.patch.object(
+            BaseCodecovTask,
+            "hard_time_limit_task",
+            new_callable=PropertyMock,
+            return_value=hard_limit,
+        )
+        captured = {}
+
+        def fake_super_retry(max_retries=None, countdown=None, exc=None, **kwargs):
+            captured["countdown"] = countdown
+            raise Retry()
+
+        mocker.patch.object(
+            BaseCodecovTask,
+            "attempts",
+            new_callable=PropertyMock,
+            return_value=0,
+        )
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mocker.patch.object(
+            BaseCodecovTask,
+            "request",
+            new_callable=PropertyMock,
+            return_value=mock_request,
+        )
+        mocker.patch("celery.app.task.Task.retry", side_effect=fake_super_retry)
+
+        with pytest.raises(Retry):
+            task.retry(max_retries=5, countdown=99999)
+
+        assert captured["countdown"] == TASK_VISIBILITY_TIMEOUT_SECONDS - hard_limit
+
+    def test_retry_does_not_clamp_when_countdown_is_none(self, mocker):
+        """retry() with countdown=None must pass None through untouched (Celery default)."""
+        task = BaseCodecovTask()
+        mocker.patch.object(
+            BaseCodecovTask,
+            "hard_time_limit_task",
+            new_callable=PropertyMock,
+            return_value=TASK_VISIBILITY_TIMEOUT_SECONDS // 4,
+        )
+        captured = {}
+
+        def fake_super_retry(max_retries=None, countdown=None, exc=None, **kwargs):
+            captured["countdown"] = countdown
+            raise Retry()
+
+        mocker.patch.object(
+            BaseCodecovTask,
+            "attempts",
+            new_callable=PropertyMock,
+            return_value=0,
+        )
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mocker.patch.object(
+            BaseCodecovTask,
+            "request",
+            new_callable=PropertyMock,
+            return_value=mock_request,
+        )
+        mocker.patch("celery.app.task.Task.retry", side_effect=fake_super_retry)
+
+        with pytest.raises(Retry):
+            task.retry(max_retries=5, countdown=None)
+
+        assert captured["countdown"] is None
+
+    def _patch_misconfigured_task(self, mocker):
+        """Patch a task so its hard limit leaves no safe retry window."""
+        mocker.patch.object(
+            BaseCodecovTask,
+            "hard_time_limit_task",
+            new_callable=PropertyMock,
+            return_value=TASK_VISIBILITY_TIMEOUT_SECONDS,
+        )
+        mocker.patch.object(
+            BaseCodecovTask,
+            "attempts",
+            new_callable=PropertyMock,
+            return_value=0,
+        )
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mocker.patch.object(
+            BaseCodecovTask,
+            "request",
+            new_callable=PropertyMock,
+            return_value=mock_request,
+        )
+
+    def test_retry_clamps_to_max_when_misconfigured(self, mocker):
+        """retry() uses global max fallback when misconfigured — does not raise."""
+        self._patch_misconfigured_task(mocker)
+        captured = {}
+
+        def fake_super_retry(max_retries=None, countdown=None, exc=None, **kwargs):
+            captured["countdown"] = countdown
+            raise Retry()
+
+        mocker.patch("celery.app.task.Task.retry", side_effect=fake_super_retry)
+
+        with pytest.raises(Retry):
+            BaseCodecovTask().retry(max_retries=5, countdown=999)
+
+        assert captured["countdown"] == TASK_RETRY_COUNTDOWN_MAX_SECONDS
 
 
 @pytest.fixture

--- a/apps/worker/tasks/upload_finisher.py
+++ b/apps/worker/tasks/upload_finisher.py
@@ -496,7 +496,8 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 error=Errors.INTERNAL_RETRYING,
             )
             self.retry(
-                max_retries=UPLOAD_PROCESSOR_MAX_RETRIES, countdown=retry.countdown
+                max_retries=UPLOAD_PROCESSOR_MAX_RETRIES,
+                countdown=retry.countdown,
             )
 
     def _handle_finisher_lock(
@@ -617,7 +618,8 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 error=Errors.INTERNAL_RETRYING,
             )
             self.retry(
-                max_retries=UPLOAD_PROCESSOR_MAX_RETRIES, countdown=retry.countdown
+                max_retries=UPLOAD_PROCESSOR_MAX_RETRIES,
+                countdown=retry.countdown,
             )
 
     def finish_reports_processing(

--- a/apps/worker/tasks/upload_processor.py
+++ b/apps/worker/tasks/upload_processor.py
@@ -117,7 +117,10 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                     upload_ids=[arguments["upload_id"]],
                     error=Errors.INTERNAL_RETRYING,
                 )
-                self.retry(max_retries=error.max_retries, countdown=countdown)
+                self.retry(
+                    max_retries=error.max_retries,
+                    countdown=countdown,
+                )
             elif error.is_retryable and self.request.retries >= error.max_retries:
                 sentry_sdk.capture_exception(
                     error.error_class(error.error_text),

--- a/libs/shared/shared/celery_config.py
+++ b/libs/shared/shared/celery_config.py
@@ -263,6 +263,16 @@ TASK_RETRY_BACKOFF_BASE_SECONDS = int(
     get_config("setup", "tasks", "celery", "retry_backoff_base", default=20)
 )
 
+# Fallback cap for clamp_retry_countdown on tasks with no hard time limit
+# configured. As of 2026-02-25, TASK_VISIBILITY_TIMEOUT_SECONDS defaults to
+# 900 s in production. The 30 s margin is arbitrary but sufficient.
+TASK_RETRY_COUNTDOWN_MAX_SECONDS = TASK_VISIBILITY_TIMEOUT_SECONDS - 30
+
+# Minimum safe window for clamp_retry_countdown. If the remaining visibility
+# window (TASK_VISIBILITY_TIMEOUT_SECONDS - hard_time_limit_task) is smaller
+# than this, clamp_retry_countdown falls back to TASK_RETRY_COUNTDOWN_MAX_SECONDS.
+TASK_RETRY_MIN_SAFE_WINDOW_SECONDS = 30
+
 # Fixed retry delay for specific conditions (seconds)
 # Used for predictable retry intervals (e.g., waiting for processing lock)
 # Default: 60 seconds


### PR DESCRIPTION
## Problem

Fixes CODECOV-59, WORKER-XPY, ECDN-WORKER-E65.

When a task calls `self.retry(countdown=N)` where `N` exceeds `TASK_VISIBILITY_TIMEOUT_SECONDS` (900s in production), Redis redelivers the message from `unacked` before the ETA fires. This causes duplicate task executions that compound exponentially under load — the root cause of the bundle analysis queue explosions in CODECOV-59.

A second, related bug (WORKER-XPY, ECDN-WORKER-E65): enterprise tasks in the `upload` config group receive `hard_timelimit=2450s` via `apply_async(time_limit=N)`. The previous fix computed `safe_window = 900 - 2450 = -1550`, which fell below the `TASK_RETRY_MIN_SAFE_WINDOW_SECONDS` threshold and raised `MaxRetriesExceededError`, killing legitimate retries for `Upload` and `UploadProcessor` tasks.

## Solution

### `BaseCodecovTask.clamp_retry_countdown(countdown)`

A new method on `BaseCodecovTask` caps any retry countdown to the safe window before the visibility timeout expires:

```
safe_ceiling = TASK_VISIBILITY_TIMEOUT_SECONDS - hard_time_limit_task
```

A task may have been running for up to `hard_time_limit_task` seconds when it calls `retry()`, so the countdown must fit within the remaining visibility window to avoid redelivery.

**Enterprise task fallback**: when the safe window is smaller than `TASK_RETRY_MIN_SAFE_WINDOW_SECONDS` (e.g. `hard_timelimit=2450s >> visibility_timeout=900s`), the method falls back to `TASK_RETRY_COUNTDOWN_MAX_SECONDS` (870s) instead of raising. This restores retries for enterprise upload tasks while still keeping countdowns within the visibility window.

### `BaseCodecovTask.retry()` override

Clamping is applied automatically in the `retry()` override whenever a `countdown` is explicitly provided. No call sites need to be updated.

### `LockManager`

The hardcoded 5-hour cap (`MAX_RETRY_COUNTDOWN_SECONDS = 60 * 60 * 5`) is replaced with the shared `TASK_RETRY_COUNTDOWN_MAX_SECONDS` constant, so LockRetry countdowns are also bounded at the source.

## New constants (`shared/celery_config.py`)

| Constant | Value | Purpose |
|---|---|---|
| `TASK_RETRY_COUNTDOWN_MAX_SECONDS` | `TASK_VISIBILITY_TIMEOUT_SECONDS - 30` (870s) | Fallback ceiling for tasks with no hard limit or an oversized one |
| `TASK_RETRY_MIN_SAFE_WINDOW_SECONDS` | `30` | Threshold below which we fall back to the global max |

## Files changed

- `libs/shared/shared/celery_config.py` — two new constants
- `apps/worker/tasks/base.py` — `hard_time_limit_task` return type, `clamp_retry_countdown`, `retry()` override
- `apps/worker/services/lock_manager.py` — replace local 5-hour cap with shared constant
- `apps/worker/services/tests/test_lock_manager.py` — update cap assertions
- `apps/worker/tasks/tests/unit/test_base.py` — `TestClampRetryCountdown` covering normal cap, fallback, enterprise tasks, `retry()` integration
- 6 task files — formatting only (single-line `self.retry()` → multi-line)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core retry behavior for all `BaseCodecovTask` tasks by clamping `countdown`, which could alter retry timing under load or for long-running tasks; includes explicit fallback behavior and new unit coverage to reduce regression risk.
> 
> **Overview**
> Adds a global retry-delay ceiling derived from `TASK_VISIBILITY_TIMEOUT_SECONDS` (`TASK_RETRY_COUNTDOWN_MAX_SECONDS`) plus a minimum-safe-window threshold, and uses these to prevent Redis from redelivering ETA retries before they fire.
> 
> Updates `BaseCodecovTask.retry()` to automatically clamp any explicit `countdown` based on the task hard time limit (with a fallback when hard limits exceed the visibility window), and aligns `LockManager`’s lock-acquisition backoff cap to the same shared limit. Tests are expanded/updated to validate clamping, misconfiguration fallback, and the new lock backoff cap; remaining task-file changes are formatting-only around `self.retry()` calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18d106ebd3945217c293c216aa2c1c926259970b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->