### PR TITLE
feat(api): redis_admin per-queue items + filters/search/links (M2 + M3)

### DIFF
--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -1,22 +1,34 @@
 """Django admin registration for the redis_admin app.
 
 Milestone 1 ships a read-only changelist of every Redis key in the supported
-families. Subsequent milestones add filters, search, item drill-in, and
-clear actions on top of this same `ModelAdmin`.
+families. Milestone 2 adds a per-queue items view linked from each row; you
+can click "items" on a queue and land on `?queue_name__exact=<key>` filtered
+to that queue's contents. Subsequent milestones add filters, search,
+repo/commit grouping, and clear actions on top of these same `ModelAdmin`s.
 """
 
-from django.contrib import admin
-from django.http import HttpRequest
+from urllib.parse import urlencode
 
-from .models import RedisQueue
+from django.contrib import admin, messages
+from django.http import HttpRequest
+from django.urls import reverse
+from django.utils.html import format_html
+
+from . import settings as redis_admin_settings
+from .models import RedisQueue, RedisQueueItem
 
 
 @admin.register(RedisQueue)
 class RedisQueueAdmin(admin.ModelAdmin):
-    list_display = ("name", "family", "redis_type", "depth", "ttl_seconds")
+    list_display = (
+        "name",
+        "family",
+        "redis_type",
+        "depth",
+        "ttl_seconds",
+        "items_link",
+    )
     list_per_page = 50
-    # SCAN-based count is approximate and we do not want the admin to issue a
-    # second pass just to render "X of Y" in the toolbar.
     show_full_result_count = False
     ordering = ("-depth", "name")
 
@@ -28,3 +40,58 @@ class RedisQueueAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
+
+    @admin.display(description="items")
+    def items_link(self, obj: RedisQueue) -> str:
+        url = reverse("admin:redis_admin_redisqueueitem_changelist")
+        query = urlencode({"queue_name__exact": obj.name})
+        return format_html('<a href="{}?{}">view items</a>', url, query)
+
+
+@admin.register(RedisQueueItem)
+class RedisQueueItemAdmin(admin.ModelAdmin):
+    list_display = ("index_or_field", "raw_value_truncated")
+    list_per_page = redis_admin_settings.ITEM_PAGE_SIZE
+    show_full_result_count = False
+
+    def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
+        # No detail/edit page yet; M5 wires up per-item delete actions.
+        return False
+
+    def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_view_permission(self, request: HttpRequest, obj=None) -> bool:
+        return bool(request.user and request.user.is_staff)
+
+    def lookup_allowed(self, lookup, value) -> bool:
+        if lookup == "queue_name__exact":
+            return True
+        return super().lookup_allowed(lookup, value)
+
+    def get_queryset(self, request: HttpRequest):
+        # Bypass ChangeList's automatic `.filter(**lookup_params)` plumbing so
+        # the queue_name filter survives even when no list_filter is declared.
+        queryset = self.model._default_manager.all()
+        queue_name = request.GET.get("queue_name__exact")
+        if queue_name:
+            queryset = queryset.filter(queue_name__exact=queue_name)
+        return queryset
+
+    def changelist_view(self, request: HttpRequest, extra_context=None):
+        if not request.GET.get("queue_name__exact"):
+            messages.info(
+                request,
+                "Pick a queue from the Redis queues list (the 'view items' link) "
+                "to see its contents.",
+            )
+        return super().changelist_view(request, extra_context)
+
+    @admin.display(description="value")
+    def raw_value_truncated(self, obj: RedisQueueItem) -> str:
+        # Truncation already applied at queryset materialization time using
+        # MAX_DECODE_BYTES, so this column just renders what's there.
+        return obj.raw_value or ""

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -1,21 +1,130 @@
 """Django admin registration for the redis_admin app.
 
-Milestone 1 ships a read-only changelist of every Redis key in the supported
-families. Milestone 2 adds a per-queue items view linked from each row; you
-can click "items" on a queue and land on `?queue_name__exact=<key>` filtered
-to that queue's contents. Subsequent milestones add filters, search,
-repo/commit grouping, and clear actions on top of these same `ModelAdmin`s.
+Milestone 1 ships the read-only changelist, M2 adds the per-queue items
+view, M3 adds filtering / search / repo+commit links so an operator
+investigating a backed-up queue can pivot to the relevant Repository or
+Commit admin in one click.
+
+Search syntax (M3): the changelist's search box accepts simple
+prefix-style tokens in addition to plain substrings:
+
+- `repoid:1234`         → narrows to that repo (pushed into SCAN MATCH)
+- `commitid:abcdef0`    → commitid prefix
+- `family:uploads`      → only that family (pushed into SCAN MATCH)
+- `report_type:test_results`
+- bare token            → substring match on the Redis key itself
 """
+
+from __future__ import annotations
 
 from urllib.parse import urlencode
 
 from django.contrib import admin, messages
 from django.http import HttpRequest
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils.html import format_html
 
 from . import settings as redis_admin_settings
+from .families import FAMILIES
 from .models import RedisQueue, RedisQueueItem
+
+# ---- list_filter classes ---------------------------------------------------
+
+
+class FamilyFilter(admin.SimpleListFilter):
+    title = "family"
+    parameter_name = "family"
+
+    def lookups(self, request, model_admin):
+        return tuple((f.name, f.name) for f in FAMILIES)
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(family__exact=value)
+        return queryset
+
+
+class MinDepthFilter(admin.SimpleListFilter):
+    title = "min depth"
+    parameter_name = "min_depth"
+
+    _PRESETS: tuple[tuple[str, str], ...] = (
+        ("1", "1+"),
+        ("10", "10+"),
+        ("100", "100+"),
+        ("1000", "1000+"),
+    )
+
+    def lookups(self, request, model_admin):
+        return self._PRESETS
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(depth__gte=int(value))
+        return queryset
+
+
+class ReportTypeFilter(admin.SimpleListFilter):
+    title = "report type"
+    parameter_name = "report_type"
+
+    _CHOICES: tuple[tuple[str, str], ...] = (
+        ("coverage", "coverage"),
+        ("test_results", "test_results"),
+        ("bundle_analysis", "bundle_analysis"),
+    )
+
+    def lookups(self, request, model_admin):
+        return self._CHOICES
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(report_type=value)
+        return queryset
+
+
+# ---- Helpers ---------------------------------------------------------------
+
+
+def _parse_search_term(term: str) -> dict[str, str]:
+    """Pull out `key:value` tokens from a search bar string.
+
+    Recognised keys: `repoid`, `commitid`, `family`, `report_type`. Tokens
+    that aren't in `key:value` form become a single `name_substring` filter.
+    Multiple unrecognised tokens are joined back together so the substring
+    match still works for keys that contain spaces/slashes.
+    """
+
+    bare: list[str] = []
+    out: dict[str, str] = {}
+    for tok in term.split():
+        if ":" in tok:
+            key, _, value = tok.partition(":")
+            key = key.strip().lower()
+            value = value.strip()
+            if not value:
+                continue
+            if key == "repoid":
+                out["repoid__exact"] = value
+            elif key == "commitid":
+                out["commitid__startswith"] = value
+            elif key == "family":
+                out["family__exact"] = value
+            elif key == "report_type":
+                out["report_type"] = value
+            else:
+                bare.append(tok)
+        else:
+            bare.append(tok)
+    if bare:
+        out["name__icontains"] = " ".join(bare)
+    return out
+
+
+# ---- Queue changelist ------------------------------------------------------
 
 
 @admin.register(RedisQueue)
@@ -26,11 +135,23 @@ class RedisQueueAdmin(admin.ModelAdmin):
         "redis_type",
         "depth",
         "ttl_seconds",
+        "repoid_link",
+        "commitid_link",
+        "report_type",
         "items_link",
     )
