### PR TITLE
feat(api): redis_admin app — view Redis queue keys in admin (M1)

### DIFF
--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     "django_prometheus",
     "psqlextra",
     "django_better_admin_arrayfield",
+    "redis_admin",
     # Shared Models
     "shared.django_apps.rollouts",
     "shared.django_apps.user_measurements",

--- a/apps/codecov-api/redis_admin/__init__.py
+++ b/apps/codecov-api/redis_admin/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "redis_admin.apps.RedisAdminConfig"

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -1,0 +1,30 @@
+"""Django admin registration for the redis_admin app.
+
+Milestone 1 ships a read-only changelist of every Redis key in the supported
+families. Subsequent milestones add filters, search, item drill-in, and
+clear actions on top of this same `ModelAdmin`.
+"""
+
+from django.contrib import admin
+from django.http import HttpRequest
+
+from .models import RedisQueue
+
+
+@admin.register(RedisQueue)
+class RedisQueueAdmin(admin.ModelAdmin):
+    list_display = ("name", "family", "redis_type", "depth", "ttl_seconds")
+    list_per_page = 50
+    # SCAN-based count is approximate and we do not want the admin to issue a
+    # second pass just to render "X of Y" in the toolbar.
+    show_full_result_count = False
+    ordering = ("-depth", "name")
+
+    def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
+        return bool(request.user and request.user.is_staff)
+
+    def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False

--- a/apps/codecov-api/redis_admin/apps.py
+++ b/apps/codecov-api/redis_admin/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class RedisAdminConfig(AppConfig):
+    name = "redis_admin"
+    verbose_name = "Redis Queues"
+    default_auto_field = "django.db.models.BigAutoField"

