### PR TITLE
adding compression migration

### DIFF
--- a/libs/shared/shared/django_apps/ta_timeseries/migrations/0038_add_compression.py
+++ b/libs/shared/shared/django_apps/ta_timeseries/migrations/0038_add_compression.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+from shared.django_apps.migration_utils import RiskyRunSQL
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ta_timeseries", "0037_testrun_ta_ts_repo_id_outcome_time_idx"),
+    ]
+
+    operations = [
+        RiskyRunSQL(
+            """
+            ALTER TABLE ta_timeseries_testrun SET (
+                timescaledb.compress,
+                timescaledb.compress_segmentby = 'repo_id',
+                timescaledb.compress_orderby = 'timestamp DESC'
+            );
+            """,
+            reverse_sql="ALTER TABLE ta_timeseries_testrun SET (timescaledb.compress = false);",
+        ),
+        RiskyRunSQL(
+            "SELECT add_compression_policy('ta_timeseries_testrun', INTERVAL '7 days');",
+            reverse_sql="SELECT remove_compression_policy('ta_timeseries_testrun');",
+        ),
+    ]


### PR DESCRIPTION
<!-- Describe your PR here. -->

Adding Timescale Compression for data greater then 7 days

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a production database migration that enables TimescaleDB compression and a 7-day compression policy on `ta_timeseries_testrun`, which can impact storage/performance and requires Timescale features to be available in target environments.
> 
> **Overview**
> Enables TimescaleDB native compression for the `ta_timeseries_testrun` hypertable, segmenting by `repo_id` and ordering by `timestamp DESC`.
> 
> Adds a compression policy to automatically compress chunks older than **7 days**, with reverse SQL to disable compression and remove the policy (implemented via `RiskyRunSQL`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd75bc3737ca873f00fbfd632b3bfaa4761436a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->