+    list_filter = (FamilyFilter, MinDepthFilter, ReportTypeFilter)
     list_per_page = 50
     show_full_result_count = False
     ordering = ("-depth", "name")
+    # `search_fields` is set so the admin renders the search bar; the actual
+    # query parsing happens in `get_search_results` so we can support both
+    # bare substrings and `key:value` tokens.
+    search_fields = ("name",)
+    search_help_text = (
+        "search by 'repoid:1234', 'commitid:abc', 'family:uploads', "
+        "'report_type:test_results', or any substring of the Redis key"
+    )
 
     def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
@@ -41,11 +162,48 @@ class RedisQueueAdmin(admin.ModelAdmin):
     def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
 
+    def get_search_results(self, request, queryset, search_term):
+        if not search_term:
+            return queryset, False
+        try:
+            kwargs = _parse_search_term(search_term)
+        except NotImplementedError:
+            return queryset.none(), False
+        if not kwargs:
+            return queryset, False
+        return queryset.filter(**kwargs), False
+
+    @admin.display(description="repo")
+    def repoid_link(self, obj: RedisQueue) -> str:
+        if not obj.repoid:
+            return "—"
+        try:
+            url = reverse("admin:core_repository_change", args=[obj.repoid])
+        except NoReverseMatch:
+            return str(obj.repoid)
+        return format_html('<a href="{}">{}</a>', url, obj.repoid)
+
+    @admin.display(description="commit")
+    def commitid_link(self, obj: RedisQueue) -> str:
+        if not obj.commitid:
+            return "—"
+        try:
+            base = reverse("admin:core_commit_changelist")
+        except NoReverseMatch:
+            return obj.commitid[:7]
+        url = f"{base}?{urlencode({'q': obj.commitid})}"
+        return format_html(
+            '<a href="{}" title="{}">{}</a>', url, obj.commitid, obj.commitid[:7]
+        )
+
     @admin.display(description="items")
     def items_link(self, obj: RedisQueue) -> str:
         url = reverse("admin:redis_admin_redisqueueitem_changelist")
         query = urlencode({"queue_name__exact": obj.name})
         return format_html('<a href="{}?{}">view items</a>', url, query)
+
+
+# ---- Item changelist (M2) --------------------------------------------------
 
 
 @admin.register(RedisQueueItem)

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -1,22 +1,24 @@
 """Registry of Redis key "families" surfaced in the admin.
 
-A `Family` describes a Redis key pattern owned by some part of the system,
-how to recognise it, and (in later milestones) how to extract repo/commit
-metadata and decode individual items.
+A `Family` describes a Redis key pattern owned by some part of the system:
+how to recognise it, how to extract structured fields (repo / commit /
+report type), and how to build a tighter SCAN pattern when the admin user
+narrows their query.
 
-Milestone 1 only needs the bare minimum to enumerate keys and report their
-type and depth in the admin changelist, so we ship two representative
-families today (`uploads` and `ta_flake_key`). Subsequent milestones extend
-this module rather than touching the queryset/admin layers.
+Milestone 1 just enumerated keys; milestone 3 makes the parsers real and
+adds the SCAN pushdown helpers used by the changelist's filter/search.
+Milestone 4 will extend the registry with `latest_upload`,
+`upload-processing-state`, `intermediate-report`, the Celery broker
+queues, and the locks family.
 """
 
 from __future__ import annotations
 
 import fnmatch
 import logging
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from . import conn as _conn
 from . import settings as redis_admin_settings
@@ -31,10 +33,8 @@ RedisType = Literal["list", "set", "hash", "string"]
 class ParsedKey:
     """Structured view of a Redis key once we know which family it belongs to.
 
-    All fields are optional because not every family encodes every dimension
-    in its key. Later milestones populate `repoid`, `commitid`, etc. from the
-    family-specific parser; in M1 we only need `family` so the admin can show
-    the family column.
+    Fields are optional because not every family encodes every dimension in
+    its key (e.g. `ta_flake_key:{repoid}` has no commitid).
     """
 
     family: str
@@ -44,14 +44,78 @@ class ParsedKey:
     upload_id: str | None = None
 
 
+# ---- Parsers ---------------------------------------------------------------
+
+
 def _parse_uploads_key(key: str) -> ParsedKey:
-    # Shape: uploads/{repoid}/{commitid}[/{report_type}]
-    return ParsedKey(family="uploads")
+    """`uploads/{repoid}/{commitid}` (coverage) or
+    `uploads/{repoid}/{commitid}/{report_type}` (test_results, bundle_analysis).
+
+    Mirrors what `upload.helpers.dispatch_upload_task` writes today:
+    coverage drops the trailing report-type segment.
+    """
+
+    parts = key.split("/", 3)
+    if len(parts) < 3 or parts[0] != "uploads":
+        return ParsedKey(family="uploads")
+    repoid: int | None
+    try:
+        repoid = int(parts[1])
+    except ValueError:
+        repoid = None
+    commitid = parts[2] or None
+    report_type = parts[3] if len(parts) >= 4 and parts[3] else "coverage"
+    return ParsedKey(
+        family="uploads",
+        repoid=repoid,
+        commitid=commitid,
+        report_type=report_type,
+    )
 
 
 def _parse_ta_flake_key(key: str) -> ParsedKey:
-    # Shape: ta_flake_key:{repoid}
-    return ParsedKey(family="ta_flake_key")
+    """`ta_flake_key:{repoid}` written by the test-analytics finisher."""
+
+    if not key.startswith("ta_flake_key:"):
+        return ParsedKey(family="ta_flake_key")
+    tail = key[len("ta_flake_key:") :]
+    repoid: int | None
+    try:
+        repoid = int(tail)
+    except ValueError:
+        repoid = None
+    return ParsedKey(family="ta_flake_key", repoid=repoid)
+
+
+# ---- SCAN pattern pushdown -------------------------------------------------
+
+
+def _uploads_pattern(filters: Mapping[str, Any]) -> str:
+    """Tighten `uploads/*` based on what the admin filter supplied.
+
+    The trailing `*` covers both coverage (`uploads/{r}/{c}`) and the
+    typed variants (`uploads/{r}/{c}/{report_type}`), so a commitid-prefix
+    pushdown still sees both.
+    """
+
+    repoid = filters.get("repoid")
+    commitid_prefix = filters.get("commitid_prefix") or ""
+    if repoid is not None and commitid_prefix:
+        return f"uploads/{repoid}/{commitid_prefix}*"
+    if repoid is not None:
+        return f"uploads/{repoid}/*"
+    if commitid_prefix:
+        return f"uploads/*/{commitid_prefix}*"
+    return "uploads/*"
+
+
+def _ta_flake_pattern(filters: Mapping[str, Any]) -> str:
+    """`ta_flake_key:{repoid}` is exact when we know the repoid."""
+
+    repoid = filters.get("repoid")
+    if repoid is not None:
+        return f"ta_flake_key:{repoid}"
+    return "ta_flake_key:*"
 
 
 @dataclass(frozen=True)
@@ -60,7 +124,13 @@ class Family:
     scan_pattern: str
     redis_type: RedisType
     parse_key: Callable[[str], ParsedKey]
+    pattern_for: Callable[[Mapping[str, Any]], str] | None = None
     fixed_keys: tuple[str, ...] = field(default_factory=tuple)
+
+    def build_scan_pattern(self, filters: Mapping[str, Any]) -> str:
+        if self.pattern_for is None:
+            return self.scan_pattern
+        return self.pattern_for(filters)
 
 
 FAMILIES: tuple[Family, ...] = (
@@ -69,12 +139,14 @@ FAMILIES: tuple[Family, ...] = (
         scan_pattern="uploads/*",
         redis_type="list",
         parse_key=_parse_uploads_key,
+        pattern_for=_uploads_pattern,
     ),
     Family(
         name="ta_flake_key",
         scan_pattern="ta_flake_key:*",
         redis_type="list",
         parse_key=_parse_ta_flake_key,
+        pattern_for=_ta_flake_pattern,
     ),
 )
 
