### PR TITLE
catch TorngitRefreshTokenFailedError without retrying

### DIFF
--- a/apps/worker/tasks/base.py
+++ b/apps/worker/tasks/base.py
@@ -43,7 +43,7 @@ from shared.django_apps.upload_breadcrumbs.models import (
 )
 from shared.metrics import Counter, Histogram
 from shared.torngit.base import TorngitBaseAdapter
-from shared.torngit.exceptions import TorngitClientError, TorngitRepoNotFoundError
+from shared.torngit.exceptions import TorngitClientError, TorngitRefreshTokenFailedError, TorngitRepoNotFoundError
 from shared.typings.torngit import AdditionalData
 from shared.utils.sentry import current_sentry_trace_id
 
@@ -636,6 +636,18 @@ class BaseCodecovTask(celery_app.Task):
             log.warning(
                 "Unable to reach git provider because this specific bot/integration can't see that repository",
                 extra={"repoid": repository.repoid},
+            )
+        except TorngitRefreshTokenFailedError:
+            if commit:
+                self._call_upload_breadcrumb_task(
+                    commit_sha=commit.commitid,
+                    repo_id=repository.repoid,
+                    error=Errors.GIT_CLIENT_ERROR,
+                )
+            log.warning(
+                "Unable to refresh git provider token",
+                extra={"repoid": repository.repoid},
+                exc_info=True,
             )
         except TorngitClientError:
             if commit:

--- a/apps/worker/tasks/tests/unit/test_base.py
+++ b/apps/worker/tasks/tests/unit/test_base.py
@@ -28,7 +28,7 @@ from shared.celery_config import (
 )
 from shared.django_apps.upload_breadcrumbs.models import BreadcrumbData, Errors
 from shared.plan.constants import PlanName
-from shared.torngit.exceptions import TorngitClientError
+from shared.torngit.exceptions import TorngitClientError, TorngitRefreshTokenFailedError
 from tasks.base import BaseCodecovRequest, BaseCodecovTask
 from tasks.base import celery_app as base_celery_app
 from tests.helpers import mock_all_plans_and_tiers
@@ -406,6 +406,35 @@ class TestBaseCodecovTask:
         mock_commit = mocker.MagicMock()
         mock_commit.commitid = "abc123"
         task.get_repo_provider_service(mock_repo, commit=mock_commit)
+        mock_self_app.tasks[
+            upload_breadcrumb_task_name
+        ].apply_async.assert_called_once_with(
+            kwargs={
+                "commit_sha": mock_commit.commitid,
+                "repo_id": mock_repo.repoid,
+                "breadcrumb_data": BreadcrumbData(
+                    error=Errors.GIT_CLIENT_ERROR,
+                ),
+                "upload_ids": [],
+                "sentry_trace_id": None,
+            }
+        )
+
+    def test_get_repo_provider_service_refresh_token_failed(
+        self, mocker, mock_self_app
+    ):
+        mocker.patch(
+            "tasks.base.get_repo_provider_service",
+            side_effect=TorngitRefreshTokenFailedError("400 Bad Request"),
+        )
+
+        task = BaseCodecovTask()
+        mock_repo = mocker.MagicMock()
+        mock_repo.repoid = 8
+        mock_commit = mocker.MagicMock()
+        mock_commit.commitid = "abc123"
+        result = task.get_repo_provider_service(mock_repo, commit=mock_commit)
+        assert result is None
         mock_self_app.tasks[
             upload_breadcrumb_task_name
         ].apply_async.assert_called_once_with(


### PR DESCRIPTION
## Summary

- `TorngitRefreshTokenFailedError` was not caught in `BaseCodecovTask.get_repo_provider_service`, causing Celery to retry the task indefinitely on token refresh failures (e.g. 400 Bad Request from GitLab OAuth)
- Retrying is actively harmful: GitLab's refresh token reuse detection invalidates the entire token family if the same refresh token is submitted twice, turning a recoverable failure into a permanent one
- Added an explicit catch with no retry, matching the existing `TorngitClientError` pattern

## Root cause

`TorngitRefreshTokenFailedError` inherits from `TorngitError`, not `TorngitClientError`, so it bypassed the existing clean-exit handler. `TorngitCantRefreshTokenError` (the "no refresh token present" case) was already handled correctly via `TorngitClientError`.

## Test plan

- [ ] `test_get_repo_provider_service_refresh_token_failed` — verifies exception is caught, returns `None`, breadcrumb task called with `GIT_CLIENT_ERROR`, no retry raised
- [ ] Full `TestBaseCodecovTask` class passes (22 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, targeted change to worker error handling that prevents infinite Celery retries on git-provider token refresh failures while keeping existing breadcrumb/error reporting behavior.
> 
> **Overview**
> `BaseCodecovTask.get_repo_provider_service` now explicitly catches `TorngitRefreshTokenFailedError` and exits cleanly (returning `None`) instead of letting the task fail and be retried indefinitely.
> 
> On refresh-token failure it records a `GIT_CLIENT_ERROR` breadcrumb and logs a warning with stack trace, and a new unit test asserts this behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1eba83fbf2e9877b9ddfa7966042310b1aad0753. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->