### PR TITLE
fix(worker): cap BA processor lock retry countdown to visibility timeout

### DIFF
--- a/apps/worker/tasks/bundle_analysis_processor.py
+++ b/apps/worker/tasks/bundle_analysis_processor.py
@@ -153,7 +153,11 @@ class BundleAnalysisProcessorTask(
                     retry_num=self.request.retries,
                 )
                 return previous_result
-            self.retry(max_retries=self.max_retries, countdown=retry.countdown)
+            # Cap at 870s (30s below the 900s Redis visibility timeout) so the
+            # message is never held unacked longer than the visibility window.
+            self.retry(
+                max_retries=self.max_retries, countdown=min(retry.countdown, 870)
+            )
 
     @staticmethod
     def _ba_report_already_exists(db_session, repoid: int, commitid: str) -> bool:


### PR DESCRIPTION
BA retry cap patch. current visibility timeout at 900s, set a hard cap of slightly lower, and a regression test


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to retry timing in the worker, but it can affect task scheduling/throughput if the cap changes retry backoff behavior under lock contention.
> 
> **Overview**
> Prevents `BundleAnalysisProcessorTask` from retrying with a `countdown` longer than the Redis visibility window by capping `LockRetry` backoff to 870s before calling `self.retry`.
> 
> This reduces the chance of messages being held unacked past visibility timeout during bundle analysis lock contention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab35a2fc016a83630d0cc18291713261384432ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->