@@ -89,14 +161,7 @@ def _decode(value: bytes | str) -> str:
 
 
 def find_family(key: str) -> Family | None:
-    """Return the `Family` whose `scan_pattern` matches `key`, or None.
-
-    Used by the item view: given a queue name pulled from a URL filter, look
-    up the family so we know its declared `redis_type` and (in later
-    milestones) its parser. We fall back to None for keys that don't belong
-    to any known family; the item queryset then asks Redis directly for the
-    type via `TYPE`.
-    """
+    """Return the `Family` whose `scan_pattern` matches `key`, or None."""
 
     for family in FAMILIES:
         if key in family.fixed_keys:
@@ -106,24 +171,37 @@ def find_family(key: str) -> Family | None:
     return None
 
 
-def iter_keys(redis=None) -> Iterator[tuple[str, Family]]:
-    """Yield `(key, family)` pairs for every known family.
+def iter_keys(
+    redis=None,
+    *,
+    family: str | None = None,
+    repoid: int | None = None,
+    commitid_prefix: str | None = None,
+) -> Iterator[tuple[str, Family]]:
+    """Yield `(key, family)` for every known family, optionally narrowed.
 
-    Uses Redis SCAN with a per-call `COUNT` and a hard cap on the total number
-    of keys returned across all families so a runaway keyspace cannot block
-    Redis. Always returns the matching `Family` so callers do not have to
-    re-classify the key.
+    Filters that the family understands are pushed down into the SCAN
+    pattern (see `_uploads_pattern` / `_ta_flake_pattern`); filters that
+    don't apply are dropped, and post-scan filtering happens in
+    `RedisQueueQuerySet`. Total work is bounded by `MAX_SCAN_KEYS`.
     """
 
     redis = redis if redis is not None else _conn.get_connection()
     seen = 0
     cap = redis_admin_settings.MAX_SCAN_KEYS
     count = redis_admin_settings.SCAN_COUNT
+    filters: dict[str, Any] = {
+        "repoid": repoid,
+        "commitid_prefix": commitid_prefix,
+    }
 
-    for family in FAMILIES:
-        for key in family.fixed_keys:
+    for fam in FAMILIES:
+        if family and fam.name != family:
+            continue
+
+        for key in fam.fixed_keys:
             if redis.exists(key):
-                yield key, family
+                yield key, fam
                 seen += 1
                 if seen >= cap:
                     log.warning(
@@ -132,16 +210,17 @@ def iter_keys(redis=None) -> Iterator[tuple[str, Family]]:
                     )
                     return
 
-        if not family.scan_pattern:
+        pattern = fam.build_scan_pattern(filters)
+        if not pattern:
             continue
 
-        for raw_key in redis.scan_iter(match=family.scan_pattern, count=count):
-            yield _decode(raw_key), family
+        for raw_key in redis.scan_iter(match=pattern, count=count):
+            yield _decode(raw_key), fam
             seen += 1
             if seen >= cap:
                 log.warning(
                     "redis_admin: hit MAX_SCAN_KEYS=%s while scanning %s",
                     cap,
-                    family.scan_pattern,
+                    pattern,
                 )
                 return

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -12,6 +12,7 @@ this module rather than touching the queryset/admin layers.
 
 from __future__ import annotations
 
+import fnmatch
 import logging
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
@@ -85,6 +86,24 @@ def _decode(value: bytes | str) -> str:
         except UnicodeDecodeError:
             return value.decode("utf-8", errors="replace")
     return value
+
+
+def find_family(key: str) -> Family | None:
+    """Return the `Family` whose `scan_pattern` matches `key`, or None.
+
+    Used by the item view: given a queue name pulled from a URL filter, look
+    up the family so we know its declared `redis_type` and (in later
+    milestones) its parser. We fall back to None for keys that don't belong
+    to any known family; the item queryset then asks Redis directly for the
+    type via `TYPE`.
+    """
+
+    for family in FAMILIES:
+        if key in family.fixed_keys:
+            return family
+        if family.scan_pattern and fnmatch.fnmatchcase(key, family.scan_pattern):
+            return family
+    return None
 
 
 def iter_keys(redis=None) -> Iterator[tuple[str, Family]]:

--- a/apps/codecov-api/redis_admin/models.py
+++ b/apps/codecov-api/redis_admin/models.py
@@ -9,12 +9,17 @@ Redis SCAN results and are never saved.
 
 from django.db import models
 
-from .queryset import RedisQueueQuerySet
+from .queryset import RedisItemQuerySet, RedisQueueQuerySet
 
 
 class RedisQueueManager(models.Manager):
     def get_queryset(self) -> RedisQueueQuerySet:  # type: ignore[override]
         return RedisQueueQuerySet(self.model)
+
+
+class RedisQueueItemManager(models.Manager):
+    def get_queryset(self) -> RedisItemQuerySet:  # type: ignore[override]
+        return RedisItemQuerySet(self.model)
 
 
 class RedisQueue(models.Model):
@@ -43,3 +48,35 @@ class RedisQueue(models.Model):
 
     def delete(self, *args, **kwargs):  # pragma: no cover - milestone 5
         raise NotImplementedError("RedisQueue.delete arrives in milestone 5.")
+
+
+class RedisQueueItem(models.Model):
+    """A single item inside a Redis-backed container.
+
+    `pk_token` is `<queue_name>#<index_or_field>`. For LIST items it's the
+    LRANGE index; later milestones extend it to the field name (HASH) or the
+    SHA1 of the value (SET) so each row in the admin still has a stable pk.
+    """
+
+    pk_token = models.CharField(primary_key=True, max_length=600)
+    queue_name = models.CharField(max_length=512)
+    index_or_field = models.CharField(max_length=128)
+    raw_value = models.TextField(blank=True)
+
+    objects = RedisQueueItemManager()
+
+    class Meta:
+        managed = False
+        app_label = "redis_admin"
+        verbose_name = "Redis queue item"
+        verbose_name_plural = "Redis queue items"
+        default_permissions = ("view",)
+
+    def __str__(self) -> str:
+        return f"{self.queue_name}[{self.index_or_field}]"
+
+    def save(self, *args, **kwargs):  # pragma: no cover - safety net
+        raise RuntimeError("RedisQueueItem is read-only; saves are not supported.")
+
+    def delete(self, *args, **kwargs):  # pragma: no cover - milestone 5
+        raise NotImplementedError("RedisQueueItem.delete arrives in milestone 5.")

--- a/apps/codecov-api/redis_admin/models.py
+++ b/apps/codecov-api/redis_admin/models.py
@@ -28,6 +28,9 @@ class RedisQueue(models.Model):
     redis_type = models.CharField(max_length=16)
     depth = models.PositiveIntegerField(default=0)
     ttl_seconds = models.IntegerField(null=True, blank=True)
+    repoid = models.IntegerField(null=True, blank=True)
+    commitid = models.CharField(max_length=64, null=True, blank=True)
+    report_type = models.CharField(max_length=32, null=True, blank=True)
 
     objects = RedisQueueManager()
 

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -1,14 +1,15 @@
-"""Fake QuerySet that lets Django admin render Redis keys.
+"""Fake QuerySets that let Django admin render Redis keys and their items.
 
 Inspired by `wolph/django-redis-admin`. The Django admin's changelist talks to
 its model via a small set of QuerySet methods: `iterator`, `count`,
 `__getitem__` (slicing for pagination), `_clone`/`all`/`none`/`using`, and
 `order_by`. This module implements just those, dispatching to Redis under the
-hood so the model needs no real database table.
+hood so the models need no real database table.
 
-Milestone 1 keeps the surface small: enumeration, count, slicing, in-memory
-ordering. `filter`/`exclude`/`get`/`delete` deliberately raise
-`NotImplementedError` so future milestones know exactly what to wire in.
+`RedisQueueQuerySet` — milestone 1, enumerates keys.
+`RedisItemQuerySet`  — milestone 2, enumerates items inside a single keyed
+                       container, gated on a `queue_name__exact=<key>` filter
+                       so we never accidentally scan every item in Redis.
 """
 
 from __future__ import annotations