--- a/apps/codecov-api/redis_admin/conn.py
+++ b/apps/codecov-api/redis_admin/conn.py
@@ -1,0 +1,34 @@
+"""Single entry point for Redis access from the redis_admin app.
+
+By default we hand out the same connection used everywhere else in the
+codebase via `shared.helpers.redis.get_redis_connection`. Tests and operators
+can swap in a custom factory by setting `REDIS_ADMIN_CONNECTION_FACTORY` to a
+dotted path of a zero-arg callable returning a `redis.Redis`-compatible
+instance.
+"""
+
+from collections.abc import Callable
+from importlib import import_module
+from typing import Any
+
+from django.conf import settings
+
+from shared.helpers.redis import get_redis_connection
+
+
+def _resolve_factory(dotted: str) -> Callable[[], Any]:
+    module_path, _, attr = dotted.rpartition(".")
+    if not module_path:
+        raise ValueError(
+            f"REDIS_ADMIN_CONNECTION_FACTORY must be a dotted path, got {dotted!r}"
+        )
+    module = import_module(module_path)
+    return getattr(module, attr)
+
+
+def get_connection() -> Any:
+    factory_path = getattr(settings, "REDIS_ADMIN_CONNECTION_FACTORY", None)
+    if factory_path:
+        factory = _resolve_factory(factory_path)
+        return factory()
+    return get_redis_connection()

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -1,0 +1,128 @@
+"""Registry of Redis key "families" surfaced in the admin.
+
+A `Family` describes a Redis key pattern owned by some part of the system,
+how to recognise it, and (in later milestones) how to extract repo/commit
+metadata and decode individual items.
+
+Milestone 1 only needs the bare minimum to enumerate keys and report their
+type and depth in the admin changelist, so we ship two representative
+families today (`uploads` and `ta_flake_key`). Subsequent milestones extend
+this module rather than touching the queryset/admin layers.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import Literal
+
+from . import conn as _conn
+from . import settings as redis_admin_settings
+
+log = logging.getLogger(__name__)
+
+
+RedisType = Literal["list", "set", "hash", "string"]
+
+
+@dataclass(frozen=True)
+class ParsedKey:
+    """Structured view of a Redis key once we know which family it belongs to.
+
+    All fields are optional because not every family encodes every dimension
+    in its key. Later milestones populate `repoid`, `commitid`, etc. from the
+    family-specific parser; in M1 we only need `family` so the admin can show
+    the family column.
+    """
+
+    family: str
+    repoid: int | None = None
+    commitid: str | None = None
+    report_type: str | None = None
+    upload_id: str | None = None
+
+
+def _parse_uploads_key(key: str) -> ParsedKey:
+    # Shape: uploads/{repoid}/{commitid}[/{report_type}]
+    return ParsedKey(family="uploads")
+
+
+def _parse_ta_flake_key(key: str) -> ParsedKey:
+    # Shape: ta_flake_key:{repoid}
+    return ParsedKey(family="ta_flake_key")
+
+
+@dataclass(frozen=True)
+class Family:
+    name: str
+    scan_pattern: str
+    redis_type: RedisType
+    parse_key: Callable[[str], ParsedKey]
+    fixed_keys: tuple[str, ...] = field(default_factory=tuple)
+
+
+FAMILIES: tuple[Family, ...] = (
+    Family(
+        name="uploads",
+        scan_pattern="uploads/*",
+        redis_type="list",
+        parse_key=_parse_uploads_key,
+    ),
+    Family(
+        name="ta_flake_key",
+        scan_pattern="ta_flake_key:*",
+        redis_type="list",
+        parse_key=_parse_ta_flake_key,
+    ),
+)
+
+
+def _decode(value: bytes | str) -> str:
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.decode("utf-8", errors="replace")
+    return value
+
+
+def iter_keys(redis=None) -> Iterator[tuple[str, Family]]:
+    """Yield `(key, family)` pairs for every known family.
+
+    Uses Redis SCAN with a per-call `COUNT` and a hard cap on the total number
+    of keys returned across all families so a runaway keyspace cannot block
+    Redis. Always returns the matching `Family` so callers do not have to
+    re-classify the key.
+    """
+
+    redis = redis if redis is not None else _conn.get_connection()
+    seen = 0
+    cap = redis_admin_settings.MAX_SCAN_KEYS
+    count = redis_admin_settings.SCAN_COUNT
+
+    for family in FAMILIES:
+        for key in family.fixed_keys:
+            if redis.exists(key):
+                yield key, family
+                seen += 1
+                if seen >= cap:
+                    log.warning(
+                        "redis_admin: hit MAX_SCAN_KEYS=%s while iterating fixed keys",
+                        cap,
+                    )
+                    return
+
+        if not family.scan_pattern:
+            continue
+
+        for raw_key in redis.scan_iter(match=family.scan_pattern, count=count):
+            yield _decode(raw_key), family
+            seen += 1
+            if seen >= cap:
+                log.warning(
+                    "redis_admin: hit MAX_SCAN_KEYS=%s while scanning %s",
+                    cap,
+                    family.scan_pattern,
+                )
+                return

--- a/apps/codecov-api/redis_admin/models.py
+++ b/apps/codecov-api/redis_admin/models.py
@@ -1,0 +1,45 @@
+"""Unmanaged Django models that the admin renders from Redis.
+
+These have `Meta.managed = False` so Django never tries to create or migrate
+a database table for them. Field declarations exist purely to give the admin
+something to introspect for `list_display`, ordering, and search machinery.
+Instances are constructed by `redis_admin.queryset.RedisQueueQuerySet` from
+Redis SCAN results and are never saved.
+"""
+
+from django.db import models
+
+from .queryset import RedisQueueQuerySet
+
+
+class RedisQueueManager(models.Manager):
+    def get_queryset(self) -> RedisQueueQuerySet:  # type: ignore[override]
+        return RedisQueueQuerySet(self.model)
+
+
+class RedisQueue(models.Model):
+    name = models.CharField(primary_key=True, max_length=512)
+    family = models.CharField(max_length=64)
+    redis_type = models.CharField(max_length=16)
+    depth = models.PositiveIntegerField(default=0)
+    ttl_seconds = models.IntegerField(null=True, blank=True)
+
+    objects = RedisQueueManager()
+
+    class Meta:
+        managed = False
+        app_label = "redis_admin"
+        verbose_name = "Redis queue"
+        verbose_name_plural = "Redis queues"
+        # Required by Django even for unmanaged models so makemigrations stays
+        # quiet; these have no real DB table.
+        default_permissions = ("view",)
+
+    def __str__(self) -> str:
+        return self.name
+
+    def save(self, *args, **kwargs):  # pragma: no cover - safety net
+        raise RuntimeError("RedisQueue is read-only; saves are not supported.")
+
+    def delete(self, *args, **kwargs):  # pragma: no cover - milestone 5
+        raise NotImplementedError("RedisQueue.delete arrives in milestone 5.")

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -1,0 +1,177 @@
+"""Fake QuerySet that lets Django admin render Redis keys.
+
+Inspired by `wolph/django-redis-admin`. The Django admin's changelist talks to
+its model via a small set of QuerySet methods: `iterator`, `count`,
+`__getitem__` (slicing for pagination), `_clone`/`all`/`none`/`using`, and
+`order_by`. This module implements just those, dispatching to Redis under the
+hood so the model needs no real database table.
+
+Milestone 1 keeps the surface small: enumeration, count, slicing, in-memory
+ordering. `filter`/`exclude`/`get`/`delete` deliberately raise
+`NotImplementedError` so future milestones know exactly what to wire in.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from . import conn as _conn
+from .families import Family, iter_keys
+
+
+def _build_redis_queue(model, key: str, family: Family, redis) -> Any:
+    """Materialize a single `RedisQueue` model instance from Redis."""
+
+    redis_type = family.redis_type
+    if redis_type == "list":
+        depth = redis.llen(key)
+    elif redis_type == "set":
+        depth = redis.scard(key)
+    elif redis_type == "hash":
+        depth = redis.hlen(key)
+    elif redis_type == "string":
+        # For a string we report 0 (no items to consume) but keep the entry so
+        # operators can see/clear it. STRLEN would be misleading as a "depth".
+        depth = 0
+    else:
+        depth = 0
+
+    ttl = redis.ttl(key)
+    # redis-py returns -2 if the key does not exist and -1 if it has no TTL.
+    # We surface "no TTL" as None in the admin to keep the column readable.
+    ttl_seconds = None if ttl is None or ttl < 0 else int(ttl)
+
+    return model(
+        name=key,
+        family=family.name,
+        redis_type=redis_type.upper(),
+        depth=int(depth or 0),
+        ttl_seconds=ttl_seconds,
+    )
+
+
+class RedisQueueQuerySet:
+    """Quacks like a Django QuerySet for the admin changelist."""
+
+    def __init__(self, model, *, ordering: tuple[str, ...] = ()) -> None:
+        self.model = model
+        self._ordering = ordering
+        self._result_cache: list | None = None
+
+    # ---- Cloning helpers --------------------------------------------------
+
+    def _clone(self, *, ordering: tuple[str, ...] | None = None) -> RedisQueueQuerySet:
+        return RedisQueueQuerySet(
+            self.model,
+            ordering=self._ordering if ordering is None else ordering,
+        )
+
+    def all(self) -> RedisQueueQuerySet:
+        return self._clone()
+
+    def none(self) -> RedisQueueQuerySet:
+        empty = self._clone()
+        empty._result_cache = []
+        return empty
+
+    def using(self, alias) -> RedisQueueQuerySet:
+        # Database alias has no meaning for a Redis-backed queryset; the
+        # admin still calls this so we accept and ignore it.
+        return self
+
+    # ---- Filtering / lookup (M3+) ----------------------------------------
+
+    def filter(self, *args, **kwargs) -> RedisQueueQuerySet:
+        if not args and not kwargs:
+            return self._clone()
+        raise NotImplementedError(
+            "redis_admin.RedisQueueQuerySet.filter is added in milestone 3"
+        )
+
+    def exclude(self, *args, **kwargs) -> RedisQueueQuerySet:
+        if not args and not kwargs:
+            return self._clone()
+        raise NotImplementedError(
+            "redis_admin.RedisQueueQuerySet.exclude is added in milestone 3"
+        )
+
+    def get(self, *args, **kwargs):
+        raise NotImplementedError(
+            "redis_admin.RedisQueueQuerySet.get is added in milestone 3"
+        )
+
+    # ---- Ordering --------------------------------------------------------
+
+    def order_by(self, *fields: str) -> RedisQueueQuerySet:
+        return self._clone(ordering=tuple(fields))
+
+    # ---- Materialization -------------------------------------------------
+
+    def _fetch_all(self) -> list:
+        if self._result_cache is not None:
+            return self._result_cache
+
+        redis = _conn.get_connection()
+        items = [
+            _build_redis_queue(self.model, key, family, redis)
+            for key, family in iter_keys(redis)
+        ]
+
+        for field in reversed(self._ordering):
+            reverse = field.startswith("-")
+            attr = field.lstrip("-")
+            items.sort(
+                key=lambda obj, attr=attr: getattr(obj, attr) or 0, reverse=reverse
+            )
+
+        self._result_cache = items
+        return items
+
+    def __iter__(self) -> Iterator:
+        return iter(self._fetch_all())
+
+    def iterator(self, chunk_size: int | None = None) -> Iterator:
+        # The admin sometimes calls `.iterator()`; honour it but materialize
+        # since the dataset is bounded by MAX_SCAN_KEYS.
+        return iter(self._fetch_all())
+
+    def __len__(self) -> int:
+        return len(self._fetch_all())
+
+    def count(self) -> int:
+        return len(self._fetch_all())
+
+    def __getitem__(self, item):
+        return self._fetch_all()[item]
+
+    def __bool__(self) -> bool:
+        return bool(self._fetch_all())
+
+    # ---- Mutations (M5) --------------------------------------------------
+
+    def delete(self):
+        raise NotImplementedError(
+            "redis_admin.RedisQueueQuerySet.delete is added in milestone 5"
+        )
+
+    # ---- Admin compatibility shims ---------------------------------------
+
+    @property
+    def query(self):
+        # The admin occasionally pokes at `.query` (e.g. for ordering hints);
+        # returning a tiny stub keeps `ChangeList.get_ordering` happy.
+        class _Query:
+            order_by = self._ordering
+            select_related = False
+            distinct = False
+
+        return _Query()
+
+    @property
+    def ordered(self) -> bool:
+        return bool(self._ordering)
+
+    @property
+    def db(self) -> str:
+        return "default"

