### PR TITLE
feat(api): redis_admin per-queue items view (M2)

### DIFF
--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -1,22 +1,34 @@
 """Django admin registration for the redis_admin app.
 
 Milestone 1 ships a read-only changelist of every Redis key in the supported
-families. Subsequent milestones add filters, search, item drill-in, and
-clear actions on top of this same `ModelAdmin`.
+families. Milestone 2 adds a per-queue items view linked from each row; you
+can click "items" on a queue and land on `?queue_name__exact=<key>` filtered
+to that queue's contents. Subsequent milestones add filters, search,
+repo/commit grouping, and clear actions on top of these same `ModelAdmin`s.
 """
 
-from django.contrib import admin
-from django.http import HttpRequest
+from urllib.parse import urlencode
 
-from .models import RedisQueue
+from django.contrib import admin, messages
+from django.http import HttpRequest
+from django.urls import reverse
+from django.utils.html import format_html
+
+from . import settings as redis_admin_settings
+from .models import RedisQueue, RedisQueueItem
 
 
 @admin.register(RedisQueue)
 class RedisQueueAdmin(admin.ModelAdmin):
-    list_display = ("name", "family", "redis_type", "depth", "ttl_seconds")
+    list_display = (
+        "name",
+        "family",
+        "redis_type",
+        "depth",
+        "ttl_seconds",
+        "items_link",
+    )
     list_per_page = 50
-    # SCAN-based count is approximate and we do not want the admin to issue a
-    # second pass just to render "X of Y" in the toolbar.
     show_full_result_count = False
     ordering = ("-depth", "name")
 
@@ -28,3 +40,58 @@ class RedisQueueAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
+
+    @admin.display(description="items")
+    def items_link(self, obj: RedisQueue) -> str:
+        url = reverse("admin:redis_admin_redisqueueitem_changelist")
+        query = urlencode({"queue_name__exact": obj.name})
+        return format_html('<a href="{}?{}">view items</a>', url, query)
+
+
+@admin.register(RedisQueueItem)
+class RedisQueueItemAdmin(admin.ModelAdmin):
+    list_display = ("index_or_field", "raw_value_truncated")
+    list_per_page = redis_admin_settings.ITEM_PAGE_SIZE
+    show_full_result_count = False
+
+    def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
+        # No detail/edit page yet; M5 wires up per-item delete actions.
+        return False
+
+    def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_view_permission(self, request: HttpRequest, obj=None) -> bool:
+        return bool(request.user and request.user.is_staff)
+
+    def lookup_allowed(self, lookup, value) -> bool:
+        if lookup == "queue_name__exact":
+            return True
+        return super().lookup_allowed(lookup, value)
+
+    def get_queryset(self, request: HttpRequest):
+        # Bypass ChangeList's automatic `.filter(**lookup_params)` plumbing so
+        # the queue_name filter survives even when no list_filter is declared.
+        queryset = self.model._default_manager.all()
+        queue_name = request.GET.get("queue_name__exact")
+        if queue_name:
+            queryset = queryset.filter(queue_name__exact=queue_name)
+        return queryset
+
+    def changelist_view(self, request: HttpRequest, extra_context=None):
+        if not request.GET.get("queue_name__exact"):
+            messages.info(
+                request,
+                "Pick a queue from the Redis queues list (the 'view items' link) "
+                "to see its contents.",
+            )
+        return super().changelist_view(request, extra_context)
+
+    @admin.display(description="value")
+    def raw_value_truncated(self, obj: RedisQueueItem) -> str:
+        # Truncation already applied at queryset materialization time using
+        # MAX_DECODE_BYTES, so this column just renders what's there.
+        return obj.raw_value or ""

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -12,6 +12,7 @@ this module rather than touching the queryset/admin layers.
 
 from __future__ import annotations
 
+import fnmatch
 import logging
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
@@ -85,6 +86,24 @@ def _decode(value: bytes | str) -> str:
         except UnicodeDecodeError:
             return value.decode("utf-8", errors="replace")
     return value