@@ -17,7 +18,10 @@ from collections.abc import Iterator
 from typing import Any
 
 from . import conn as _conn
-from .families import Family, iter_keys
+from . import settings as redis_admin_settings
+from .families import Family, find_family, iter_keys
+
+_UNSET: Any = object()
 
 
 def _build_redis_queue(model, key: str, family: Family, redis) -> Any:
@@ -163,6 +167,201 @@ class RedisQueueQuerySet:
         # returning a tiny stub keeps `ChangeList.get_ordering` happy.
         class _Query:
             order_by = self._ordering
+            select_related = False
+            distinct = False
+
+        return _Query()
+
+    @property
+    def ordered(self) -> bool:
+        return bool(self._ordering)
+
+    @property
+    def db(self) -> str:
+        return "default"
+
+
+def _decode_value(value: bytes | str) -> str:
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _truncate_for_display(value: str, *, cap: int | None = None) -> str:
+    if cap is None:
+        cap = redis_admin_settings.MAX_DECODE_BYTES
+    if len(value) <= cap:
+        return value
+    truncated_count = len(value) - cap
+    return f"{value[:cap]}\u2026 (+{truncated_count} chars truncated)"
+
+
+class RedisItemQuerySet:
+    """Fake QuerySet for items inside a single Redis-backed container.
+
+    The admin URL `?queue_name__exact=<key>` is the only supported filter.
+    Without it, this queryset is empty by design so we never accidentally
+    fan out into every item in Redis.
+    """
+
+    def __init__(
+        self,
+        model,
+        *,
+        queue_name: str | None = None,
+        ordering: tuple[str, ...] = (),
+    ) -> None:
+        self.model = model
+        self.queue_name = queue_name
+        self._ordering = ordering
+
+    # ---- Cloning helpers --------------------------------------------------
+
+    def _clone(
+        self,
+        *,
+        queue_name: str | None = _UNSET,
+        ordering: tuple[str, ...] | None = None,
+    ) -> RedisItemQuerySet:
+        return RedisItemQuerySet(
+            self.model,
+            queue_name=self.queue_name if queue_name is _UNSET else queue_name,
+            ordering=self._ordering if ordering is None else ordering,
+        )
+
+    def all(self) -> RedisItemQuerySet:
+        return self._clone()
+
+    def none(self) -> RedisItemQuerySet:
+        return self._clone(queue_name=None)
+
+    def using(self, alias) -> RedisItemQuerySet:
+        return self
+
+    # ---- Filtering -------------------------------------------------------
+
+    def filter(self, *args, **kwargs) -> RedisItemQuerySet:
+        kwargs = dict(kwargs)
+        new_queue_name = self.queue_name
+        for key in ("queue_name__exact", "queue_name"):
+            if key in kwargs:
+                new_queue_name = kwargs.pop(key)
+        if args or kwargs:
+            raise NotImplementedError(
+                "RedisItemQuerySet.filter only supports queue_name[/__exact] in M2; "
+                f"got args={args!r}, kwargs={list(kwargs)!r}"
+            )
+        return self._clone(queue_name=new_queue_name)
+
+    def exclude(self, *args, **kwargs) -> RedisItemQuerySet:
+        if not args and not kwargs:
+            return self._clone()
+        raise NotImplementedError("RedisItemQuerySet.exclude is added in milestone 5")
+
+    def get(self, *args, **kwargs):
+        raise NotImplementedError("RedisItemQuerySet.get is added in milestone 5")
+
+    def order_by(self, *fields: str) -> RedisItemQuerySet:
+        return self._clone(ordering=tuple(fields))
+
+    # ---- Materialization -------------------------------------------------
+
+    def _resolve_type(self, redis) -> str | None:
+        """Best-effort lookup of the Redis type for `self.queue_name`."""
+
+        if not self.queue_name:
+            return None
+        family = find_family(self.queue_name)
+        if family is not None:
+            return family.redis_type
+        raw_type = redis.type(self.queue_name)
+        kind = _decode_value(raw_type) if raw_type is not None else "none"
+        if kind == "none":
+            return None
+        return kind
+
+    def _build_list_items(self, redis, start: int, raw_values: list) -> list:
+        return [
+            self.model(
+                pk_token=f"{self.queue_name}#{start + offset}",
+                queue_name=self.queue_name,
+                index_or_field=str(start + offset),
+                raw_value=_truncate_for_display(_decode_value(value)),
+            )
+            for offset, value in enumerate(raw_values)
+        ]
+
+    def _list_slice(self, redis, start: int, stop: int) -> list:
+        if stop <= start:
+            return []
+        cap = redis_admin_settings.ITEM_PAGE_SIZE
+        capped_stop = min(stop, start + cap)
+        raw = redis.lrange(self.queue_name, start, capped_stop - 1)
+        return self._build_list_items(redis, start, raw)
+
+    def count(self) -> int:
+        if not self.queue_name:
+            return 0
+        redis = _conn.get_connection()
+        kind = self._resolve_type(redis)
+        if kind == "list":
+            return int(redis.llen(self.queue_name) or 0)
+        # SET/HASH/STRING land in M4 alongside their families. For now they
+        # report 0 so the changelist renders cleanly.
+        return 0
+
+    def __len__(self) -> int:
+        return self.count()
+
+    def __iter__(self) -> Iterator:
+        if not self.queue_name:
+            return iter(())
+        return iter(self[: redis_admin_settings.ITEM_PAGE_SIZE])
+
+    def iterator(self, chunk_size: int | None = None) -> Iterator:
+        return iter(self)
+
+    def __bool__(self) -> bool:
+        return self.count() > 0
+
+    def __getitem__(self, item):
+        if not self.queue_name:
+            return [] if isinstance(item, slice) else None
+        redis = _conn.get_connection()
+        kind = self._resolve_type(redis)
+        if kind != "list":
+            return [] if isinstance(item, slice) else None
+        if isinstance(item, slice):
+            start = item.start or 0
+            stop = (
+                item.stop
+                if item.stop is not None
+                else start + redis_admin_settings.ITEM_PAGE_SIZE
+            )
+            return self._list_slice(redis, start, stop)
+        if isinstance(item, int):
+            page = self._list_slice(redis, item, item + 1)
+            if not page:
+                raise IndexError(item)
+            return page[0]
+        raise TypeError(f"unsupported index type: {type(item)!r}")
+
+    # ---- Mutations (M5) --------------------------------------------------
+
+    def delete(self):
+        raise NotImplementedError("RedisItemQuerySet.delete is added in milestone 5")
+
+    # ---- Admin compatibility shims ---------------------------------------
+
+    @property
+    def query(self):
+        ordering = self._ordering
+
+        class _Query:
+            order_by = ordering
             select_related = False
             distinct = False
 

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -46,29 +46,71 @@ def _build_redis_queue(model, key: str, family: Family, redis) -> Any:
     # We surface "no TTL" as None in the admin to keep the column readable.
     ttl_seconds = None if ttl is None or ttl < 0 else int(ttl)
 
+    parsed = family.parse_key(key)
+
     return model(
         name=key,
         family=family.name,
         redis_type=redis_type.upper(),
         depth=int(depth or 0),
         ttl_seconds=ttl_seconds,
+        repoid=parsed.repoid,
+        commitid=parsed.commitid,
+        report_type=parsed.report_type,
     )
 
 