--- a/apps/codecov-api/redis_admin/settings.py
+++ b/apps/codecov-api/redis_admin/settings.py
@@ -1,0 +1,24 @@
+"""Default settings for the redis_admin app.
+
+Override any of these by setting `REDIS_ADMIN_<NAME>` in your Django settings,
+or expose a custom Redis client via `REDIS_ADMIN_CONNECTION_FACTORY` (a dotted
+path to a callable that returns a `redis.Redis`-compatible instance).
+"""
+
+from django.conf import settings
+
+# Hard cap on the number of keys we will visit during a single SCAN sweep across
+# all family patterns. Protects Redis from runaway scans if the keyspace grows
+# unexpectedly large.
+MAX_SCAN_KEYS: int = getattr(settings, "REDIS_ADMIN_MAX_SCAN_KEYS", 10_000)
+
+# COUNT hint passed to each Redis SCAN call. Larger values trade per-call CPU
+# for fewer round trips; 500 is a balanced default for a single-shard instance.
+SCAN_COUNT: int = getattr(settings, "REDIS_ADMIN_SCAN_COUNT", 500)
+
+# Page size for the items-in-a-queue admin view (added in milestone 2).
+ITEM_PAGE_SIZE: int = getattr(settings, "REDIS_ADMIN_ITEM_PAGE_SIZE", 100)
+
+# Maximum bytes of a single Redis value rendered in the admin item view; values
+# larger than this are truncated with a "(... N bytes truncated)" suffix.
+MAX_DECODE_BYTES: int = getattr(settings, "REDIS_ADMIN_MAX_DECODE_BYTES", 4_096)

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -1,0 +1,76 @@
+"""End-to-end smoke test for the M1 read-only Redis admin changelist.
+
+Populates a fakeredis instance with one key from each currently registered
+family, logs into the Django admin as a staff user, and asserts the
+changelist renders both keys with their correct `family` and `depth`.
+
+Acts as the milestone gate: if these tests pass the M1 deliverable
+("view Redis keys in admin") works end to end. Requires the test database
+to be available (Postgres + Timescale), so these run as part of the regular
+api test suite rather than as standalone unit tests.
+"""
+
+from __future__ import annotations
+
+import fakeredis
+import pytest
+from django.test import TestCase
+
+from redis_admin import conn as redis_admin_conn
+from shared.django_apps.codecov_auth.tests.factories import UserFactory
+from utils.test_utils import Client
+
+
+class RedisAdminSmokeTest(TestCase):
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+
+        self.user = UserFactory(is_staff=True)
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def test_changelist_lists_known_redis_keys(self):
+        self.redis.rpush("uploads/123/abc123", '{"upload_id": 1}')
+        self.redis.rpush("uploads/123/abc123", '{"upload_id": 2}')
+        self.redis.rpush("ta_flake_key:123", "abc123")
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200, response.content[:500]
+        body = response.content.decode("utf-8", errors="replace")
+        assert "uploads/123/abc123" in body
+        assert "ta_flake_key:123" in body
+        assert "uploads" in body
+        assert "ta_flake_key" in body
+
+    def test_changelist_orders_by_depth_descending(self):
+        self.redis.rpush("ta_flake_key:1", "a")
+        for i in range(5):
+            self.redis.rpush("uploads/2/deadbeef", f'{{"i": {i}}}')
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        uploads_pos = body.find("uploads/2/deadbeef")
+        flake_pos = body.find("ta_flake_key:1")
+        assert uploads_pos != -1 and flake_pos != -1
+        # Default ordering is `-depth`, so the deeper queue must appear first.
+        assert uploads_pos < flake_pos
+
+
+@pytest.mark.django_db
+def test_non_staff_user_is_redirected_from_redis_admin():
+    user = UserFactory(is_staff=False)
+    client = Client()
+    client.force_login(user)
+
+    response = client.get("/admin/redis_admin/redisqueue/")
+
+    # Non-staff hits the admin login redirect.
+    assert response.status_code in (302, 403)