+
+
+def find_family(key: str) -> Family | None:
+    """Return the `Family` whose `scan_pattern` matches `key`, or None.
+
+    Used by the item view: given a queue name pulled from a URL filter, look
+    up the family so we know its declared `redis_type` and (in later
+    milestones) its parser. We fall back to None for keys that don't belong
+    to any known family; the item queryset then asks Redis directly for the
+    type via `TYPE`.
+    """
+
+    for family in FAMILIES:
+        if key in family.fixed_keys:
+            return family
+        if family.scan_pattern and fnmatch.fnmatchcase(key, family.scan_pattern):
+            return family
+    return None
 
 
 def iter_keys(redis=None) -> Iterator[tuple[str, Family]]:

--- a/apps/codecov-api/redis_admin/models.py
+++ b/apps/codecov-api/redis_admin/models.py
@@ -9,12 +9,17 @@ Redis SCAN results and are never saved.
 
 from django.db import models
 
-from .queryset import RedisQueueQuerySet
+from .queryset import RedisItemQuerySet, RedisQueueQuerySet
 
 
 class RedisQueueManager(models.Manager):
     def get_queryset(self) -> RedisQueueQuerySet:  # type: ignore[override]
         return RedisQueueQuerySet(self.model)
+
+
+class RedisQueueItemManager(models.Manager):
+    def get_queryset(self) -> RedisItemQuerySet:  # type: ignore[override]
+        return RedisItemQuerySet(self.model)
 
 
 class RedisQueue(models.Model):
@@ -43,3 +48,35 @@ class RedisQueue(models.Model):
 
     def delete(self, *args, **kwargs):  # pragma: no cover - milestone 5
         raise NotImplementedError("RedisQueue.delete arrives in milestone 5.")
+
+
+class RedisQueueItem(models.Model):
+    """A single item inside a Redis-backed container.
+
+    `pk_token` is `<queue_name>#<index_or_field>`. For LIST items it's the
+    LRANGE index; later milestones extend it to the field name (HASH) or the
+    SHA1 of the value (SET) so each row in the admin still has a stable pk.
+    """
+
+    pk_token = models.CharField(primary_key=True, max_length=600)
+    queue_name = models.CharField(max_length=512)
+    index_or_field = models.CharField(max_length=128)
+    raw_value = models.TextField(blank=True)
+
+    objects = RedisQueueItemManager()
+
+    class Meta:
+        managed = False
+        app_label = "redis_admin"
+        verbose_name = "Redis queue item"
+        verbose_name_plural = "Redis queue items"
+        default_permissions = ("view",)
+
+    def __str__(self) -> str:
+        return f"{self.queue_name}[{self.index_or_field}]"
+
+    def save(self, *args, **kwargs):  # pragma: no cover - safety net
+        raise RuntimeError("RedisQueueItem is read-only; saves are not supported.")
+
+    def delete(self, *args, **kwargs):  # pragma: no cover - milestone 5
+        raise NotImplementedError("RedisQueueItem.delete arrives in milestone 5.")

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -1,14 +1,15 @@
-"""Fake QuerySet that lets Django admin render Redis keys.
+"""Fake QuerySets that let Django admin render Redis keys and their items.
 
 Inspired by `wolph/django-redis-admin`. The Django admin's changelist talks to
 its model via a small set of QuerySet methods: `iterator`, `count`,
 `__getitem__` (slicing for pagination), `_clone`/`all`/`none`/`using`, and
 `order_by`. This module implements just those, dispatching to Redis under the
-hood so the model needs no real database table.
+hood so the models need no real database table.
 