-class RedisQueueQuerySet:
-    """Quacks like a Django QuerySet for the admin changelist."""
+# Filter kwargs `RedisQueueQuerySet.filter()` understands; everything else
+# raises NotImplementedError so missing functionality is loud, not silent.
+_QUEUE_FILTER_KEYS: dict[str, str] = {
+    "family": "family",
+    "family__exact": "family",
+    "repoid": "repoid",
+    "repoid__exact": "repoid",
+    "commitid": "commitid_prefix",
+    "commitid__exact": "commitid_prefix",
+    "commitid__startswith": "commitid_prefix",
+    "report_type": "report_type",
+    "report_type__exact": "report_type",
+    "depth__gte": "depth_gte",
+    "name__icontains": "name_substring",
+    "name__contains": "name_substring",
+}
 
-    def __init__(self, model, *, ordering: tuple[str, ...] = ()) -> None:
+
+class RedisQueueQuerySet:
+    """Quacks like a Django QuerySet for the admin changelist.
+
+    Filter kwargs in `_QUEUE_FILTER_KEYS` are honoured: `family`, `repoid`,
+    and `commitid` are pushed into a tighter SCAN MATCH; the rest
+    (`depth__gte`, `name__icontains`, `report_type`) are applied as a
+    post-scan filter on materialised rows.
+    """
+
+    def __init__(
+        self,
+        model,
+        *,
+        ordering: tuple[str, ...] = (),
+        filters: dict[str, Any] | None = None,
+    ) -> None:
         self.model = model
         self._ordering = ordering
+        self._filters: dict[str, Any] = dict(filters or {})
         self._result_cache: list | None = None
 
     # ---- Cloning helpers --------------------------------------------------
 
-    def _clone(self, *, ordering: tuple[str, ...] | None = None) -> RedisQueueQuerySet:
+    def _clone(
+        self,
+        *,
+        ordering: tuple[str, ...] | None = None,
+        filters: dict[str, Any] | None = None,
+    ) -> RedisQueueQuerySet:
         return RedisQueueQuerySet(
             self.model,
             ordering=self._ordering if ordering is None else ordering,
+            filters={**self._filters, **(filters or {})},
         )
 
     def all(self) -> RedisQueueQuerySet:
@@ -84,26 +126,57 @@ class RedisQueueQuerySet:
         # admin still calls this so we accept and ignore it.
         return self
 
-    # ---- Filtering / lookup (M3+) ----------------------------------------
+    # ---- Filtering -------------------------------------------------------
+
+    def _interpret_filter_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        new_filters: dict[str, Any] = {}
+        unsupported: dict[str, Any] = {}
+        for key, value in kwargs.items():
+            target = _QUEUE_FILTER_KEYS.get(key)
+            if target is None:
+                unsupported[key] = value
+                continue
+            if value is None or value == "":
+                continue
+            if target == "repoid":
+                try:
+                    new_filters[target] = int(value)
+                except (TypeError, ValueError):
+                    # An int-only filter against a non-int value can never
+                    # match; force the queryset empty rather than crashing.
+                    new_filters["__empty__"] = True
+            elif target == "depth_gte":
+                try:
+                    new_filters[target] = int(value)
+                except (TypeError, ValueError):
+                    new_filters["__empty__"] = True
+            elif target == "name_substring":
+                new_filters[target] = str(value).lower()
+            else:
+                new_filters[target] = str(value)
+        if unsupported:
+            raise NotImplementedError(
+                "RedisQueueQuerySet.filter received unsupported kwargs: "
+                f"{sorted(unsupported)!r}; supported: {sorted(_QUEUE_FILTER_KEYS)!r}"
+            )
+        return new_filters
 
     def filter(self, *args, **kwargs) -> RedisQueueQuerySet:
-        if not args and not kwargs:
+        if args:
+            raise NotImplementedError(
+                "RedisQueueQuerySet.filter does not accept positional Q objects"
+            )
+        if not kwargs:
             return self._clone()
-        raise NotImplementedError(
-            "redis_admin.RedisQueueQuerySet.filter is added in milestone 3"
-        )
+        return self._clone(filters=self._interpret_filter_kwargs(kwargs))
 
     def exclude(self, *args, **kwargs) -> RedisQueueQuerySet:
         if not args and not kwargs:
             return self._clone()
-        raise NotImplementedError(
-            "redis_admin.RedisQueueQuerySet.exclude is added in milestone 3"
-        )
+        raise NotImplementedError("RedisQueueQuerySet.exclude is added in milestone 5")
 
     def get(self, *args, **kwargs):
-        raise NotImplementedError(
-            "redis_admin.RedisQueueQuerySet.get is added in milestone 3"
-        )
+        raise NotImplementedError("RedisQueueQuerySet.get is added in milestone 5")
 
     # ---- Ordering --------------------------------------------------------
 
@@ -112,15 +185,45 @@ class RedisQueueQuerySet:
 
     # ---- Materialization -------------------------------------------------
 
+    def _post_scan_predicate(self, obj: Any) -> bool:
+        f = self._filters
+        depth_gte = f.get("depth_gte")
+        if depth_gte is not None and (obj.depth or 0) < depth_gte:
+            return False
+        name_substring = f.get("name_substring")
+        if name_substring and name_substring not in (obj.name or "").lower():
+            return False
+        report_type = f.get("report_type")
+        if report_type and (obj.report_type or "") != report_type:
+            return False
+        # Redis glob `*` matches `/`, so a `uploads/*/abc*` pushdown can
+        # surface `uploads/<r>/<other>/abc-something`; double-check the
+        # parsed commitid starts with the prefix the caller asked for.
+        commitid_prefix = f.get("commitid_prefix")
+        if commitid_prefix and not (obj.commitid or "").startswith(commitid_prefix):
+            return False
+        return True
+
     def _fetch_all(self) -> list:
         if self._result_cache is not None:
             return self._result_cache
 
+        if self._filters.get("__empty__"):
+            self._result_cache = []
+            return []
+
         redis = _conn.get_connection()
         items = [
             _build_redis_queue(self.model, key, family, redis)
-            for key, family in iter_keys(redis)
+            for key, family in iter_keys(
+                redis,
+                family=self._filters.get("family"),
+                repoid=self._filters.get("repoid"),
+                commitid_prefix=self._filters.get("commitid_prefix"),
+            )
         ]
+
+        items = [obj for obj in items if self._post_scan_predicate(obj)]
 
         for field in reversed(self._ordering):
             reverse = field.startswith("-")

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -142,3 +142,117 @@ class RedisQueueItemAdminSmokeTest(TestCase):
             or "0 of 0" in body
             or "no Redis" in body.lower()
         )