--- a/apps/codecov-api/redis_admin/tests/test_queryset.py
+++ b/apps/codecov-api/redis_admin/tests/test_queryset.py
@@ -1,0 +1,112 @@
+"""Unit tests for `RedisQueueQuerySet` against an in-process fakeredis.
+
+These do not touch Django auth or the admin URL routes, so they run without
+the Postgres test database. The end-to-end admin smoke tests live in
+`test_admin_smoke.py` and are gated on the test DB being available.
+"""
+
+from __future__ import annotations
+
+import fakeredis
+import pytest
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin import families as redis_admin_families
+from redis_admin import settings as redis_admin_settings
+from redis_admin.models import RedisQueue
+
+
+@pytest.fixture
+def patched_redis(monkeypatch) -> fakeredis.FakeStrictRedis:
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(redis_admin_conn, "get_connection", lambda: server)
+    return server
+
+
+def test_queryset_lists_uploads_and_flake_keys(patched_redis):
+    patched_redis.rpush("uploads/1/abc", '{"upload_id": 1}')
+    patched_redis.rpush("uploads/1/abc", '{"upload_id": 2}')
+    patched_redis.rpush("ta_flake_key:9", "abc")
+
+    rows = list(RedisQueue.objects.all())
+
+    by_name = {row.name: row for row in rows}
+    assert set(by_name) == {"uploads/1/abc", "ta_flake_key:9"}
+    assert by_name["uploads/1/abc"].family == "uploads"
+    assert by_name["uploads/1/abc"].redis_type == "LIST"
+    assert by_name["uploads/1/abc"].depth == 2
+    assert by_name["ta_flake_key:9"].family == "ta_flake_key"
+    assert by_name["ta_flake_key:9"].depth == 1
+
+
+def test_queryset_count_matches_iter(patched_redis):
+    patched_redis.rpush("uploads/1/aa", "x")
+    patched_redis.rpush("uploads/2/bb", "x")
+    patched_redis.rpush("ta_flake_key:5", "x")
+
+    assert RedisQueue.objects.all().count() == 3
+
+
+def test_queryset_supports_slicing_for_admin_pagination(patched_redis):
+    for i in range(5):
+        patched_redis.rpush(f"uploads/1/c{i}", "x")
+
+    qs = RedisQueue.objects.all().order_by("name")
+    page = qs[0:2]
+    assert len(page) == 2
+    assert all(isinstance(item, RedisQueue) for item in page)
+
+
+def test_queryset_orders_by_depth_descending(patched_redis):
+    patched_redis.rpush("ta_flake_key:1", "x")
+    for i in range(4):
+        patched_redis.rpush("uploads/2/deep", f"x{i}")
+
+    rows = list(RedisQueue.objects.all().order_by("-depth"))
+
+    assert rows[0].name == "uploads/2/deep"
+    assert rows[0].depth == 4
+
+
+def test_queryset_filter_with_no_args_is_a_clone(patched_redis):
+    patched_redis.rpush("uploads/1/aa", "x")
+    assert RedisQueue.objects.filter().count() == 1
+
+
+def test_queryset_filter_with_kwargs_raises_until_milestone3(patched_redis):
+    with pytest.raises(NotImplementedError):
+        list(RedisQueue.objects.filter(family="uploads"))
+
+
+def test_queryset_delete_raises_until_milestone5(patched_redis):
+    patched_redis.rpush("uploads/1/aa", "x")
+    with pytest.raises(NotImplementedError):
+        RedisQueue.objects.all().delete()
+
+
+def test_queryset_returns_none_ttl_when_no_ttl_set(patched_redis):
+    patched_redis.rpush("uploads/1/no-ttl", "x")
+    [row] = list(RedisQueue.objects.all())
+    assert row.ttl_seconds is None
+
+
+def test_queryset_returns_positive_ttl_when_set(patched_redis):
+    patched_redis.rpush("uploads/1/with-ttl", "x")
+    patched_redis.expire("uploads/1/with-ttl", 600)
+    [row] = list(RedisQueue.objects.all())
+    assert row.ttl_seconds is not None
+    assert 0 < row.ttl_seconds <= 600
+
+
+def test_max_scan_keys_limits_result_set(patched_redis, settings, monkeypatch):
+    settings.REDIS_ADMIN_MAX_SCAN_KEYS = 3
+    # `families.iter_keys` reads MAX_SCAN_KEYS off the redis_admin settings
+    # module, which captured `getattr(settings, "REDIS_ADMIN_MAX_SCAN_KEYS")`
+    # at import time. Patch the captured value directly for this test.
+    monkeypatch.setattr(redis_admin_settings, "MAX_SCAN_KEYS", 3)
+
+    for i in range(5):
+        patched_redis.rpush(f"uploads/1/k{i}", "x")
+
+    keys = list(redis_admin_families.iter_keys(patched_redis))
+    assert len(keys) == 3