-Milestone 1 keeps the surface small: enumeration, count, slicing, in-memory
-ordering. `filter`/`exclude`/`get`/`delete` deliberately raise
-`NotImplementedError` so future milestones know exactly what to wire in.
+`RedisQueueQuerySet` — milestone 1, enumerates keys.
+`RedisItemQuerySet`  — milestone 2, enumerates items inside a single keyed
+                       container, gated on a `queue_name__exact=<key>` filter
+                       so we never accidentally scan every item in Redis.
 """
 
 from __future__ import annotations
@@ -17,7 +18,10 @@ from collections.abc import Iterator
 from typing import Any
 
 from . import conn as _conn
-from .families import Family, iter_keys
+from . import settings as redis_admin_settings
+from .families import Family, find_family, iter_keys
+
+_UNSET: Any = object()
 
 
 def _build_redis_queue(model, key: str, family: Family, redis) -> Any:
@@ -163,6 +167,201 @@ class RedisQueueQuerySet:
         # returning a tiny stub keeps `ChangeList.get_ordering` happy.
         class _Query:
             order_by = self._ordering
+            select_related = False
+            distinct = False
+
+        return _Query()
+
+    @property
+    def ordered(self) -> bool:
+        return bool(self._ordering)
+
+    @property
+    def db(self) -> str:
+        return "default"
+
+
+def _decode_value(value: bytes | str) -> str:
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _truncate_for_display(value: str, *, cap: int | None = None) -> str:
+    if cap is None:
+        cap = redis_admin_settings.MAX_DECODE_BYTES
+    if len(value) <= cap:
+        return value
+    truncated_count = len(value) - cap
+    return f"{value[:cap]}\u2026 (+{truncated_count} chars truncated)"
+
+
+class RedisItemQuerySet:
+    """Fake QuerySet for items inside a single Redis-backed container.
+
+    The admin URL `?queue_name__exact=<key>` is the only supported filter.
+    Without it, this queryset is empty by design so we never accidentally
+    fan out into every item in Redis.
+    """
+
+    def __init__(
+        self,
+        model,
+        *,
+        queue_name: str | None = None,
+        ordering: tuple[str, ...] = (),
+    ) -> None:
+        self.model = model
+        self.queue_name = queue_name
+        self._ordering = ordering
+
+    # ---- Cloning helpers --------------------------------------------------
+
+    def _clone(
+        self,
+        *,
+        queue_name: str | None = _UNSET,
+        ordering: tuple[str, ...] | None = None,
+    ) -> RedisItemQuerySet:
+        return RedisItemQuerySet(
+            self.model,
+            queue_name=self.queue_name if queue_name is _UNSET else queue_name,
+            ordering=self._ordering if ordering is None else ordering,
+        )
+
+    def all(self) -> RedisItemQuerySet:
+        return self._clone()
+
+    def none(self) -> RedisItemQuerySet:
+        return self._clone(queue_name=None)
+
+    def using(self, alias) -> RedisItemQuerySet:
+        return self
+
+    # ---- Filtering -------------------------------------------------------
+
+    def filter(self, *args, **kwargs) -> RedisItemQuerySet:
+        kwargs = dict(kwargs)
+        new_queue_name = self.queue_name
+        for key in ("queue_name__exact", "queue_name"):
+            if key in kwargs:
+                new_queue_name = kwargs.pop(key)
+        if args or kwargs:
+            raise NotImplementedError(
+                "RedisItemQuerySet.filter only supports queue_name[/__exact] in M2; "
+                f"got args={args!r}, kwargs={list(kwargs)!r}"
+            )
+        return self._clone(queue_name=new_queue_name)
+
+    def exclude(self, *args, **kwargs) -> RedisItemQuerySet:
+        if not args and not kwargs:
+            return self._clone()
+        raise NotImplementedError("RedisItemQuerySet.exclude is added in milestone 5")
+
+    def get(self, *args, **kwargs):
+        raise NotImplementedError("RedisItemQuerySet.get is added in milestone 5")
+
+    def order_by(self, *fields: str) -> RedisItemQuerySet:
+        return self._clone(ordering=tuple(fields))
+
+    # ---- Materialization -------------------------------------------------
+
+    def _resolve_type(self, redis) -> str | None:
+        """Best-effort lookup of the Redis type for `self.queue_name`."""
+
+        if not self.queue_name:
+            return None
+        family = find_family(self.queue_name)
+        if family is not None:
+            return family.redis_type
+        raw_type = redis.type(self.queue_name)
+        kind = _decode_value(raw_type) if raw_type is not None else "none"
+        if kind == "none":
+            return None
+        return kind
+
+    def _build_list_items(self, redis, start: int, raw_values: list) -> list:
+        return [
+            self.model(
+                pk_token=f"{self.queue_name}#{start + offset}",
+                queue_name=self.queue_name,
+                index_or_field=str(start + offset),
+                raw_value=_truncate_for_display(_decode_value(value)),
+            )
+            for offset, value in enumerate(raw_values)
+        ]
+
+    def _list_slice(self, redis, start: int, stop: int) -> list:
+        if stop <= start:
+            return []
+        cap = redis_admin_settings.ITEM_PAGE_SIZE
+        capped_stop = min(stop, start + cap)
+        raw = redis.lrange(self.queue_name, start, capped_stop - 1)
+        return self._build_list_items(redis, start, raw)
+
+    def count(self) -> int:
+        if not self.queue_name:
+            return 0
+        redis = _conn.get_connection()
+        kind = self._resolve_type(redis)
+        if kind == "list":
+            return int(redis.llen(self.queue_name) or 0)
+        # SET/HASH/STRING land in M4 alongside their families. For now they
+        # report 0 so the changelist renders cleanly.
+        return 0
+
+    def __len__(self) -> int:
+        return self.count()
+
+    def __iter__(self) -> Iterator:
+        if not self.queue_name:
+            return iter(())
+        return iter(self[: redis_admin_settings.ITEM_PAGE_SIZE])
+
+    def iterator(self, chunk_size: int | None = None) -> Iterator:
+        return iter(self)
+
+    def __bool__(self) -> bool:
+        return self.count() > 0
+
+    def __getitem__(self, item):
+        if not self.queue_name:
+            return [] if isinstance(item, slice) else None
+        redis = _conn.get_connection()
+        kind = self._resolve_type(redis)
+        if kind != "list":
+            return [] if isinstance(item, slice) else None
+        if isinstance(item, slice):
+            start = item.start or 0
+            stop = (
+                item.stop
+                if item.stop is not None
+                else start + redis_admin_settings.ITEM_PAGE_SIZE
+            )
+            return self._list_slice(redis, start, stop)
+        if isinstance(item, int):
+            page = self._list_slice(redis, item, item + 1)
+            if not page:
+                raise IndexError(item)
+            return page[0]
+        raise TypeError(f"unsupported index type: {type(item)!r}")
+
+    # ---- Mutations (M5) --------------------------------------------------
+
+    def delete(self):
+        raise NotImplementedError("RedisItemQuerySet.delete is added in milestone 5")
+
+    # ---- Admin compatibility shims ---------------------------------------
+
+    @property
+    def query(self):
+        ordering = self._ordering
+
+        class _Query:
+            order_by = ordering
             select_related = False
             distinct = False
 

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -74,3 +74,71 @@ def test_non_staff_user_is_redirected_from_redis_admin():
 
     # Non-staff hits the admin login redirect.
     assert response.status_code in (302, 403)
+
+
+class RedisQueueItemAdminSmokeTest(TestCase):
+    """End-to-end checks for the M2 per-queue items view."""
+
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+
+        self.user = UserFactory(is_staff=True)
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def test_queue_changelist_links_to_items_view(self):
+        self.redis.rpush("uploads/123/abc", "payload-1")
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # The items_link column emits a relative URL with the encoded key.
+        assert "/admin/redis_admin/redisqueueitem/" in body
+        assert "queue_name__exact=uploads%2F123%2Fabc" in body
+        assert "view items" in body
+
+    def test_items_changelist_without_queue_filter_shows_helper_message(self):
+        response = self.client.get("/admin/redis_admin/redisqueueitem/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "Pick a queue from the Redis queues list" in body
+
+    def test_items_changelist_with_queue_filter_renders_list_items(self):
+        for i in range(3):
+            self.redis.rpush("uploads/9/deadbeef", f"payload-{i}")
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueueitem/",
+            {"queue_name__exact": "uploads/9/deadbeef"},
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        for i in range(3):
+            assert f"payload-{i}" in body
+        # Index column shows 0/1/2 so users can identify positions.
+        assert ">0<" in body or ">0 " in body
+        assert ">2<" in body or ">2 " in body
+
+    def test_items_changelist_with_unknown_queue_renders_empty(self):
+        response = self.client.get(
+            "/admin/redis_admin/redisqueueitem/",
+            {"queue_name__exact": "no-such-queue"},
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Django admin's empty-results phrase varies a bit between releases;
+        # the important thing is no 500 and no unrelated payload leaks in.
+        assert (
+            "0 Redis queue items" in body
+            or "0 of 0" in body
+            or "no Redis" in body.lower()
+        )

--- a/apps/codecov-api/redis_admin/tests/test_item_queryset.py
+++ b/apps/codecov-api/redis_admin/tests/test_item_queryset.py
@@ -1,0 +1,130 @@
+"""Unit tests for `RedisItemQuerySet` against fakeredis (no DB needed)."""
+
+from __future__ import annotations
+
+import fakeredis
+import pytest
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin import settings as redis_admin_settings
+from redis_admin.models import RedisQueueItem
+
+
+@pytest.fixture
+def patched_redis(monkeypatch) -> fakeredis.FakeStrictRedis:
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(redis_admin_conn, "get_connection", lambda: server)
+    return server
+
+
+def test_unfiltered_queryset_is_empty(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    assert list(RedisQueueItem.objects.all()) == []
+    assert RedisQueueItem.objects.all().count() == 0
+
+
+def test_filter_by_queue_name_exact_returns_list_items(patched_redis):
+    patched_redis.rpush("uploads/1/abc", '{"upload_id": 1}')
+    patched_redis.rpush("uploads/1/abc", '{"upload_id": 2}')
+    patched_redis.rpush("uploads/1/abc", '{"upload_id": 3}')
+
+    qs = RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc")
+
+    rows = list(qs)
+    assert len(rows) == 3
+    assert [row.queue_name for row in rows] == ["uploads/1/abc"] * 3
+    assert [row.index_or_field for row in rows] == ["0", "1", "2"]
+    assert [row.raw_value for row in rows] == [
+        '{"upload_id": 1}',
+        '{"upload_id": 2}',
+        '{"upload_id": 3}',
+    ]
+    assert [row.pk_token for row in rows] == [
+        "uploads/1/abc#0",
+        "uploads/1/abc#1",
+        "uploads/1/abc#2",
+    ]
+
+
+def test_count_returns_real_llen_for_lists(patched_redis):
+    for i in range(7):
+        patched_redis.rpush("uploads/1/abc", f"x{i}")
+    assert RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc").count() == 7
+
+
+def test_slice_pagination_uses_lrange(patched_redis):
+    for i in range(10):
+        patched_redis.rpush("uploads/1/abc", f"x{i}")
+    qs = RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc")
+
+    page = qs[3:6]
+
+    assert [row.index_or_field for row in page] == ["3", "4", "5"]
+    assert [row.raw_value for row in page] == ["x3", "x4", "x5"]
+    assert [row.pk_token for row in page] == [
+        "uploads/1/abc#3",
+        "uploads/1/abc#4",
+        "uploads/1/abc#5",
+    ]
+
+
+def test_iter_caps_at_item_page_size(patched_redis, monkeypatch):
+    monkeypatch.setattr(redis_admin_settings, "ITEM_PAGE_SIZE", 5)
+    for i in range(20):
+        patched_redis.rpush("uploads/1/abc", f"x{i}")
+
+    qs = RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc")
+
+    # __iter__ honors ITEM_PAGE_SIZE so naive `list(qs)` cannot blow up.
+    rows = list(qs)
+    assert len(rows) == 5
+    # count() still reports the real length so paginator can navigate.
+    assert qs.count() == 20
+
+
+def test_long_value_is_truncated_with_suffix(patched_redis, monkeypatch):
+    monkeypatch.setattr(redis_admin_settings, "MAX_DECODE_BYTES", 16)
+    patched_redis.rpush("uploads/1/abc", "0123456789ABCDEFGHIJ")  # 20 chars
+
+    [row] = list(RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc"))
+
+    assert row.raw_value.startswith("0123456789ABCDEF")
+    assert "+4 chars truncated" in row.raw_value
+
+
+def test_unsupported_filter_kwarg_raises(patched_redis):
+    with pytest.raises(NotImplementedError):
+        RedisQueueItem.objects.filter(
+            queue_name__exact="uploads/1/abc", redis_type="LIST"
+        )
+
+
+def test_filter_by_unknown_queue_name_returns_empty(patched_redis):
+    assert list(RedisQueueItem.objects.filter(queue_name__exact="missing")) == []
+    assert RedisQueueItem.objects.filter(queue_name__exact="missing").count() == 0
+
+
+def test_set_and_hash_queues_report_zero_until_milestone_4(patched_redis):
+    # M2 only handles LIST. SET/HASH/STRING families arrive in M4; until then
+    # the item view reports zero so the changelist renders cleanly without
+    # blowing up.
+    patched_redis.sadd("upload-processing-state/1/abc", "x", "y")
+    patched_redis.hset("intermediate-report/1/abc", mapping={"a": "1", "b": "2"})
+
+    set_qs = RedisQueueItem.objects.filter(
+        queue_name__exact="upload-processing-state/1/abc"
+    )
+    hash_qs = RedisQueueItem.objects.filter(
+        queue_name__exact="intermediate-report/1/abc"
+    )
+    assert set_qs.count() == 0
+    assert hash_qs.count() == 0
+    assert list(set_qs) == []
+    assert list(hash_qs) == []
+
+
+def test_delete_raises_until_milestone_5(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    qs = RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc")
+    with pytest.raises(NotImplementedError):
+        qs.delete()


### PR DESCRIPTION
> Stacked on top of #885 (M1). Review and merge that one first; this PR's diff is just the M2-only delta.

## Summary

Second milestone of the [Redis admin queue browser plan](.cursor/plans/redis_admin_queue_browser_50236495.plan.md). Click \"view items\" on any row in the Redis queues changelist and you land on the new \`/admin/redis_admin/redisqueueitem/?queue_name__exact=<key>\` page that shows that queue's contents — index and value, paginated, with long values truncated at \`REDIS_ADMIN_MAX_DECODE_BYTES\`.

This delivers the M2 milestone goal: **\"click a queue row → see its items\"**.

### What's in this PR

- **\`RedisQueueItem\`** model (\`Meta.managed = False\`, no migration). PK is \`<queue_name>#<index_or_field>\` so every row has a stable identifier — used by M5 for per-item delete actions.
- **\`RedisItemQuerySet\`** — fake QuerySet gated on \`queue_name__exact=<key>\`. Without that filter, the queryset is empty by design so we never accidentally scan every item in Redis. With it, slicing maps to \`LRANGE start, stop-1\` so the admin paginator never pulls more than \`ITEM_PAGE_SIZE\` values per request, even on deep pages.
- **\`RedisQueueItemAdmin\`** — read-only (view-only permission), \`lookup_allowed\` whitelists \`queue_name__exact\`, \`changelist_view\` shows a helper message when no filter is set.
- **\`items_link\` column** on \`RedisQueueAdmin\` — emits \`<a href=\"…/redisqueueitem/?queue_name__exact=<encoded-key>\">view items</a>\` per row.
- **\`families.find_family(key)\`** — fnmatch-based classifier so the items view picks up the family's declared \`redis_type\` without re-asking Redis for \`TYPE\`.

### What's intentionally NOT in this PR

- Only LIST items render today (covers both M1 families: \`uploads/*\` and \`ta_flake_key:*\`). SET / HASH / STRING families and their item handling arrive in **M4** alongside \`upload-processing-state\`, \`intermediate-report\`, \`latest_upload\`, etc.
- No filters/search by repo or commit (M3).
- No item detail or delete actions (M5).
- The \`unknown queue name → empty\` test is permissive about the exact \"empty\" message Django renders; it just asserts no 500 and no unrelated payload leaks in.

## Test plan

- [x] \`pytest redis_admin/tests/\` — **27 passing locally** (14 new in M2: 10 fakeredis-only \`RedisItemQuerySet\` unit tests + 4 admin smoke tests through real URL routes)
- [x] \`ruff check\` and \`ruff format\` clean
- [ ] CI on the api test suite is green
- [ ] Manual smoke against a populated dev Redis: open \`/admin/redis_admin/redisqueue/\`, click \"view items\" on a non-empty row, confirm items render

Made with [Cursor](https://cursor.com)