+
+
+class RedisAdminFiltersAndSearchTest(TestCase):
+    """M3 end-to-end: list_filter, search, repo/commit links."""
+
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+
+        self.user = UserFactory(is_staff=True)
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def _populate_diverse_keys(self):
+        # repo 1234 has several queues across coverage / test_results /
+        # ta_flake_key, and repo 9999 has an unrelated queue we expect to
+        # be filtered out by repoid searches.
+        self.redis.rpush("uploads/1234/sha-aaa", "p1")
+        self.redis.rpush("uploads/1234/sha-aaa", "p2")
+        self.redis.rpush("uploads/1234/sha-bbb/test_results", "p3")
+        self.redis.rpush("ta_flake_key:1234", "p4")
+        self.redis.rpush("uploads/9999/sha-zzz", "p5")
+
+    def test_search_by_repoid_token_returns_only_that_repos_queues(self):
+        """End-of-M3 acceptance: 'repoid:1234' surfaces all backed-up
+        queues for that repo and excludes others."""
+
+        self._populate_diverse_keys()
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueue/", {"q": "repoid:1234"}
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "uploads/1234/sha-aaa" in body
+        assert "uploads/1234/sha-bbb/test_results" in body
+        assert "ta_flake_key:1234" in body
+        assert "uploads/9999/sha-zzz" not in body
+
+    def test_search_by_commitid_token_filters_to_matching_prefix(self):
+        self._populate_diverse_keys()
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueue/", {"q": "commitid:sha-aaa"}
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "uploads/1234/sha-aaa" in body
+        assert "uploads/1234/sha-bbb/test_results" not in body
+        assert "ta_flake_key:1234" not in body
+
+    def test_family_list_filter_narrows_results(self):
+        self._populate_diverse_keys()
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueue/", {"family": "ta_flake_key"}
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "ta_flake_key:1234" in body
+        assert "uploads/1234/sha-aaa" not in body
+
+    def test_min_depth_filter_drops_shallow_queues(self):
+        self.redis.rpush("uploads/1/shallow", "x")
+        for i in range(5):
+            self.redis.rpush("uploads/1/deep", f"x{i}")
+
+        response = self.client.get("/admin/redis_admin/redisqueue/", {"min_depth": "5"})
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "uploads/1/deep" in body
+        assert "uploads/1/shallow" not in body
+
+    def test_report_type_filter_narrows_to_typed_uploads(self):
+        self.redis.rpush("uploads/1/sha", "x")  # coverage default
+        self.redis.rpush("uploads/1/sha/test_results", "x")
+        self.redis.rpush("uploads/1/sha/bundle_analysis", "x")
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueue/",
+            {"report_type": "test_results"},
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "uploads/1/sha/test_results" in body
+        assert "uploads/1/sha/bundle_analysis" not in body
+
+    def test_repoid_link_points_at_repository_admin(self):
+        self.redis.rpush("uploads/4242/sha", "x")
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Default Django admin URL for `core.Repository` keyed by repoid.
+        assert "/admin/core/repository/4242/change/" in body
+
+    def test_commitid_link_points_at_commit_changelist_search(self):
+        self.redis.rpush("uploads/1/cafef00dcafef00d", "x")
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "/admin/core/commit/?q=cafef00dcafef00d" in body

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -74,3 +74,71 @@ def test_non_staff_user_is_redirected_from_redis_admin():
 
     # Non-staff hits the admin login redirect.
     assert response.status_code in (302, 403)