### PR DESCRIPTION
## Summary

First milestone of the [Redis admin queue browser plan](.cursor/plans/redis_admin_queue_browser_50236495.plan.md): a new `redis_admin` Django app that surfaces Redis-backed queues in the existing `/admin/` site so operators can spot backed-up queues without shelling into Redis.

This is the **smallest shippable vertical slice** — read-only enumeration of two representative key families (`uploads/*`, `ta_flake_key:*`) with their type, depth, and TTL. Filters, item drill-in, repo/commit grouping, more families (Celery broker, locks, intermediate report state), and clear actions land in subsequent milestones (M2–M6).

### Example of item in queue
<img width="1348" height="199" alt="image" src="https://github.com/user-attachments/assets/51c59908-c5f3-4ee1-b8a7-91183acc0a7a" />


### What's in this PR

- `apps/codecov-api/redis_admin/` — new Django app (no migrations: `Meta.managed = False`)
  - `families.py` — registry of key patterns with SCAN/parse rules, `iter_keys()` bounded by `REDIS_ADMIN_MAX_SCAN_KEYS` (10k) and `REDIS_ADMIN_SCAN_COUNT` (500)
  - `queryset.py` — fake `QuerySet` that translates admin calls (`__iter__`, `count`, slicing, `order_by`) into Redis SCAN/TYPE/LLEN/SCARD/HLEN/TTL. `filter`/`get`/`delete` raise `NotImplementedError` until later milestones, with the milestone called out in the message.
  - `models.py` — `RedisQueue` unmanaged model (name / family / redis_type / depth / ttl_seconds)
  - `admin.py` — `RedisQueueAdmin` (read-only, staff-gated, `show_full_result_count = False`)
  - `conn.py` — single `get_connection()` entry point, defaults to `shared.helpers.redis.get_redis_connection()`, overridable via `REDIS_ADMIN_CONNECTION_FACTORY` setting
  - `settings.py` — defaults for the four `REDIS_ADMIN_*` knobs