+
+
+class RedisQueueItemAdminSmokeTest(TestCase):
+    """End-to-end checks for the M2 per-queue items view."""
+
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+
+        self.user = UserFactory(is_staff=True)
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def test_queue_changelist_links_to_items_view(self):
+        self.redis.rpush("uploads/123/abc", "payload-1")
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # The items_link column emits a relative URL with the encoded key.
+        assert "/admin/redis_admin/redisqueueitem/" in body
+        assert "queue_name__exact=uploads%2F123%2Fabc" in body
+        assert "view items" in body
+
+    def test_items_changelist_without_queue_filter_shows_helper_message(self):
+        response = self.client.get("/admin/redis_admin/redisqueueitem/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "Pick a queue from the Redis queues list" in body
+
+    def test_items_changelist_with_queue_filter_renders_list_items(self):
+        for i in range(3):
+            self.redis.rpush("uploads/9/deadbeef", f"payload-{i}")
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueueitem/",
+            {"queue_name__exact": "uploads/9/deadbeef"},
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        for i in range(3):
+            assert f"payload-{i}" in body
+        # Index column shows 0/1/2 so users can identify positions.
+        assert ">0<" in body or ">0 " in body
+        assert ">2<" in body or ">2 " in body
+
+    def test_items_changelist_with_unknown_queue_renders_empty(self):
+        response = self.client.get(
+            "/admin/redis_admin/redisqueueitem/",
+            {"queue_name__exact": "no-such-queue"},
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Django admin's empty-results phrase varies a bit between releases;
+        # the important thing is no 500 and no unrelated payload leaks in.
+        assert (
+            "0 Redis queue items" in body
+            or "0 of 0" in body
+            or "no Redis" in body.lower()
+        )

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -1,0 +1,134 @@
+"""Unit tests for the M3 key parsers and SCAN-pattern pushdown.
+
+`ParsedKey` and the `pattern_for` helpers are pure functions so these
+tests don't need a Redis (fake or real) at all.
+"""
+
+from __future__ import annotations
+
+import fakeredis
+import pytest
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin.families import (
+    FAMILIES,
+    _parse_ta_flake_key,
+    _parse_uploads_key,
+    _ta_flake_pattern,
+    _uploads_pattern,
+    find_family,
+    iter_keys,
+)
+
+
+@pytest.fixture
+def patched_redis(monkeypatch) -> fakeredis.FakeStrictRedis:
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(redis_admin_conn, "get_connection", lambda: server)
+    return server
+
+
+def test_parse_uploads_coverage_default():
+    parsed = _parse_uploads_key("uploads/1234/abcdef0")
+    assert parsed.family == "uploads"
+    assert parsed.repoid == 1234
+    assert parsed.commitid == "abcdef0"
+    assert parsed.report_type == "coverage"
+
+
+def test_parse_uploads_with_typed_report_type():
+    parsed = _parse_uploads_key("uploads/42/sha/test_results")
+    assert parsed.repoid == 42
+    assert parsed.commitid == "sha"
+    assert parsed.report_type == "test_results"
+
+
+def test_parse_uploads_handles_extra_slashes_in_report_type():
+    # `split('/', 3)` keeps everything past the third slash in report_type
+    # so unexpected nesting is preserved as-is for inspection.
+    parsed = _parse_uploads_key("uploads/42/sha/bundle_analysis/extra")
+    assert parsed.report_type == "bundle_analysis/extra"
+
+
+def test_parse_uploads_non_int_repoid_is_none():
+    parsed = _parse_uploads_key("uploads/notanint/sha")
+    assert parsed.repoid is None
+    assert parsed.commitid == "sha"
+
+
+def test_parse_ta_flake_key_extracts_repoid():
+    parsed = _parse_ta_flake_key("ta_flake_key:99")
+    assert parsed.family == "ta_flake_key"
+    assert parsed.repoid == 99
+    assert parsed.commitid is None
+
+
+def test_parse_ta_flake_key_non_int_repoid_is_none():
+    parsed = _parse_ta_flake_key("ta_flake_key:bogus")
+    assert parsed.repoid is None
+
+
+def test_uploads_pattern_pushdown_repoid_only():
+    assert _uploads_pattern({"repoid": 1234}) == "uploads/1234/*"
+
+
+def test_uploads_pattern_pushdown_with_commitid_prefix():
+    assert (
+        _uploads_pattern({"repoid": 1234, "commitid_prefix": "abc"})
+        == "uploads/1234/abc*"
+    )
+
+
+def test_uploads_pattern_no_filters_falls_back_to_wildcard():
+    assert _uploads_pattern({}) == "uploads/*"
+
+
+def test_ta_flake_pattern_pushdown_is_exact_when_repoid_known():
+    assert _ta_flake_pattern({"repoid": 7}) == "ta_flake_key:7"
+    assert _ta_flake_pattern({}) == "ta_flake_key:*"
+
+
+def test_find_family_classifies_known_keys():
+    assert find_family("uploads/1/abc").name == "uploads"
+    assert find_family("ta_flake_key:9").name == "ta_flake_key"
+
+
+def test_find_family_returns_none_for_unknown_keys():
+    assert find_family("celery/some-queue") is None
+
+
+def test_iter_keys_pushdown_skips_other_repos(patched_redis):
+    """A `repoid` filter should narrow the SCAN pattern so unrelated
+    repos are never scanned at all."""
+
+    patched_redis.rpush("uploads/1/abc", "x")
+    patched_redis.rpush("uploads/2/def", "x")
+
+    keys = [k for k, _ in iter_keys(patched_redis, repoid=1)]
+    assert keys == ["uploads/1/abc"]
+
+
+def test_iter_keys_pushdown_skips_other_families(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    patched_redis.rpush("ta_flake_key:1", "x")
+
+    keys = [k for k, fam in iter_keys(patched_redis, family="uploads")]
+    assert keys == ["uploads/1/abc"]
+
+
+def test_iter_keys_pushdown_combines_repoid_and_commit_prefix(patched_redis):
+    patched_redis.rpush("uploads/1/abcd", "x")
+    patched_redis.rpush("uploads/1/abcd/test_results", "x")
+    patched_redis.rpush("uploads/1/zzzz", "x")
+    patched_redis.rpush("uploads/2/abcd", "x")
+
+    keys = sorted(
+        k for k, _ in iter_keys(patched_redis, repoid=1, commitid_prefix="abcd")
+    )
+    assert keys == ["uploads/1/abcd", "uploads/1/abcd/test_results"]
+
+
+def test_families_registry_exposes_uploads_and_ta_flake_key():
+    names = {f.name for f in FAMILIES}
+    assert "uploads" in names
+    assert "ta_flake_key" in names

--- a/apps/codecov-api/redis_admin/tests/test_item_queryset.py
+++ b/apps/codecov-api/redis_admin/tests/test_item_queryset.py
@@ -1,0 +1,130 @@
+"""Unit tests for `RedisItemQuerySet` against fakeredis (no DB needed)."""
+
+from __future__ import annotations
+
+import fakeredis
+import pytest
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin import settings as redis_admin_settings
+from redis_admin.models import RedisQueueItem
+
+
+@pytest.fixture
+def patched_redis(monkeypatch) -> fakeredis.FakeStrictRedis:
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(redis_admin_conn, "get_connection", lambda: server)
+    return server
+
+
+def test_unfiltered_queryset_is_empty(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    assert list(RedisQueueItem.objects.all()) == []
+    assert RedisQueueItem.objects.all().count() == 0
+
+
+def test_filter_by_queue_name_exact_returns_list_items(patched_redis):
+    patched_redis.rpush("uploads/1/abc", '{"upload_id": 1}')
+    patched_redis.rpush("uploads/1/abc", '{"upload_id": 2}')
+    patched_redis.rpush("uploads/1/abc", '{"upload_id": 3}')
+
+    qs = RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc")
+
+    rows = list(qs)
+    assert len(rows) == 3
+    assert [row.queue_name for row in rows] == ["uploads/1/abc"] * 3
+    assert [row.index_or_field for row in rows] == ["0", "1", "2"]
+    assert [row.raw_value for row in rows] == [
+        '{"upload_id": 1}',
+        '{"upload_id": 2}',
+        '{"upload_id": 3}',
+    ]
+    assert [row.pk_token for row in rows] == [
+        "uploads/1/abc#0",
+        "uploads/1/abc#1",
+        "uploads/1/abc#2",
+    ]
+
+
+def test_count_returns_real_llen_for_lists(patched_redis):
+    for i in range(7):
+        patched_redis.rpush("uploads/1/abc", f"x{i}")
+    assert RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc").count() == 7
+
+
+def test_slice_pagination_uses_lrange(patched_redis):
+    for i in range(10):
+        patched_redis.rpush("uploads/1/abc", f"x{i}")
+    qs = RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc")
+
+    page = qs[3:6]
+
+    assert [row.index_or_field for row in page] == ["3", "4", "5"]
+    assert [row.raw_value for row in page] == ["x3", "x4", "x5"]
+    assert [row.pk_token for row in page] == [
+        "uploads/1/abc#3",
+        "uploads/1/abc#4",
+        "uploads/1/abc#5",
+    ]
+
+
+def test_iter_caps_at_item_page_size(patched_redis, monkeypatch):
+    monkeypatch.setattr(redis_admin_settings, "ITEM_PAGE_SIZE", 5)
+    for i in range(20):
+        patched_redis.rpush("uploads/1/abc", f"x{i}")
+
+    qs = RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc")
+
+    # __iter__ honors ITEM_PAGE_SIZE so naive `list(qs)` cannot blow up.
+    rows = list(qs)
+    assert len(rows) == 5
+    # count() still reports the real length so paginator can navigate.
+    assert qs.count() == 20
+
+
+def test_long_value_is_truncated_with_suffix(patched_redis, monkeypatch):
+    monkeypatch.setattr(redis_admin_settings, "MAX_DECODE_BYTES", 16)
+    patched_redis.rpush("uploads/1/abc", "0123456789ABCDEFGHIJ")  # 20 chars
+
+    [row] = list(RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc"))
+
+    assert row.raw_value.startswith("0123456789ABCDEF")
+    assert "+4 chars truncated" in row.raw_value
+
+
+def test_unsupported_filter_kwarg_raises(patched_redis):
+    with pytest.raises(NotImplementedError):
+        RedisQueueItem.objects.filter(
+            queue_name__exact="uploads/1/abc", redis_type="LIST"
+        )
+
+
+def test_filter_by_unknown_queue_name_returns_empty(patched_redis):
+    assert list(RedisQueueItem.objects.filter(queue_name__exact="missing")) == []
+    assert RedisQueueItem.objects.filter(queue_name__exact="missing").count() == 0
+
+
+def test_set_and_hash_queues_report_zero_until_milestone_4(patched_redis):
+    # M2 only handles LIST. SET/HASH/STRING families arrive in M4; until then
+    # the item view reports zero so the changelist renders cleanly without
+    # blowing up.
+    patched_redis.sadd("upload-processing-state/1/abc", "x", "y")
+    patched_redis.hset("intermediate-report/1/abc", mapping={"a": "1", "b": "2"})
+
+    set_qs = RedisQueueItem.objects.filter(
+        queue_name__exact="upload-processing-state/1/abc"
+    )
+    hash_qs = RedisQueueItem.objects.filter(
+        queue_name__exact="intermediate-report/1/abc"
+    )
+    assert set_qs.count() == 0
+    assert hash_qs.count() == 0
+    assert list(set_qs) == []
+    assert list(hash_qs) == []
+
+
+def test_delete_raises_until_milestone_5(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    qs = RedisQueueItem.objects.filter(queue_name__exact="uploads/1/abc")
+    with pytest.raises(NotImplementedError):
+        qs.delete()

--- a/apps/codecov-api/redis_admin/tests/test_queryset.py
+++ b/apps/codecov-api/redis_admin/tests/test_queryset.py
@@ -73,9 +73,12 @@ def test_queryset_filter_with_no_args_is_a_clone(patched_redis):
     assert RedisQueue.objects.filter().count() == 1
 
 
-def test_queryset_filter_with_kwargs_raises_until_milestone3(patched_redis):
+def test_queryset_filter_unknown_kwarg_raises_not_implemented(patched_redis):
+    """Unrecognised filter kwargs should fail loudly so missing M3+ work
+    is obvious instead of silently returning everything."""
+    patched_redis.rpush("uploads/1/aa", "x")
     with pytest.raises(NotImplementedError):
-        list(RedisQueue.objects.filter(family="uploads"))
+        list(RedisQueue.objects.filter(repo_owner="not-a-real-field"))
 
 
 def test_queryset_delete_raises_until_milestone5(patched_redis):
@@ -96,6 +99,81 @@ def test_queryset_returns_positive_ttl_when_set(patched_redis):
     [row] = list(RedisQueue.objects.all())
     assert row.ttl_seconds is not None
     assert 0 < row.ttl_seconds <= 600
+
+
+def test_queryset_filter_by_repoid_pushes_into_scan(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    patched_redis.rpush("uploads/2/def", "x")
+    patched_redis.rpush("ta_flake_key:1", "x")
+
+    rows = list(RedisQueue.objects.filter(repoid=1))
+    names = {r.name for r in rows}
+    assert names == {"uploads/1/abc", "ta_flake_key:1"}
+    for row in rows:
+        assert row.repoid == 1
+
+
+def test_queryset_filter_by_family_only_returns_that_family(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    patched_redis.rpush("ta_flake_key:1", "x")
+
+    rows = list(RedisQueue.objects.filter(family__exact="uploads"))
+    assert {r.name for r in rows} == {"uploads/1/abc"}
+
+
+def test_queryset_filter_by_commitid_prefix_post_scan(patched_redis):
+    patched_redis.rpush("uploads/1/abcdef", "x")
+    patched_redis.rpush("uploads/1/abczzz", "x")
+    patched_redis.rpush("uploads/1/zzzzzz", "x")
+
+    rows = list(RedisQueue.objects.filter(commitid__startswith="abc"))
+    assert {r.name for r in rows} == {"uploads/1/abcdef", "uploads/1/abczzz"}
+
+
+def test_queryset_filter_by_depth_gte_drops_shallow_rows(patched_redis):
+    patched_redis.rpush("uploads/1/shallow", "x")
+    for i in range(5):
+        patched_redis.rpush("uploads/1/deep", f"x{i}")
+
+    rows = list(RedisQueue.objects.filter(depth__gte=3))
+    assert {r.name for r in rows} == {"uploads/1/deep"}
+
+
+def test_queryset_filter_by_report_type_post_scan(patched_redis):
+    patched_redis.rpush("uploads/1/sha", "x")  # coverage default
+    patched_redis.rpush("uploads/1/sha/test_results", "x")
+    patched_redis.rpush("uploads/1/sha/bundle_analysis", "x")
+
+    rows = list(RedisQueue.objects.filter(report_type="test_results"))
+    assert [r.name for r in rows] == ["uploads/1/sha/test_results"]
+
+
+def test_queryset_filter_with_non_int_repoid_returns_empty(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    rows = list(RedisQueue.objects.filter(repoid="not-a-number"))
+    assert rows == []
+
+
+def test_queryset_filter_by_name_icontains_post_scan(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    patched_redis.rpush("ta_flake_key:1", "x")
+
+    rows = list(RedisQueue.objects.filter(name__icontains="flake"))
+    assert {r.name for r in rows} == {"ta_flake_key:1"}
+
+
+def test_queryset_populates_repoid_commitid_report_type(patched_redis):
+    patched_redis.rpush("uploads/77/somesha/test_results", "x")
+    patched_redis.rpush("ta_flake_key:88", "x")
+
+    rows = {r.name: r for r in RedisQueue.objects.all()}
+    uploads_row = rows["uploads/77/somesha/test_results"]
+    assert uploads_row.repoid == 77
+    assert uploads_row.commitid == "somesha"
+    assert uploads_row.report_type == "test_results"
+    flake_row = rows["ta_flake_key:88"]
+    assert flake_row.repoid == 88
+    assert flake_row.commitid is None
 
 
 def test_max_scan_keys_limits_result_set(patched_redis, settings, monkeypatch):


### PR DESCRIPTION
## Summary

Stacked on top of #885 (M1 read-only key list). Combines milestones 2
and 3 of the redis_admin queue browser plan into a single review. The
M2-only PR (#886) is now closed and superseded by this one.

End-of-M3 acceptance: in the Redis queues changelist, type
`repoid:1234` in the search box and you get every backed-up queue for
that repo across `uploads/*` and `ta_flake_key:*`.

This PR contains two logical commits:

1. **M2 — per-queue items view** (`feat(api): redis_admin per-queue items view (M2)`)
   - `RedisQueueItem` unmanaged model + `RedisItemQuerySet` keyed on
     `queue_name__exact=<key>` (gated so the items changelist refuses to
     scan the whole keyspace).
   - LRANGE-based pagination capped by `ITEM_PAGE_SIZE`; values
     truncated by `MAX_DECODE_BYTES` for safe display.
   - `items_link` column on the queues changelist linking to the items
     view, plus a helper message when the items view is opened
     unfiltered.

2. **M3 — filters, search, repo/commit links** (`feat(api): redis_admin filters, search, repo/commit links (M3)`)
   - Real `parse_key` for `uploads/{repoid}/{commitid}[/{report_type}]`
     and `ta_flake_key:{repoid}`; `repoid` / `commitid` /
     `report_type` surfaced as columns on `RedisQueue`.
   - `pattern_for` SCAN MATCH push-down so a `repoid` or `commitid`
     filter narrows the scan instead of fanning out across the whole
     keyspace; `ta_flake_key` with a known repoid becomes an exact
     lookup.
   - `RedisQueueQuerySet.filter()` understands `family[__exact]`,
     `repoid[__exact]`, `commitid[__exact|__startswith]`,
     `report_type`, `depth__gte`, and `name__i?contains`. Pushdown-
     friendly filters go to `iter_keys`; the rest become a post-scan
     predicate. Unrecognised kwargs still raise `NotImplementedError`.
   - `list_filter=(FamilyFilter, MinDepthFilter, ReportTypeFilter)` plus
     `repoid_link` / `commitid_link` columns deep-linking to
     `admin:core_repository_change` and
     `admin:core_commit_changelist?q=<sha>`.
   - Custom `get_search_results` parses `repoid:1234`,
     `commitid:abc`, `family:uploads`, `report_type:test_results`
     tokens (plain substrings still match the Redis key).

## What's still NOT in this PR

- M4: `latest_upload`, `upload-processing-state`,
  `intermediate-report`, Celery broker queues, locks family.
- M5: per-queue and per-item delete actions with confirmation +
  audit logging + dry-run.
- M6: cross-family clear-by-scope.
- M7: docs + final polish.

Mutations remain disabled (`has_add_permission` /
`has_delete_permission` return `False`; `RedisQueueQuerySet.delete`
raises `NotImplementedError`).

## Test plan

- [x] 58 tests passing across `redis_admin/tests/`:
  - M1 baseline still green (queue changelist, ordering, non-staff
    redirect).
  - 14 new M2 tests for the items queryset + admin (LRANGE pagination,
    truncation, `queue_name__exact` gating, helper message).
  - 31 new M3 tests for parsers, `pattern_for` pushdown, queryset
    filters, list_filters, search-token end-to-end, and the
    repoid/commitid deep-links.
- [x] `ruff check` and `ruff format` clean across `redis_admin/`.
- [ ] Manually exercise `?q=repoid:N` and the list_filter sidebar in a
  staging-like environment.

## Stacking

Base: `tomhu/redis-admin-m1-view-keys` (#885). M4+M5 will be a
separate PR stacked on top of this one.

## Plan reference

`/Users/tomhu/.cursor/plans/redis_admin_queue_browser_50236495.plan.md`
— this PR closes M2 and M3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands Django admin’s Redis-backed browsing with new query/filter logic and Redis SCAN/LRANGE access; correctness/perf issues could hide queues or increase Redis load, but functionality remains read-only and staff-gated.
> 
> **Overview**
> Adds a new read-only *per-queue items* admin view, linked from the Redis queue list, that pages through LIST contents via LRANGE and truncates large values for safe display.
> 
> Enhances the Redis queue changelist with **filters + tokenized search** (e.g. `repoid:`, `commitid:`, `family:`, `report_type:`), plus `repo`/`commit` deep-links into core admin pages. To support this, Redis key families now parse `uploads/*` and `ta_flake_key:*` into structured fields (repoid/commitid/report type) and can tighten SCAN patterns for filtered searches; the Redis-backed queryset now supports these filters with a mix of SCAN pushdown and post-scan predicates, and adds comprehensive unit + admin smoke tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9eb74d744d58f57efffa50086abb5e9c2336e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->