- `INSTALLED_APPS += \"redis_admin\"` in `codecov/settings_base.py`
- 13 tests, all green:
  - `tests/test_queryset.py` — 10 fakeredis-only unit tests (no DB)
  - `tests/test_admin_smoke.py` — 3 end-to-end tests through `/admin/redis_admin/redisqueue/` covering happy path, default `-depth` ordering, and non-staff redirect

### Safety / observability hooks already in place

- SCAN is hard-capped (no `KEYS *`); cap is logged at WARNING when hit
- All Redis access funnels through one factory so future Sentry tracing wraps a single call site
- Read-only at the model layer (`save`/`delete` raise) and admin layer (`has_add_permission` / `has_delete_permission` return False) — clear actions explicitly arrive in M5 with dry-run + LogEntry auditing

### What's intentionally NOT in this PR

- No `list_filter`, `search_fields`, item drill-in (M2/M3)
- No Celery broker / locks / intermediate-report families (M4)
- No delete actions (M5/M6)
- No README — added in M7 once the surface area is final

## Test plan

- [x] `pytest redis_admin/tests/` — 13 passing locally against fakeredis + Postgres + Timescale
- [x] `ruff check` and `ruff format` clean
- [x] Verify in CI that the existing api test suite still passes
- [x] Manual smoke: log in as staff at `/admin/redis_admin/redisqueue/` against a populated dev Redis and confirm rows render with non-zero depth

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0207e5523d054d2b53d78d7e4e8d346a8bc75177. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->