### PR TITLE
feat(api): redis_admin M4 + M5 — new families, locks view, deletion service

### DIFF
--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -483,6 +483,11 @@ class RedisQueueItemAdmin(admin.ModelAdmin):
     # Empty actions tuple = no bulk actions at all (not even
     # `delete_selected`), so the changelist's action dropdown is hidden.
     actions = ()
+    # The "change" page is a strict read-only inspector for a single
+    # item: every field is readonly, the form is short-circuited so we
+    # never build a ModelForm against an unmanaged model, and any save
+    # POST is refused.
+    readonly_fields = ("pk_token", "queue_name", "index_or_field", "raw_value")
 
     def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
@@ -495,6 +500,23 @@ class RedisQueueItemAdmin(admin.ModelAdmin):
 
     def has_view_permission(self, request: HttpRequest, obj=None) -> bool:
         return bool(request.user and request.user.is_staff)
+
+    def get_fieldsets(self, request, obj=None):
+        return ((None, {"fields": list(self.readonly_fields)}),)
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        ctx = {
+            "show_save": False,
+            "show_save_and_continue": False,
+            "show_save_and_add_another": False,
+            "show_save_as_new": False,
+        }
+        if extra_context:
+            ctx.update(extra_context)
+        return super().changeform_view(request, object_id, form_url, ctx)
+
+    def save_model(self, request, obj, form, change):
+        raise RuntimeError("RedisQueueItem rows are read-only.")
 
     def lookup_allowed(self, lookup, value) -> bool:
         if lookup == "queue_name__exact":

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -26,7 +26,8 @@ from django.utils.html import format_html
 
 from . import settings as redis_admin_settings
 from .families import FAMILIES
-from .models import RedisQueue, RedisQueueItem
+from .models import RedisLock, RedisQueue, RedisQueueItem
+from .services import redis_delete
 
 # ---- list_filter classes ---------------------------------------------------
 
@@ -34,15 +35,22 @@ from .models import RedisQueue, RedisQueueItem
 class FamilyFilter(admin.SimpleListFilter):
     title = "family"
     parameter_name = "family"
+    # `RedisQueueAdmin` and `RedisLockAdmin` override this on their
+    # subclass so each admin only lists families it actually surfaces.
+    category: str = "queue"
 
     def lookups(self, request, model_admin):
-        return tuple((f.name, f.name) for f in FAMILIES)
+        return tuple((f.name, f.name) for f in FAMILIES if f.category == self.category)
 
     def queryset(self, request, queryset):
         value = self.value()
         if value:
             return queryset.filter(family__exact=value)
         return queryset
+
+
+class LockFamilyFilter(FamilyFilter):
+    category = "lock"
 
 
 class MinDepthFilter(admin.SimpleListFilter):
@@ -159,8 +167,10 @@ class RedisQueueAdmin(admin.ModelAdmin):
     def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
         return bool(request.user and request.user.is_staff)
 
+    # M5: delete is gated on `is_superuser`, *not* `is_staff`. Staff
+    # users can still browse and dry-run; only superusers can commit.
     def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
-        return False
+        return bool(request.user and request.user.is_superuser)
 
     def get_search_results(self, request, queryset, search_term):
         if not search_term:
@@ -172,6 +182,49 @@ class RedisQueueAdmin(admin.ModelAdmin):
         if not kwargs:
             return queryset, False
         return queryset.filter(**kwargs), False
+
+    # ---- Delete actions (M5.2) -----------------------------------------
+
+    actions = ("clear_dry_run",)
+
+    @admin.action(
+        description="Dry-run: count what 'delete selected' would clear",
+        permissions=("change",),
+    )
+    def clear_dry_run(self, request: HttpRequest, queryset) -> None:
+        result = redis_delete(list(queryset), user=request.user, dry_run=True)
+        self.message_user(
+            request,
+            (
+                f"Dry-run: would delete {result.count} key(s) across "
+                f"families={list(result.families) or '[]'}; "
+                f"sample={list(result.sample[:5])}"
+                + (f"; refused={list(result.refused[:5])}" if result.refused else "")
+            ),
+            level=messages.INFO,
+        )
+
+    def delete_queryset(self, request: HttpRequest, queryset) -> None:
+        """Bulk 'Delete selected' on the queues changelist."""
+        result = redis_delete(list(queryset), user=request.user, dry_run=False)
+        self.message_user(
+            request,
+            (
+                f"Cleared {result.count} Redis key(s) across "
+                f"families={list(result.families) or '[]'}"
+                + (f"; refused={list(result.refused[:5])}" if result.refused else "")
+            ),
+            level=messages.SUCCESS,
+        )
+
+    def delete_model(self, request: HttpRequest, obj: RedisQueue) -> None:
+        """Single-object delete from the change page."""
+        result = redis_delete([obj], user=request.user, dry_run=False)
+        self.message_user(
+            request,
+            f"Cleared Redis key {obj.name!r} ({result.count} removed).",
+            level=messages.SUCCESS,
+        )
 
     @admin.display(description="repo")
     def repoid_link(self, obj: RedisQueue) -> str:
@@ -203,20 +256,118 @@ class RedisQueueAdmin(admin.ModelAdmin):
         return format_html('<a href="{}?{}">view items</a>', url, query)
 
 
-# ---- Item changelist (M2) --------------------------------------------------
+# ---- Lock changelist (M4.3) ------------------------------------------------
 
 
-@admin.register(RedisQueueItem)
-class RedisQueueItemAdmin(admin.ModelAdmin):
-    list_display = ("index_or_field", "raw_value_truncated")
-    list_per_page = redis_admin_settings.ITEM_PAGE_SIZE
+@admin.register(RedisLock)
+class RedisLockAdmin(admin.ModelAdmin):
+    """Read-only admin for coordination locks, gates, and fences.
+
+    Operators can browse to confirm a stuck task left a lock behind, but
+    deletion is hard-disabled: the worker tasks that own these locks
+    rely on them being released by `LockManager`, not by an operator
+    clicking around in the admin. M5's delete service additionally
+    refuses any key whose family has `is_deletable=False` so accidental
+    URL-tampering can't bypass this.
+    """
+
+    list_display = (
+        "name",
+        "family",
+        "redis_type",
+        "ttl_seconds",
+        "repoid_link",
+        "commitid_link",
+        "report_type",
+    )
+    list_filter = (LockFamilyFilter,)
+    list_per_page = 50
     show_full_result_count = False
+    ordering = ("family", "name")
+    search_fields = ("name",)
+    search_help_text = (
+        "search by 'repoid:1234', 'commitid:abc', 'family:upload_finisher_gate', "
+        "or any substring of the lock key"
+    )
 
     def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
 
     def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
-        # No detail/edit page yet; M5 wires up per-item delete actions.
+        return bool(request.user and request.user.is_staff)
+
+    # Locks are never deletable from the admin, regardless of role; the
+    # worker's `LockManager` is the only legitimate releaser.
+    def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def get_actions(self, request):
+        # Strip the default `delete_selected` even though
+        # `has_delete_permission` already blocks it; this keeps the
+        # action dropdown empty so there's nothing to click.
+        actions = super().get_actions(request)
+        actions.pop("delete_selected", None)
+        return actions
+
+    def get_search_results(self, request, queryset, search_term):
+        if not search_term:
+            return queryset, False
+        try:
+            kwargs = _parse_search_term(search_term)
+        except NotImplementedError:
+            return queryset.none(), False
+        if not kwargs:
+            return queryset, False
+        return queryset.filter(**kwargs), False
+
+    @admin.display(description="repo")
+    def repoid_link(self, obj: RedisLock) -> str:
+        if not obj.repoid:
+            return "—"
+        try:
+            url = reverse("admin:core_repository_change", args=[obj.repoid])
+        except NoReverseMatch:
+            return str(obj.repoid)
+        return format_html('<a href="{}">{}</a>', url, obj.repoid)
+
+    @admin.display(description="commit")
+    def commitid_link(self, obj: RedisLock) -> str:
+        if not obj.commitid:
+            return "—"
+        try:
+            base = reverse("admin:core_commit_changelist")
+        except NoReverseMatch:
+            return obj.commitid[:7]
+        url = f"{base}?{urlencode({'q': obj.commitid})}"
+        return format_html(
+            '<a href="{}" title="{}">{}</a>', url, obj.commitid, obj.commitid[:7]
+        )
+
+
+# ---- Item changelist (M2) --------------------------------------------------
+
+
+@admin.register(RedisQueueItem)
+class RedisQueueItemAdmin(admin.ModelAdmin):
+    """Read-only items view (M2). M5 mutations operate at the *queue*
+    level (DEL the whole key), not per-item: per-item LREM/SREM/HDEL
+    requires reconstructing the original Redis value from the admin
+    pk_token, which we deliberately don't expose to keep operator
+    actions auditable and unambiguous. Operators who need to drop a
+    bad message clear the entire queue from `RedisQueueAdmin`.
+    """
+
+    list_display = ("index_or_field", "raw_value_truncated")
+    list_per_page = redis_admin_settings.ITEM_PAGE_SIZE
+    show_full_result_count = False
+    # Empty actions tuple = no bulk actions at all (not even
+    # `delete_selected`), so the changelist's action dropdown is hidden.
+    actions = ()
+
+    def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
 
     def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -20,16 +20,119 @@ from __future__ import annotations
 from urllib.parse import urlencode
 
 from django.contrib import admin, messages
+from django.contrib.admin.utils import quote, unquote
 from django.http import HttpRequest
 from django.urls import NoReverseMatch, reverse
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 
 from core.models import Repository
 
 from . import settings as redis_admin_settings
 from .families import FAMILIES
 from .models import RedisLock, RedisQueue, RedisQueueItem
+from .queryset import RedisItemQuerySet
 from .services import redis_delete
+
+# ---- Inline items preview (rendered on the queue change page) --------------
+#
+# Showing the items "below" the readonly field block on the change page
+# saves a click on the overwhelmingly common "operator clicked a
+# backed-up queue, wants to see what's stuck" investigation flow.
+#
+# We deliberately render this as Django admin's *tabular inline* DOM
+# (`<div class="js-inline-admin-formset inline-group"><fieldset
+# class="module">…</fieldset></div>`) rather than as a readonly field
+# value, so it picks up the standard admin CSS for inlines and visually
+# matches `TabularInline` blocks elsewhere in the admin. We can't use a
+# real `TabularInline` because `RedisQueueItem` is unmanaged and has no
+# FK back to the parent queue.
+_ITEMS_PREVIEW_MAX_ROWS = 20
+
+
+def _render_items_inline(obj, *, max_rows: int = _ITEMS_PREVIEW_MAX_ROWS):
+    """Render the items in `obj` as Django admin tabular-inline HTML.
+
+    Called from `RedisQueueAdmin.change_view` /
+    `RedisLockAdmin.change_view` and injected into the change form via
+    a custom template. Each row links to the per-item inspector for
+    drill-in; a footer link points at the full items changelist so
+    paging beyond the preview is one click away.
+    """
+
+    items_qs = RedisItemQuerySet(RedisQueueItem, queue_name=obj.name)
+    snapshot = list(items_qs[:max_rows])
+
+    full_url = reverse("admin:redis_admin_redisqueueitem_changelist")
+    full_link = format_html(
+        '<a href="{}?queue_name__exact={}">view all items \u2192</a>',
+        full_url,
+        obj.name,
+    )
+
+    heading = format_html("<h2>{}</h2>", "Items")
+
+    if not snapshot:
+        body = format_html(
+            '<p class="paginator">{} <em>(empty / nothing to preview)</em></p>',
+            full_link,
+        )
+        return format_html(
+            '<div class="js-inline-admin-formset inline-group">'
+            '<div class="tabular inline-related last-related">'
+            '<fieldset class="module">{}{}</fieldset>'
+            "</div></div>",
+            heading,
+            body,
+        )
+
+    item_change_url = "admin:redis_admin_redisqueueitem_change"
+    rows = format_html_join(
+        "",
+        '<tr class="form-row has_original">'
+        '<td class="original">'
+        '<p><a href="{}" class="inlineviewlink">View</a></p>'
+        "</td>"
+        '<td class="field-index_or_field"><p>{}</p></td>'
+        '<td class="field-raw_value"><pre style="margin:0;'
+        'white-space:pre-wrap;word-break:break-all;">{}</pre></td>'
+        "</tr>",
+        (
+            (
+                reverse(item_change_url, args=[quote(item.pk_token)]),
+                item.index_or_field,
+                item.raw_value or "",
+            )
+            for item in snapshot
+        ),
+    )
+
+    table = format_html(
+        "<table>"
+        "<thead><tr>"
+        '<th class="original"></th>'
+        '<th class="column-index_or_field">Index / field</th>'
+        '<th class="column-raw_value">Value</th>'
+        "</tr></thead>"
+        "<tbody>{}</tbody>"
+        "</table>",
+        rows,
+    )
+
+    footer = format_html(
+        '<p class="paginator">showing first {} item(s); {}</p>',
+        len(snapshot),
+        full_link,
+    )
+
+    return format_html(
+        '<div class="js-inline-admin-formset inline-group">'
+        '<div class="tabular inline-related last-related">'
+        '<fieldset class="module">{}{}{}</fieldset>'
+        "</div></div>",
+        heading,
+        table,
+        footer,
+    )
 
 
 def _hydrate_repo_displays(rows) -> None:
@@ -205,6 +308,10 @@ class RedisQueueAdmin(admin.ModelAdmin):
         "report_type",
     )
 
+    # Override the change form so we can inject a tabular-inline-style
+    # "Items" block below the readonly fields.
+    change_form_template = "admin/redis_admin/items_inline_change_form.html"
+
     def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
 
@@ -231,6 +338,16 @@ class RedisQueueAdmin(admin.ModelAdmin):
             "show_save_and_add_another": False,
             "show_save_as_new": False,
         }
+        if object_id is not None:
+            try:
+                # `object_id` arrives URL-escaped (admin uses `_2F` rather
+                # than `%2F` for `/`); Django's `_changeform_view` runs the
+                # same `unquote` before its own `get_object` call.
+                obj = self.get_object(request, unquote(object_id))
+            except self.model.DoesNotExist:
+                obj = None
+            if obj is not None:
+                ctx["redis_admin_items_inline"] = _render_items_inline(obj)
         if extra_context:
             ctx.update(extra_context)
         return super().changeform_view(request, object_id, form_url, ctx)
@@ -383,6 +500,10 @@ class RedisLockAdmin(admin.ModelAdmin):
         "report_type",
     )
 
+    # Inject the same tabular-inline items block as `RedisQueueAdmin`,
+    # so an operator can see what value the lock holds.
+    change_form_template = "admin/redis_admin/items_inline_change_form.html"
+
     def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
 
@@ -412,6 +533,13 @@ class RedisLockAdmin(admin.ModelAdmin):
             "show_save_and_add_another": False,
             "show_save_as_new": False,
         }
+        if object_id is not None:
+            try:
+                obj = self.get_object(request, unquote(object_id))
+            except self.model.DoesNotExist:
+                obj = None
+            if obj is not None:
+                ctx["redis_admin_items_inline"] = _render_items_inline(obj)
         if extra_context:
             ctx.update(extra_context)
         return super().changeform_view(request, object_id, form_url, ctx)

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -160,6 +160,20 @@ class RedisQueueAdmin(admin.ModelAdmin):
         "search by 'repoid:1234', 'commitid:abc', 'family:uploads', "
         "'report_type:test_results', or any substring of the Redis key"
     )
+    # The change page is a read-only inspector: every field is `readonly_fields`
+    # so the form has no inputs, and `change_view` strips the Save buttons.
+    # The standard "Delete" button still renders for superusers and routes
+    # through our audited `redis_delete` service via `delete_model`.
+    readonly_fields = (
+        "name",
+        "family",
+        "redis_type",
+        "depth",
+        "ttl_seconds",
+        "repoid",
+        "commitid",
+        "report_type",
+    )
 
     def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
@@ -171,6 +185,31 @@ class RedisQueueAdmin(admin.ModelAdmin):
     # users can still browse and dry-run; only superusers can commit.
     def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
         return bool(request.user and request.user.is_superuser)
+
+    def get_fieldsets(self, request, obj=None):
+        # Avoid the default ModelForm-based fieldset detection (which would
+        # build a form against an unmanaged model); render every readonly
+        # field in a single section instead.
+        return ((None, {"fields": list(self.readonly_fields)}),)
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        # Strip every save-related button so a stray POST can't reach
+        # `save_model`. Delete still renders via the standard admin button.
+        ctx = {
+            "show_save": False,
+            "show_save_and_continue": False,
+            "show_save_and_add_another": False,
+            "show_save_as_new": False,
+        }
+        if extra_context:
+            ctx.update(extra_context)
+        return super().changeform_view(request, object_id, form_url, ctx)
+
+    def save_model(self, request, obj, form, change):
+        # Defensive: should be unreachable because the change form has no
+        # editable fields, but Redis-backed rows must never round-trip
+        # through Django's SQL save path.
+        raise RuntimeError("RedisQueue rows are read-only.")
 
     def get_search_results(self, request, queryset, search_term):
         if not search_term:
@@ -289,6 +328,15 @@ class RedisLockAdmin(admin.ModelAdmin):
         "search by 'repoid:1234', 'commitid:abc', 'family:upload_finisher_gate', "
         "or any substring of the lock key"
     )
+    readonly_fields = (
+        "name",
+        "family",
+        "redis_type",
+        "ttl_seconds",
+        "repoid",
+        "commitid",
+        "report_type",
+    )
 
     def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
@@ -308,6 +356,23 @@ class RedisLockAdmin(admin.ModelAdmin):
         actions = super().get_actions(request)
         actions.pop("delete_selected", None)
         return actions
+
+    def get_fieldsets(self, request, obj=None):
+        return ((None, {"fields": list(self.readonly_fields)}),)
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        ctx = {
+            "show_save": False,
+            "show_save_and_continue": False,
+            "show_save_and_add_another": False,
+            "show_save_as_new": False,
+        }
+        if extra_context:
+            ctx.update(extra_context)
+        return super().changeform_view(request, object_id, form_url, ctx)
+
+    def save_model(self, request, obj, form, change):
+        raise RuntimeError("RedisLock rows are read-only.")
 
     def get_search_results(self, request, queryset, search_term):
         if not search_term:

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -24,10 +24,39 @@ from django.http import HttpRequest
 from django.urls import NoReverseMatch, reverse
 from django.utils.html import format_html
 
+from core.models import Repository
+
 from . import settings as redis_admin_settings
 from .families import FAMILIES
 from .models import RedisLock, RedisQueue, RedisQueueItem
 from .services import redis_delete
+
+
+def _hydrate_repo_displays(rows) -> None:
+    """Attach `_repo_display = "service:owner/name"` to each row in one query.
+
+    Called from `get_changelist_instance` to avoid an N+1 lookup per row.
+    """
+
+    repoids = {row.repoid for row in rows if row.repoid}
+    for row in rows:
+        row._repo_display = None
+    if not repoids:
+        return
+
+    mapping = {
+        repo.repoid: (
+            f"{repo.author.service}:{repo.author.username}/{repo.name}"
+            if repo.author and repo.author.username
+            else repo.name
+        )
+        for repo in Repository.objects.select_related("author").filter(
+            repoid__in=repoids
+        )
+    }
+    for row in rows:
+        row._repo_display = mapping.get(row.repoid)
+
 
 # ---- list_filter classes ---------------------------------------------------
 
@@ -144,6 +173,7 @@ class RedisQueueAdmin(admin.ModelAdmin):
         "depth",
         "ttl_seconds",
         "repoid_link",
+        "repo_display",
         "commitid_link",
         "report_type",
         "items_link",
@@ -275,6 +305,10 @@ class RedisQueueAdmin(admin.ModelAdmin):
             return str(obj.repoid)
         return format_html('<a href="{}">{}</a>', url, obj.repoid)
 
+    @admin.display(description="repo (owner/name)")
+    def repo_display(self, obj: RedisQueue) -> str:
+        return getattr(obj, "_repo_display", None) or "—"
+
     @admin.display(description="commit")
     def commitid_link(self, obj: RedisQueue) -> str:
         if not obj.commitid:
@@ -293,6 +327,16 @@ class RedisQueueAdmin(admin.ModelAdmin):
         url = reverse("admin:redis_admin_redisqueueitem_changelist")
         query = urlencode({"queue_name__exact": obj.name})
         return format_html('<a href="{}?{}">view items</a>', url, query)
+
+    def get_changelist_instance(self, request):
+        # Hydrate `_repo_display` on the rows the template will actually
+        # iterate. Doing this on the root queryset doesn't work because
+        # `ChangeList` clones it (filter/order/paginate) and the clone
+        # rebuilds fresh `RedisQueue` instances without our decorations.
+        cl = super().get_changelist_instance(request)
+        if cl.result_list:
+            _hydrate_repo_displays(cl.result_list)
+        return cl
 
 
 # ---- Lock changelist (M4.3) ------------------------------------------------
@@ -316,6 +360,7 @@ class RedisLockAdmin(admin.ModelAdmin):
         "redis_type",
         "ttl_seconds",
         "repoid_link",
+        "repo_display",
         "commitid_link",
         "report_type",
     )
@@ -385,6 +430,12 @@ class RedisLockAdmin(admin.ModelAdmin):
             return queryset, False
         return queryset.filter(**kwargs), False
 
+    def get_changelist_instance(self, request):
+        cl = super().get_changelist_instance(request)
+        if cl.result_list:
+            _hydrate_repo_displays(cl.result_list)
+        return cl
+
     @admin.display(description="repo")
     def repoid_link(self, obj: RedisLock) -> str:
         if not obj.repoid:
@@ -394,6 +445,10 @@ class RedisLockAdmin(admin.ModelAdmin):
         except NoReverseMatch:
             return str(obj.repoid)
         return format_html('<a href="{}">{}</a>', url, obj.repoid)
+
+    @admin.display(description="repo (owner/name)")
+    def repo_display(self, obj: RedisLock) -> str:
+        return getattr(obj, "_repo_display", None) or "—"
 
     @admin.display(description="commit")
     def commitid_link(self, obj: RedisLock) -> str:

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -374,33 +374,61 @@ def _parse_upload_finisher_gate_key(key: str) -> ParsedKey:
     return ParsedKey(family="upload_finisher_gate", repoid=repoid, commitid=commitid)
 
 
-def _lock_pattern_factory(prefix: str, *, sep: str):
+def _lock_pattern_factory(prefix: str, *, prefix_sep: str, has_commit: bool):
     """Build a `pattern_for` for a lock family whose key shape is
-    `<prefix><sep><repoid>[<sep>...]`. Pushes `repoid` into the SCAN
-    when known; drops the family if the user filtered by commitid
-    against a key shape that has no commit segment.
+    either `<prefix><prefix_sep><repoid>` (when `has_commit=False`) or
+    `<prefix><prefix_sep><repoid>_<commit>` (when `has_commit=True`).
+    Pushes `repoid` (and `commitid_prefix` when applicable) into the
+    SCAN; drops the family entirely when the user filtered by
+    `commitid_prefix` against a `has_commit=False` key shape.
+
+    `prefix_sep` is the literal between the family prefix and the
+    repoid (`:` for `ta_flake_lock`/`ta_notifier_fence`, `_` for
+    `upload_finisher_gate`). When `has_commit` is true the
+    repoid-to-commit separator is hardcoded `_` because that's what
+    every callsite in the worker uses.
     """
 
-    has_commit = sep == "_"  # only `_`-separated locks carry a commit
-
     def pattern_for(filters: Mapping[str, Any]) -> str | None:
-        if not has_commit and filters.get("commitid_prefix"):
+        commitid = filters.get("commitid_prefix")
+        if not has_commit and commitid:
             return None
         repoid = filters.get("repoid")
+        if repoid is not None and has_commit and commitid:
+            return f"{prefix}{prefix_sep}{repoid}_{commitid}*"
         if repoid is not None:
-            return f"{prefix}{sep}{repoid}{sep if has_commit else ''}*"
-        return f"{prefix}{sep}*"
+            tail = "_*" if has_commit else "*"
+            return f"{prefix}{prefix_sep}{repoid}{tail}"
+        return f"{prefix}{prefix_sep}*"
 
     return pattern_for
 
 
-def _coordination_lock_pattern(filters: Mapping[str, Any]) -> str:
-    """`*_lock_*` is broad on purpose; we de-dup against more specific
-    families (e.g. `lock_attempts:` keys also contain `_lock_`) by
-    relying on `find_family` registration order in `iter_keys`.
+def _lock_attempts_pattern(filters: Mapping[str, Any]) -> str:
+    """`pattern_for` for the `lock_attempts:` family whose keys are
+    `lock_attempts:<coordination_lock_name>` and the coordination-
+    lock-name in turn is `<type>_lock_<repoid>_<commit>...`. The
+    repoid is buried inside the suffix, so a naive
+    `lock_attempts:<repoid>*` pushdown matches zero keys (cf. the
+    Bugbot review on PR #888). We push the embedded structure into
+    the SCAN MATCH instead.
+
+    `lock_attempts:*_lock_<repoid>_*` is still tighter than the
+    full-keyspace fallback (`lock_attempts:*`) and keeps the SCAN
+    targeted enough to be useful on busy clusters.
     """
 
-    return "*_lock_*"
+    repoid = filters.get("repoid")
+    commitid = filters.get("commitid_prefix")
+    if repoid is not None and commitid:
+        return f"lock_attempts:*_lock_{repoid}_{commitid}*"
+    if repoid is not None:
+        return f"lock_attempts:*_lock_{repoid}_*"
+    # Commitid-only pushdown isn't safe (commitid can collide with
+    # repoid digits at any position in the key); fall back to the
+    # family wildcard and let the post-scan `parse_key` filter do
+    # the work.
+    return "lock_attempts:*"
 
 
 # ---- SCAN pattern pushdown -------------------------------------------------
@@ -571,7 +599,7 @@ FAMILIES: tuple[Family, ...] = (
         scan_pattern="lock_attempts:*",
         redis_type="string",
         parse_key=_parse_lock_attempts_key,
-        pattern_for=_lock_pattern_factory("lock_attempts", sep=":"),
+        pattern_for=_lock_attempts_pattern,
         is_deletable=False,
         category="lock",
     ),
@@ -580,7 +608,9 @@ FAMILIES: tuple[Family, ...] = (
         scan_pattern="ta_flake_lock:*",
         redis_type="string",
         parse_key=_parse_ta_flake_lock_key,
-        pattern_for=_lock_pattern_factory("ta_flake_lock", sep=":"),
+        pattern_for=_lock_pattern_factory(
+            "ta_flake_lock", prefix_sep=":", has_commit=False
+        ),
         is_deletable=False,
         category="lock",
     ),
@@ -589,7 +619,9 @@ FAMILIES: tuple[Family, ...] = (
         scan_pattern="ta_notifier_fence:*",
         redis_type="string",
         parse_key=_parse_ta_notifier_fence_key,
-        pattern_for=_lock_pattern_factory("ta_notifier_fence", sep=":"),
+        pattern_for=_lock_pattern_factory(
+            "ta_notifier_fence", prefix_sep=":", has_commit=True
+        ),
         is_deletable=False,
         category="lock",
     ),
@@ -598,7 +630,9 @@ FAMILIES: tuple[Family, ...] = (
         scan_pattern="upload_finisher_gate_*",
         redis_type="string",
         parse_key=_parse_upload_finisher_gate_key,
-        pattern_for=_lock_pattern_factory("upload_finisher_gate", sep="_"),
+        pattern_for=_lock_pattern_factory(
+            "upload_finisher_gate", prefix_sep="_", has_commit=True
+        ),
         is_deletable=False,
         category="lock",
     ),

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -2,19 +2,22 @@
 
 A `Family` describes a Redis key pattern owned by some part of the system:
 how to recognise it, how to extract structured fields (repo / commit /
-report type), and how to build a tighter SCAN pattern when the admin user
-narrows their query.
+report type), how to build a tighter SCAN pattern when the admin user
+narrows their query, and (optionally) how to decode a single item for
+display.
 
-Milestone 1 just enumerated keys; milestone 3 makes the parsers real and
-adds the SCAN pushdown helpers used by the changelist's filter/search.
-Milestone 4 will extend the registry with `latest_upload`,
-`upload-processing-state`, `intermediate-report`, the Celery broker
-queues, and the locks family.
+Milestone 1 enumerated keys; M3 added repo/commit parsers + pushdown;
+M4 extends the registry with the remaining Redis-backed surfaces:
+`latest_upload`, `upload-processing-state`, `intermediate-report`, the
+Celery broker queues (with kombu-envelope decoding), and a read-only
+locks family.
 """
 
 from __future__ import annotations
 
+import base64
 import fnmatch
+import json
 import logging
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
@@ -34,7 +37,8 @@ class ParsedKey:
     """Structured view of a Redis key once we know which family it belongs to.
 
     Fields are optional because not every family encodes every dimension in
-    its key (e.g. `ta_flake_key:{repoid}` has no commitid).
+    its key (e.g. `ta_flake_key:{repoid}` has no commitid;
+    `intermediate-report/{upload_id}` has only an upload_id).
     """
 
     family: str
@@ -42,6 +46,7 @@ class ParsedKey:
     commitid: str | None = None
     report_type: str | None = None
     upload_id: str | None = None
+    state: str | None = None
 
 
 # ---- Parsers ---------------------------------------------------------------
@@ -87,6 +92,317 @@ def _parse_ta_flake_key(key: str) -> ParsedKey:
     return ParsedKey(family="ta_flake_key", repoid=repoid)
 
 
+def _parse_latest_upload_key(key: str) -> ParsedKey:
+    """`latest_upload/{repoid}/{commitid}` (coverage default) or
+    `latest_upload/{repoid}/{commitid}/{report_type}`.
+
+    Mirrors the key shape written next to the matching `uploads/` queue
+    by `upload.helpers.dispatch_upload_task`.
+    """
+
+    parts = key.split("/", 3)
+    if len(parts) < 3 or parts[0] != "latest_upload":
+        return ParsedKey(family="latest_upload")
+    repoid: int | None
+    try:
+        repoid = int(parts[1])
+    except ValueError:
+        repoid = None
+    commitid = parts[2] or None
+    report_type = parts[3] if len(parts) >= 4 and parts[3] else "coverage"
+    return ParsedKey(
+        family="latest_upload",
+        repoid=repoid,
+        commitid=commitid,
+        report_type=report_type,
+    )
+
+
+def _parse_upload_processing_state_key(key: str) -> ParsedKey:
+    """`upload-processing-state/{repoid}/{commitsha}/{state}` written by
+    `apps/worker/services/processing/state.py`. Each state lives in its
+    own SET key; the trailing `{state}` segment is preserved on the
+    parsed `state` field for context.
+    """
+
+    parts = key.split("/", 3)
+    if len(parts) < 3 or parts[0] != "upload-processing-state":
+        return ParsedKey(family="upload-processing-state")
+    repoid: int | None
+    try:
+        repoid = int(parts[1])
+    except ValueError:
+        repoid = None
+    commitid = parts[2] or None
+    state = parts[3] if len(parts) >= 4 and parts[3] else None
+    return ParsedKey(
+        family="upload-processing-state",
+        repoid=repoid,
+        commitid=commitid,
+        state=state,
+    )
+
+
+def _parse_intermediate_report_key(key: str) -> ParsedKey:
+    """`intermediate-report/{upload_id}` written by
+    `apps/worker/services/processing/intermediate.py`. The key shape
+    only carries an `upload_id`; `repoid` / `commitid` are not derivable
+    without a DB lookup we deliberately don't do here.
+    """
+
+    if not key.startswith("intermediate-report/"):
+        return ParsedKey(family="intermediate-report")
+    upload_id = key[len("intermediate-report/") :] or None
+    return ParsedKey(family="intermediate-report", upload_id=upload_id)
+
+
+def _parse_celery_broker_key(_: str) -> ParsedKey:
+    """Celery broker queues are keyed by their queue name (`celery`,
+    `healthcheck`, `enterprise_*`, etc.); none of them carry repo or
+    commit info in the *queue* key. Per-item decoding is what surfaces
+    `repoid`/`commitid` (see `_celery_decode_value`).
+    """
+
+    return ParsedKey(family="celery_broker")
+
+
+def _resolve_celery_queue_names() -> tuple[str, ...]:
+    """Best-effort enumeration of the well-known Celery queue names.
+
+    Reads from the live `BaseCeleryConfig` so we pick up any queues an
+    operator configured via `setup.tasks.*.queue`. Falls back to the two
+    documented defaults if the import fails (e.g. during tests or in a
+    minimal environment).
+    """
+
+    try:
+        from shared.celery_config import BaseCeleryConfig  # noqa: PLC0415
+    except Exception:  # pragma: no cover - defensive: any import error
+        log.warning(
+            "redis_admin: could not import BaseCeleryConfig; "
+            "using ('celery', 'healthcheck') only"
+        )
+        return ("celery", "healthcheck")
+
+    names: set[str] = set()
+    names.add(getattr(BaseCeleryConfig, "task_default_queue", "celery") or "celery")
+    names.add(
+        getattr(BaseCeleryConfig, "health_check_default_queue", "healthcheck")
+        or "healthcheck"
+    )
+    routes = getattr(BaseCeleryConfig, "task_routes", {}) or {}
+    for spec in routes.values():
+        if isinstance(spec, dict):
+            queue_name = spec.get("queue")
+            if isinstance(queue_name, str) and queue_name:
+                names.add(queue_name)
+    return tuple(sorted(names))
+
+
+def _peek_celery_envelope(decoded: str) -> tuple[str | None, int | None, str | None]:
+    """Pull `(task, repoid, commitid)` from a kombu JSON envelope.
+
+    Returns `(None, None, None)` for anything we can't parse so the
+    fallback is "show the raw payload" rather than "crash the admin".
+    """
+
+    try:
+        envelope = json.loads(decoded)
+    except (ValueError, TypeError):
+        return (None, None, None)
+    if not isinstance(envelope, dict):
+        return (None, None, None)
+
+    headers = envelope.get("headers") or {}
+    task = headers.get("task") if isinstance(headers, dict) else None
+    if not isinstance(task, str):
+        task = None
+
+    repoid: int | None = None
+    commitid: str | None = None
+    body_b64 = envelope.get("body")
+    if isinstance(body_b64, str) and body_b64:
+        try:
+            body_bytes = base64.b64decode(body_b64, validate=False)
+            body = json.loads(body_bytes.decode("utf-8", errors="replace"))
+        except (ValueError, TypeError, UnicodeDecodeError):
+            body = None
+        if isinstance(body, list) and len(body) >= 2 and isinstance(body[1], dict):
+            kwargs = body[1]
+            rid = kwargs.get("repoid")
+            if isinstance(rid, int):
+                repoid = rid
+            elif isinstance(rid, str) and rid.isdigit():
+                repoid = int(rid)
+            cid = kwargs.get("commitid")
+            if isinstance(cid, str) and cid:
+                commitid = cid
+    return (task, repoid, commitid)
+
+
+def _celery_decode_value(raw_decoded: str) -> str:
+    """Prefix the kombu payload with a one-line summary if we can."""
+
+    task, repoid, commitid = _peek_celery_envelope(raw_decoded)
+    parts: list[str] = []
+    if task:
+        parts.append(f"task={task}")
+    if repoid is not None:
+        parts.append(f"repoid={repoid}")
+    if commitid:
+        short = commitid[:7]
+        parts.append(f"commit={short}")
+    if parts:
+        return f"[{' '.join(parts)}] {raw_decoded}"
+    return raw_decoded
+
+
+def _celery_pattern(filters: Mapping[str, Any]) -> str | None:
+    """Celery queue *keys* don't carry repoid/commitid; if those filters
+    are set, every Celery queue would be dropped post-scan, so skip the
+    family entirely.
+    """
+
+    if filters.get("repoid") is not None or filters.get("commitid_prefix"):
+        return None
+    return "enterprise_*"
+
+
+# ---- Lock parsers (M4.3) ---------------------------------------------------
+#
+# Locks / fences / gates are read-only in the admin: deleting an active
+# lock could cause race conditions in the worker tasks that own them.
+# Their families are registered with `is_deletable=False`, surface only
+# in the `RedisLock` admin (not `RedisQueue`), and never accept a
+# `DELETE` from `services.redis_delete()` (M5).
+
+
+def _split_lock_tail(tail: str) -> tuple[int | None, str | None, str | None]:
+    """Pull `(repoid, commitid, report_type)` out of `<repoid>_<commit>[_<rt>]`.
+
+    Used by every lock-family parser since the suffix shape is shared.
+    """
+
+    if not tail:
+        return (None, None, None)
+    parts = tail.split("_")
+    repoid: int | None = None
+    commitid: str | None = None
+    report_type: str | None = None
+    if parts and parts[0]:
+        try:
+            repoid = int(parts[0])
+        except ValueError:
+            repoid = None
+    if len(parts) >= 2:
+        commitid = parts[1] or None
+    if len(parts) >= 3:
+        report_type = "_".join(parts[2:]) or None
+    return (repoid, commitid, report_type)
+
+
+def _parse_coordination_lock_name(family_name: str, name: str) -> ParsedKey:
+    """`<type>_lock_<repoid>_<commit>[_<report_type>]` per
+    `apps/worker/services/lock_manager.py::LockManager.lock_name`.
+    Shared by the `coordination_lock` family and `lock_attempts:` keys
+    (which embed a coordination-lock name as their suffix).
+    """
+
+    sep = "_lock_"
+    if sep not in name:
+        return ParsedKey(family=family_name)
+    _, _, tail = name.partition(sep)
+    repoid, commitid, report_type = _split_lock_tail(tail)
+    return ParsedKey(
+        family=family_name,
+        repoid=repoid,
+        commitid=commitid,
+        report_type=report_type,
+    )
+
+
+def _parse_coordination_lock_key(key: str) -> ParsedKey:
+    return _parse_coordination_lock_name("coordination_lock", key)
+
+
+def _parse_lock_attempts_key(key: str) -> ParsedKey:
+    """`lock_attempts:{coordination_lock_name}` — STRING counter set by
+    `lock_manager._track_lock_attempt`. The interesting fields live in
+    the embedded coordination-lock name, so reuse that parser.
+    """
+
+    if not key.startswith("lock_attempts:"):
+        return ParsedKey(family="lock_attempts")
+    inner = key[len("lock_attempts:") :]
+    parsed = _parse_coordination_lock_name("lock_attempts", inner)
+    return ParsedKey(
+        family="lock_attempts",
+        repoid=parsed.repoid,
+        commitid=parsed.commitid,
+        report_type=parsed.report_type,
+    )
+
+
+def _parse_ta_flake_lock_key(key: str) -> ParsedKey:
+    """`ta_flake_lock:{repoid}` per `ta_process_flakes.py`."""
+
+    if not key.startswith("ta_flake_lock:"):
+        return ParsedKey(family="ta_flake_lock")
+    tail = key[len("ta_flake_lock:") :]
+    try:
+        repoid = int(tail)
+    except ValueError:
+        return ParsedKey(family="ta_flake_lock")
+    return ParsedKey(family="ta_flake_lock", repoid=repoid)
+
+
+def _parse_ta_notifier_fence_key(key: str) -> ParsedKey:
+    """`ta_notifier_fence:{repoid}_{commitid}` per `test_analytics_notifier.py`."""
+
+    if not key.startswith("ta_notifier_fence:"):
+        return ParsedKey(family="ta_notifier_fence")
+    repoid, commitid, _ = _split_lock_tail(key[len("ta_notifier_fence:") :])
+    return ParsedKey(family="ta_notifier_fence", repoid=repoid, commitid=commitid)
+
+
+def _parse_upload_finisher_gate_key(key: str) -> ParsedKey:
+    """`upload_finisher_gate_{repoid}_{commitid}` per `finisher_gate.py`."""
+
+    if not key.startswith("upload_finisher_gate_"):
+        return ParsedKey(family="upload_finisher_gate")
+    repoid, commitid, _ = _split_lock_tail(key[len("upload_finisher_gate_") :])
+    return ParsedKey(family="upload_finisher_gate", repoid=repoid, commitid=commitid)
+
+
+def _lock_pattern_factory(prefix: str, *, sep: str):
+    """Build a `pattern_for` for a lock family whose key shape is
+    `<prefix><sep><repoid>[<sep>...]`. Pushes `repoid` into the SCAN
+    when known; drops the family if the user filtered by commitid
+    against a key shape that has no commit segment.
+    """
+
+    has_commit = sep == "_"  # only `_`-separated locks carry a commit
+
+    def pattern_for(filters: Mapping[str, Any]) -> str | None:
+        if not has_commit and filters.get("commitid_prefix"):
+            return None
+        repoid = filters.get("repoid")
+        if repoid is not None:
+            return f"{prefix}{sep}{repoid}{sep if has_commit else ''}*"
+        return f"{prefix}{sep}*"
+
+    return pattern_for
+
+
+def _coordination_lock_pattern(filters: Mapping[str, Any]) -> str:
+    """`*_lock_*` is broad on purpose; we de-dup against more specific
+    families (e.g. `lock_attempts:` keys also contain `_lock_`) by
+    relying on `find_family` registration order in `iter_keys`.
+    """
+
+    return "*_lock_*"
+
+
 # ---- SCAN pattern pushdown -------------------------------------------------
 
 
@@ -109,13 +425,60 @@ def _uploads_pattern(filters: Mapping[str, Any]) -> str:
     return "uploads/*"
 
 
-def _ta_flake_pattern(filters: Mapping[str, Any]) -> str:
-    """`ta_flake_key:{repoid}` is exact when we know the repoid."""
+def _ta_flake_pattern(filters: Mapping[str, Any]) -> str | None:
+    """`ta_flake_key:{repoid}` is exact when we know the repoid.
 
+    Filtering by `commitid` short-circuits the family entirely since
+    the key shape has no commit segment to match against.
+    """
+
+    if filters.get("commitid_prefix"):
+        return None
     repoid = filters.get("repoid")
     if repoid is not None:
         return f"ta_flake_key:{repoid}"
     return "ta_flake_key:*"
+
+
+def _latest_upload_pattern(filters: Mapping[str, Any]) -> str:
+    """Same shape as `uploads/`: `latest_upload/{repoid}/{commitid}[/{rt}]`."""
+
+    repoid = filters.get("repoid")
+    commitid_prefix = filters.get("commitid_prefix") or ""
+    if repoid is not None and commitid_prefix:
+        return f"latest_upload/{repoid}/{commitid_prefix}*"
+    if repoid is not None:
+        return f"latest_upload/{repoid}/*"
+    if commitid_prefix:
+        return f"latest_upload/*/{commitid_prefix}*"
+    return "latest_upload/*"
+
+
+def _upload_processing_state_pattern(filters: Mapping[str, Any]) -> str:
+    """`upload-processing-state/{repoid}/{commitsha}/{state}` — `*`
+    matches across `/` so the wildcard tail covers the state suffix.
+    """
+
+    repoid = filters.get("repoid")
+    commitid_prefix = filters.get("commitid_prefix") or ""
+    if repoid is not None and commitid_prefix:
+        return f"upload-processing-state/{repoid}/{commitid_prefix}*"
+    if repoid is not None:
+        return f"upload-processing-state/{repoid}/*"
+    if commitid_prefix:
+        return f"upload-processing-state/*/{commitid_prefix}*"
+    return "upload-processing-state/*"
+
+
+def _intermediate_report_pattern(filters: Mapping[str, Any]) -> str | None:
+    """No repoid/commitid in the key shape; if either is being filtered
+    on, every intermediate-report key would be dropped post-scan, so
+    skip the family entirely instead of paying for the SCAN.
+    """
+
+    if filters.get("repoid") is not None or filters.get("commitid_prefix"):
+        return None
+    return "intermediate-report/*"
 
 
 @dataclass(frozen=True)
@@ -124,10 +487,28 @@ class Family:
     scan_pattern: str
     redis_type: RedisType
     parse_key: Callable[[str], ParsedKey]
-    pattern_for: Callable[[Mapping[str, Any]], str] | None = None
+    # `pattern_for` may return None to declare that the current filters
+    # cannot match anything in this family (e.g. filtering by commitid
+    # against a family whose key shape has no commit segment); the
+    # iterator skips such families entirely instead of running a doomed
+    # SCAN.
+    pattern_for: Callable[[Mapping[str, Any]], str | None] | None = None
     fixed_keys: tuple[str, ...] = field(default_factory=tuple)
+    # M5 tags: families that are safe to delete from. Locks (M4.3) leave
+    # this False so the admin refuses to mutate them even by mistake.
+    is_deletable: bool = True
+    # Which top-level admin model surfaces this family — RedisQueue
+    # (default) or RedisLock. Locks live in their own admin so an
+    # operator can't accidentally clear them from the queues page.
+    category: Literal["queue", "lock"] = "queue"
+    # Optional per-item display transformer. Items queryset (M2/M4) calls
+    # this on each LRANGE / SSCAN / HSCAN value before truncation, so
+    # families like `celery_broker` can decorate their kombu envelope
+    # with a `[task=... repoid=... commit=...]` prefix without
+    # special-casing the queryset itself.
+    decode_value: Callable[[str], str] | None = None
 
-    def build_scan_pattern(self, filters: Mapping[str, Any]) -> str:
+    def build_scan_pattern(self, filters: Mapping[str, Any]) -> str | None:
         if self.pattern_for is None:
             return self.scan_pattern
         return self.pattern_for(filters)
@@ -147,6 +528,90 @@ FAMILIES: tuple[Family, ...] = (
         redis_type="list",
         parse_key=_parse_ta_flake_key,
         pattern_for=_ta_flake_pattern,
+    ),
+    Family(
+        name="latest_upload",
+        scan_pattern="latest_upload/*",
+        redis_type="string",
+        parse_key=_parse_latest_upload_key,
+        pattern_for=_latest_upload_pattern,
+    ),
+    Family(
+        name="upload-processing-state",
+        scan_pattern="upload-processing-state/*",
+        redis_type="set",
+        parse_key=_parse_upload_processing_state_key,
+        pattern_for=_upload_processing_state_pattern,
+    ),
+    Family(
+        name="intermediate-report",
+        scan_pattern="intermediate-report/*",
+        redis_type="hash",
+        parse_key=_parse_intermediate_report_key,
+        pattern_for=_intermediate_report_pattern,
+    ),
+    Family(
+        name="celery_broker",
+        # Used as the SCAN pattern for ad-hoc enterprise_* queues; the
+        # well-known names from BaseCeleryConfig come through `fixed_keys`.
+        scan_pattern="enterprise_*",
+        redis_type="list",
+        parse_key=_parse_celery_broker_key,
+        pattern_for=_celery_pattern,
+        fixed_keys=_resolve_celery_queue_names(),
+        decode_value=_celery_decode_value,
+    ),
+    # ---- Locks (M4.3) -----------------------------------------------------
+    # Order matters: more-specific prefixes go BEFORE the broad
+    # `*_lock_*` coordination family so `find_family` correctly routes
+    # `lock_attempts:upload_lock_…` to `lock_attempts` rather than
+    # `coordination_lock`.
+    Family(
+        name="lock_attempts",
+        scan_pattern="lock_attempts:*",
+        redis_type="string",
+        parse_key=_parse_lock_attempts_key,
+        pattern_for=_lock_pattern_factory("lock_attempts", sep=":"),
+        is_deletable=False,
+        category="lock",
+    ),
+    Family(
+        name="ta_flake_lock",
+        scan_pattern="ta_flake_lock:*",
+        redis_type="string",
+        parse_key=_parse_ta_flake_lock_key,
+        pattern_for=_lock_pattern_factory("ta_flake_lock", sep=":"),
+        is_deletable=False,
+        category="lock",
+    ),
+    Family(
+        name="ta_notifier_fence",
+        scan_pattern="ta_notifier_fence:*",
+        redis_type="string",
+        parse_key=_parse_ta_notifier_fence_key,
+        pattern_for=_lock_pattern_factory("ta_notifier_fence", sep=":"),
+        is_deletable=False,
+        category="lock",
+    ),
+    Family(
+        name="upload_finisher_gate",
+        scan_pattern="upload_finisher_gate_*",
+        redis_type="string",
+        parse_key=_parse_upload_finisher_gate_key,
+        pattern_for=_lock_pattern_factory("upload_finisher_gate", sep="_"),
+        is_deletable=False,
+        category="lock",
+    ),
+    Family(
+        name="coordination_lock",
+        scan_pattern="*_lock_*",
+        redis_type="string",
+        parse_key=_parse_coordination_lock_key,
+        # Repoid pushdown isn't safe here because the `_lock_` infix can
+        # appear inside the type prefix (e.g. `upload_lock_123_…`); the
+        # post-scan repoid filter on the queryset takes care of it.
+        is_deletable=False,
+        category="lock",
     ),
 )
 
@@ -177,13 +642,16 @@ def iter_keys(
     family: str | None = None,
     repoid: int | None = None,
     commitid_prefix: str | None = None,
+    category: Literal["queue", "lock"] | None = None,
 ) -> Iterator[tuple[str, Family]]:
     """Yield `(key, family)` for every known family, optionally narrowed.
 
     Filters that the family understands are pushed down into the SCAN
     pattern (see `_uploads_pattern` / `_ta_flake_pattern`); filters that
     don't apply are dropped, and post-scan filtering happens in
-    `RedisQueueQuerySet`. Total work is bounded by `MAX_SCAN_KEYS`.
+    `RedisQueueQuerySet`. `category` separates queue families (default
+    `RedisQueue` audience) from lock families (`RedisLock` audience).
+    Total work is bounded by `MAX_SCAN_KEYS`.
     """
 
     redis = redis if redis is not None else _conn.get_connection()
@@ -194,13 +662,30 @@ def iter_keys(
         "repoid": repoid,
         "commitid_prefix": commitid_prefix,
     }
+    # Track yielded keys so an overlapping pattern (e.g.
+    # `lock_attempts:upload_lock_…` is matched by both `lock_attempts:*`
+    # and the broader `*_lock_*`) doesn't double-count.
+    yielded: set[str] = set()
 
     for fam in FAMILIES:
         if family and fam.name != family:
             continue
+        if category is not None and fam.category != category:
+            continue
+
+        pattern = fam.build_scan_pattern(filters)
+        # `pattern is None` means the family cannot match the requested
+        # filters (e.g. filtering by repoid against `celery_broker`).
+        # Skip both fixed_keys and the SCAN so we don't waste roundtrips
+        # on guaranteed-empty matches.
+        if pattern is None:
+            continue
 
         for key in fam.fixed_keys:
+            if key in yielded:
+                continue
             if redis.exists(key):
+                yielded.add(key)
                 yield key, fam
                 seen += 1
                 if seen >= cap:
@@ -210,12 +695,22 @@ def iter_keys(
                     )
                     return
 
-        pattern = fam.build_scan_pattern(filters)
         if not pattern:
             continue
 
         for raw_key in redis.scan_iter(match=pattern, count=count):
-            yield _decode(raw_key), fam
+            key = _decode(raw_key)
+            if key in yielded:
+                continue
+            # If a more-specific family registered earlier owns this key
+            # (e.g. `lock_attempts:` matched it before the broader
+            # `*_lock_*` pattern), it'll yield it on its own iteration —
+            # don't surface it again here as a `coordination_lock`.
+            owner = find_family(key)
+            if owner is not None and owner.name != fam.name:
+                continue
+            yielded.add(key)
+            yield key, fam
             seen += 1
             if seen >= cap:
                 log.warning(

--- a/apps/codecov-api/redis_admin/models.py
+++ b/apps/codecov-api/redis_admin/models.py
@@ -14,7 +14,12 @@ from .queryset import RedisItemQuerySet, RedisQueueQuerySet
 
 class RedisQueueManager(models.Manager):
     def get_queryset(self) -> RedisQueueQuerySet:  # type: ignore[override]
-        return RedisQueueQuerySet(self.model)
+        return RedisQueueQuerySet(self.model, category="queue")
+
+
+class RedisLockManager(models.Manager):
+    def get_queryset(self) -> RedisQueueQuerySet:  # type: ignore[override]
+        return RedisQueueQuerySet(self.model, category="lock")
 
 
 class RedisQueueItemManager(models.Manager):
@@ -51,6 +56,48 @@ class RedisQueue(models.Model):
 
     def delete(self, *args, **kwargs):  # pragma: no cover - milestone 5
         raise NotImplementedError("RedisQueue.delete arrives in milestone 5.")
+
+
+class RedisLock(models.Model):
+    """Read-only view of Redis locks/fences/gates.
+
+    Same field shape as `RedisQueue` but lives in its own admin so an
+    operator can't accidentally clear them from the queues page; the
+    queueset is wired with `category="lock"` so `iter_keys` only yields
+    families flagged with `is_deletable=False`. M5's delete service
+    refuses every key whose family has `is_deletable=False`, regardless
+    of which model the row is rendered through.
+    """
+
+    name = models.CharField(primary_key=True, max_length=512)
+    family = models.CharField(max_length=64)
+    redis_type = models.CharField(max_length=16)
+    depth = models.PositiveIntegerField(default=0)
+    ttl_seconds = models.IntegerField(null=True, blank=True)
+    repoid = models.IntegerField(null=True, blank=True)
+    commitid = models.CharField(max_length=64, null=True, blank=True)
+    report_type = models.CharField(max_length=32, null=True, blank=True)
+
+    objects = RedisLockManager()
+
+    class Meta:
+        managed = False
+        app_label = "redis_admin"
+        verbose_name = "Redis lock"
+        verbose_name_plural = "Redis locks"
+        default_permissions = ("view",)
+
+    def __str__(self) -> str:
+        return self.name
+
+    def save(self, *args, **kwargs):  # pragma: no cover - safety net
+        raise RuntimeError("RedisLock is read-only; saves are not supported.")
+
+    def delete(self, *args, **kwargs):  # pragma: no cover - intentional
+        raise RuntimeError(
+            "RedisLock entries are immutable from the admin; coordination "
+            "locks must be released by their owning task, not by an operator."
+        )
 
 
 class RedisQueueItem(models.Model):

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -462,7 +462,121 @@ class RedisItemQuerySet:
         raise NotImplementedError("RedisItemQuerySet.exclude is added in milestone 5")
 
     def get(self, *args, **kwargs):
-        raise NotImplementedError("RedisItemQuerySet.get is added in milestone 5")
+        """Resolve a single item by its `pk_token` (`<queue>#<locator>`).
+
+        Used by Django admin's `get_object` when the operator clicks an
+        item row to open the per-item inspector. Locator shape varies by
+        Redis type:
+
+        * list   → numeric index (e.g. `uploads/1/abc#0`)
+        * set    → `m:<idx>` into the sorted snapshot
+        * hash   → `f:<field>` for the literal field name
+        * string → `v` (singleton)
+        """
+
+        if args:
+            raise self.model.DoesNotExist(
+                f"{self.model.__name__} positional get() is not supported"
+            )
+        pk = (
+            kwargs.pop("pk", None)
+            or kwargs.pop("pk__exact", None)
+            or kwargs.pop("pk_token", None)
+            or kwargs.pop("pk_token__exact", None)
+        )
+        if kwargs:
+            raise NotImplementedError(
+                "RedisItemQuerySet.get only accepts pk/pk_token; "
+                f"got {sorted(kwargs)!r}"
+            )
+        if pk is None:
+            raise self.model.DoesNotExist(
+                f"{self.model.__name__} matching no kwargs does not exist"
+            )
+        return self._get_one(str(pk))
+
+    def _get_one(self, pk_token: str):
+        queue_name, sep, locator = pk_token.rpartition("#")
+        if not sep or not queue_name or not locator:
+            raise self.model.DoesNotExist(
+                f"pk_token must look like 'queue#locator'; got {pk_token!r}"
+            )
+
+        redis = _conn.get_connection()
+        if not redis.exists(queue_name):
+            raise self.model.DoesNotExist(f"Redis key {queue_name!r} does not exist")
+
+        bound = self._clone(queue_name=queue_name)
+        kind = bound._resolve_type(redis)
+
+        if kind == "list":
+            try:
+                idx = int(locator)
+            except ValueError as exc:
+                raise self.model.DoesNotExist(
+                    f"list pk_token must be 'queue#<index>'; got {locator!r}"
+                ) from exc
+            raw = redis.lindex(queue_name, idx)
+            if raw is None:
+                raise self.model.DoesNotExist(
+                    f"index {idx} out of range for list {queue_name!r}"
+                )
+            return self.model(
+                pk_token=pk_token,
+                queue_name=queue_name,
+                index_or_field=str(idx),
+                raw_value=_truncate_for_display(bound._decode_with_family(raw)),
+            )
+
+        if kind == "set":
+            if not locator.startswith("m:"):
+                raise self.model.DoesNotExist(
+                    f"set pk_token must be 'queue#m:<idx>'; got {locator!r}"
+                )
+            try:
+                idx = int(locator[2:])
+            except ValueError as exc:
+                raise self.model.DoesNotExist(
+                    f"set pk_token index must be int; got {locator!r}"
+                ) from exc
+            snapshot = bound._materialize_set(redis)
+            if idx < 0 or idx >= len(snapshot):
+                raise self.model.DoesNotExist(
+                    f"set member index {idx} out of range for {queue_name!r}"
+                )
+            return snapshot[idx]
+
+        if kind == "hash":
+            if not locator.startswith("f:"):
+                raise self.model.DoesNotExist(
+                    f"hash pk_token must be 'queue#f:<field>'; got {locator!r}"
+                )
+            field = locator[2:]
+            raw = redis.hget(queue_name, field)
+            if raw is None:
+                raise self.model.DoesNotExist(
+                    f"hash field {field!r} does not exist on {queue_name!r}"
+                )
+            return self.model(
+                pk_token=pk_token,
+                queue_name=queue_name,
+                index_or_field=field,
+                raw_value=_truncate_for_display(_decode_value(raw)),
+            )
+
+        if kind == "string":
+            if locator != "v":
+                raise self.model.DoesNotExist(
+                    f"string pk_token must be 'queue#v'; got {locator!r}"
+                )
+            snapshot = bound._materialize_string(redis)
+            if not snapshot:
+                raise self.model.DoesNotExist(f"string {queue_name!r} does not exist")
+            return snapshot[0]
+
+        raise self.model.DoesNotExist(
+            f"unsupported Redis type {kind!r} for {queue_name!r}"
+        )
 
     def order_by(self, *fields: str) -> RedisItemQuerySet:
         return self._clone(ordering=tuple(fields))

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -215,7 +215,28 @@ class RedisQueueQuerySet:
         raise NotImplementedError("RedisQueueQuerySet.exclude is added in milestone 5")
 
     def get(self, *args, **kwargs):
-        raise NotImplementedError("RedisQueueQuerySet.get is added in milestone 5")
+        """Lookup a single queue by `pk=` / `name=` (or their `__exact` variants).
+
+        The admin's `get_object` calls `queryset.get(name=<key>)` when the
+        operator clicks a row on the changelist; we reuse the explicit-name
+        fast path in `_fetch_all` so this never triggers a SCAN.
+        """
+
+        if args:
+            raise self.model.DoesNotExist(
+                f"{self.model.__name__} matching positional args is not supported"
+            )
+        filtered = self.filter(**kwargs)
+        items = filtered._fetch_all()
+        if not items:
+            raise self.model.DoesNotExist(
+                f"{self.model.__name__} matching {kwargs!r} does not exist"
+            )
+        if len(items) > 1:
+            raise self.model.MultipleObjectsReturned(
+                f"get() returned {len(items)} {self.model.__name__} rows"
+            )
+        return items[0]
 
     # ---- Ordering --------------------------------------------------------
 

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -75,6 +75,15 @@ _QUEUE_FILTER_KEYS: dict[str, str] = {
     "depth__gte": "depth_gte",
     "name__icontains": "name_substring",
     "name__contains": "name_substring",
+    # Admin bulk actions (delete_selected, custom actions) narrow the
+    # queryset to selected pks via `filter(pk__in=[...])`. We treat that
+    # as a direct-by-name lookup that bypasses iter_keys SCAN entirely.
+    "pk": "name_exact",
+    "pk__exact": "name_exact",
+    "pk__in": "name_in",
+    "name": "name_exact",
+    "name__exact": "name_exact",
+    "name__in": "name_in",
 }
 
 
@@ -93,10 +102,12 @@ class RedisQueueQuerySet:
         *,
         ordering: tuple[str, ...] = (),
         filters: dict[str, Any] | None = None,
+        category: str = "queue",
     ) -> None:
         self.model = model
         self._ordering = ordering
         self._filters: dict[str, Any] = dict(filters or {})
+        self._category = category
         self._result_cache: list | None = None
 
     # ---- Cloning helpers --------------------------------------------------
@@ -111,6 +122,7 @@ class RedisQueueQuerySet:
             self.model,
             ordering=self._ordering if ordering is None else ordering,
             filters={**self._filters, **(filters or {})},
+            category=self._category,
         )
 
     def all(self) -> RedisQueueQuerySet:
@@ -125,6 +137,21 @@ class RedisQueueQuerySet:
         # Database alias has no meaning for a Redis-backed queryset; the
         # admin still calls this so we accept and ignore it.
         return self
+
+    # ---- Compatibility shims for django.contrib.admin.utils ---------------
+
+    @property
+    def verbose_name(self):
+        # `delete_selected` calls `model_ngettext(queryset)` →
+        # `model_format_dict(obj)`; since our queryset doesn't subclass
+        # `django.db.models.QuerySet`, that helper falls into the
+        # `else: opts = obj` branch and reads `verbose_name` directly.
+        # Proxy to the model's Meta so the confirmation page renders.
+        return self.model._meta.verbose_name
+
+    @property
+    def verbose_name_plural(self):
+        return self.model._meta.verbose_name_plural
 
     # ---- Filtering -------------------------------------------------------
 
@@ -152,6 +179,18 @@ class RedisQueueQuerySet:
                     new_filters["__empty__"] = True
             elif target == "name_substring":
                 new_filters[target] = str(value).lower()
+            elif target == "name_in":
+                # `pk__in=[...]` from admin bulk actions; merge with any
+                # previously-set name_in so chained `.filter()` calls
+                # narrow the set rather than overwriting.
+                names = list(value) if not isinstance(value, str) else [value]
+                existing = self._filters.get("name_in")
+                if existing is not None:
+                    new_filters[target] = [n for n in names if n in set(existing)]
+                else:
+                    new_filters[target] = names
+            elif target == "name_exact":
+                new_filters[target] = str(value)
             else:
                 new_filters[target] = str(value)
         if unsupported:
@@ -202,6 +241,13 @@ class RedisQueueQuerySet:
         commitid_prefix = f.get("commitid_prefix")
         if commitid_prefix and not (obj.commitid or "").startswith(commitid_prefix):
             return False
+        # Families without a repoid in their key shape (e.g. intermediate-
+        # report) opt out of repoid SCAN pushdown by returning None from
+        # `pattern_for`, but a defensive post-scan check guards future
+        # families that *do* scan and need the value re-verified.
+        repoid = f.get("repoid")
+        if repoid is not None and obj.repoid != repoid:
+            return False
         return True
 
     def _fetch_all(self) -> list:
@@ -213,15 +259,42 @@ class RedisQueueQuerySet:
             return []
 
         redis = _conn.get_connection()
-        items = [
-            _build_redis_queue(self.model, key, family, redis)
-            for key, family in iter_keys(
-                redis,
-                family=self._filters.get("family"),
-                repoid=self._filters.get("repoid"),
-                commitid_prefix=self._filters.get("commitid_prefix"),
-            )
-        ]
+
+        # `pk__in=[...]` / `pk=name` from admin bulk actions: skip SCAN
+        # and resolve each requested name directly against the family
+        # registry. This keeps the bulk-delete confirmation page fast
+        # even on a large keyspace, and avoids re-scanning for keys we
+        # already have names for.
+        explicit_names: list[str] | None = None
+        name_in = self._filters.get("name_in")
+        name_exact = self._filters.get("name_exact")
+        if name_in is not None:
+            explicit_names = list(name_in)
+        elif name_exact is not None:
+            explicit_names = [name_exact]
+
+        if explicit_names is not None:
+            items = []
+            for name in explicit_names:
+                family = find_family(name)
+                if family is None:
+                    continue
+                if family.category != self._category:
+                    continue
+                if not redis.exists(name):
+                    continue
+                items.append(_build_redis_queue(self.model, name, family, redis))
+        else:
+            items = [
+                _build_redis_queue(self.model, key, family, redis)
+                for key, family in iter_keys(
+                    redis,
+                    family=self._filters.get("family"),
+                    repoid=self._filters.get("repoid"),
+                    commitid_prefix=self._filters.get("commitid_prefix"),
+                    category=self._category,
+                )
+            ]
 
         items = [obj for obj in items if self._post_scan_predicate(obj)]
 
@@ -320,6 +393,9 @@ class RedisItemQuerySet:
         self.model = model
         self.queue_name = queue_name
         self._ordering = ordering
+        # Cached materialized snapshot for SET/HASH/STRING reads. LIST
+        # reads remain LRANGE-paginated so we don't bother caching.
+        self._snapshot: list | None = None
 
     # ---- Cloning helpers --------------------------------------------------
 
@@ -372,12 +448,17 @@ class RedisItemQuerySet:
 
     # ---- Materialization -------------------------------------------------
 
+    def _resolve_family(self) -> Family | None:
+        if not self.queue_name:
+            return None
+        return find_family(self.queue_name)
+
     def _resolve_type(self, redis) -> str | None:
         """Best-effort lookup of the Redis type for `self.queue_name`."""
 
         if not self.queue_name:
             return None
-        family = find_family(self.queue_name)
+        family = self._resolve_family()
         if family is not None:
             return family.redis_type
         raw_type = redis.type(self.queue_name)
@@ -386,13 +467,23 @@ class RedisItemQuerySet:
             return None
         return kind
 
+    def _decode_with_family(self, raw_value: bytes | str) -> str:
+        decoded = _decode_value(raw_value)
+        family = self._resolve_family()
+        if family is not None and family.decode_value is not None:
+            try:
+                decoded = family.decode_value(decoded)
+            except Exception:  # pragma: no cover - decoder bug shouldn't 500
+                pass
+        return decoded
+
     def _build_list_items(self, redis, start: int, raw_values: list) -> list:
         return [
             self.model(
                 pk_token=f"{self.queue_name}#{start + offset}",
                 queue_name=self.queue_name,
                 index_or_field=str(start + offset),
-                raw_value=_truncate_for_display(_decode_value(value)),
+                raw_value=_truncate_for_display(self._decode_with_family(value)),
             )
             for offset, value in enumerate(raw_values)
         ]
@@ -405,6 +496,78 @@ class RedisItemQuerySet:
         raw = redis.lrange(self.queue_name, start, capped_stop - 1)
         return self._build_list_items(redis, start, raw)
 
+    # ---- SET / HASH / STRING readers (M4) --------------------------------
+    #
+    # SETs and HASHes are read with SSCAN/HSCAN bounded by MAX_ITEMS_PER_KEY
+    # so a pathologically large container doesn't OOM the api process. The
+    # full snapshot is sorted lexically and paginated in Python; this gives
+    # the admin a stable page-to-page ordering that SSCAN cursors cannot
+    # provide on their own. Snapshots are cached per-queryset so repeated
+    # `count()` / `__getitem__` calls don't re-stream Redis.
+
+    def _materialize_set(self, redis) -> list:
+        if self._snapshot is not None:
+            return self._snapshot
+        cap = redis_admin_settings.MAX_ITEMS_PER_KEY
+        members: list[str] = []
+        for raw in redis.sscan_iter(
+            self.queue_name, count=redis_admin_settings.SCAN_COUNT
+        ):
+            members.append(_decode_value(raw))
+            if len(members) >= cap:
+                break
+        members.sort()
+        self._snapshot = [
+            self.model(
+                pk_token=f"{self.queue_name}#m:{idx}",
+                queue_name=self.queue_name,
+                index_or_field=member if len(member) <= 64 else member[:61] + "...",
+                raw_value=_truncate_for_display(member),
+            )
+            for idx, member in enumerate(members)
+        ]
+        return self._snapshot
+
+    def _materialize_hash(self, redis) -> list:
+        if self._snapshot is not None:
+            return self._snapshot
+        cap = redis_admin_settings.MAX_ITEMS_PER_KEY
+        pairs: list[tuple[str, str]] = []
+        for raw_field, raw_value in redis.hscan_iter(
+            self.queue_name, count=redis_admin_settings.SCAN_COUNT
+        ):
+            pairs.append((_decode_value(raw_field), _decode_value(raw_value)))
+            if len(pairs) >= cap:
+                break
+        pairs.sort(key=lambda fv: fv[0])
+        self._snapshot = [
+            self.model(
+                pk_token=f"{self.queue_name}#f:{field}",
+                queue_name=self.queue_name,
+                index_or_field=field,
+                raw_value=_truncate_for_display(value),
+            )
+            for field, value in pairs
+        ]
+        return self._snapshot
+
+    def _materialize_string(self, redis) -> list:
+        if self._snapshot is not None:
+            return self._snapshot
+        raw = redis.get(self.queue_name)
+        if raw is None:
+            self._snapshot = []
+            return self._snapshot
+        self._snapshot = [
+            self.model(
+                pk_token=f"{self.queue_name}#v",
+                queue_name=self.queue_name,
+                index_or_field="(value)",
+                raw_value=_truncate_for_display(_decode_value(raw)),
+            )
+        ]
+        return self._snapshot
+
     def count(self) -> int:
         if not self.queue_name:
             return 0
@@ -412,8 +575,12 @@ class RedisItemQuerySet:
         kind = self._resolve_type(redis)
         if kind == "list":
             return int(redis.llen(self.queue_name) or 0)
-        # SET/HASH/STRING land in M4 alongside their families. For now they
-        # report 0 so the changelist renders cleanly.
+        if kind == "set":
+            return int(redis.scard(self.queue_name) or 0)
+        if kind == "hash":
+            return int(redis.hlen(self.queue_name) or 0)
+        if kind == "string":
+            return 1 if redis.exists(self.queue_name) else 0
         return 0
 
     def __len__(self) -> int:
@@ -430,12 +597,25 @@ class RedisItemQuerySet:
     def __bool__(self) -> bool:
         return self.count() > 0
 
+    def _slice(self, redis, kind: str | None, start: int, stop: int) -> list:
+        if stop <= start:
+            return []
+        if kind == "list":
+            return self._list_slice(redis, start, stop)
+        if kind == "set":
+            return self._materialize_set(redis)[start:stop]
+        if kind == "hash":
+            return self._materialize_hash(redis)[start:stop]
+        if kind == "string":
+            return self._materialize_string(redis)[start:stop]
+        return []
+
     def __getitem__(self, item):
         if not self.queue_name:
             return [] if isinstance(item, slice) else None
         redis = _conn.get_connection()
         kind = self._resolve_type(redis)
-        if kind != "list":
+        if kind not in ("list", "set", "hash", "string"):
             return [] if isinstance(item, slice) else None
         if isinstance(item, slice):
             start = item.start or 0
@@ -444,9 +624,9 @@ class RedisItemQuerySet:
                 if item.stop is not None
                 else start + redis_admin_settings.ITEM_PAGE_SIZE
             )
-            return self._list_slice(redis, start, stop)
+            return self._slice(redis, kind, start, stop)
         if isinstance(item, int):
-            page = self._list_slice(redis, item, item + 1)
+            page = self._slice(redis, kind, item, item + 1)
             if not page:
                 raise IndexError(item)
             return page[0]

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -96,6 +96,25 @@ def _classify_items(
         if family is None or not family.is_deletable:
             refused.append(f"{item.queue_name}#{item.index_or_field}")
             continue
+        # Families with a `decode_value` transformer (today: only
+        # `celery_broker`) round-trip the raw Redis bytes through a
+        # display-decorator — `_celery_decode_value` prepends a
+        # `[task=… repoid=… commit=…]` prefix so backed-up celery
+        # queues are triagable from the admin. That same prefix
+        # would land in `LREM`/`SREM` selectors and silently match
+        # zero rows in Redis. We intentionally don't track an
+        # un-decorated copy on the model (it'd defeat the
+        # truncation budget for big payloads), so refuse item-
+        # level deletion for these families: operators clear the
+        # whole queue from `RedisQueueAdmin` instead. (LREM-by-
+        # index isn't a Redis primitive; the only ways to drop a
+        # single celery message are LREM by exact value or DEL the
+        # whole queue.) HASH-typed families with `decode_value` are
+        # safe — HDEL keys off `index_or_field`, not the value —
+        # but no current family hits that combination.
+        if family.redis_type in ("list", "set") and family.decode_value is not None:
+            refused.append(f"{item.queue_name}#{item.index_or_field}")
+            continue
         # The HASH selector is the field name; SET selector is the
         # member value; LIST uses the raw value (not the index) since
         # LREM is value-based — admin pagination already gave us the

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -1,0 +1,309 @@
+"""Mutation services for `redis_admin` (M5).
+
+Everything that *changes* Redis from the admin UI funnels through
+`redis_delete()`. The admin's `ModelAdmin.delete_queryset` /
+`delete_model` overrides are thin wrappers around this so we have a
+single chokepoint for:
+
+- Family-aware command dispatch (`DEL` for top-level keys, `LREM` /
+  `SREM` / `HDEL` for individual list/set/hash items).
+- Locks safety: any key whose family has `is_deletable=False` is
+  refused, even when the queryset somehow surfaces it.
+- Pipeline batching: `DELETE_BATCH_SIZE` ops per pipeline so a single
+  delete action doesn't block Redis with one giant MULTI.
+- Audit logging: every call (dry-run included) writes a
+  `django.contrib.admin.LogEntry` so operators can reconstruct who
+  cleared what and when.
+- Dry-run mode: returns the same `DeleteResult` shape but performs
+  zero mutations, used by the admin's "Dry-run" action to preview
+  scope before committing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+
+from django.contrib.admin.models import DELETION, LogEntry
+from django.contrib.contenttypes.models import ContentType
+
+from . import conn as _conn
+from . import settings as redis_admin_settings
+from .families import find_family
+from .models import RedisLock, RedisQueue, RedisQueueItem
+
+log = logging.getLogger(__name__)
+
+# Hard sample cap on what we record in the LogEntry change_message;
+# operators just need a few representative names, not the whole list.
+_AUDIT_SAMPLE_SIZE = 25
+
+
+@dataclass(frozen=True)
+class DeleteResult:
+    """Outcome of a single `redis_delete()` call."""
+
+    count: int
+    sample: tuple[str, ...]
+    families: tuple[str, ...]
+    dry_run: bool
+    refused: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class _PendingItem:
+    """Internal: a single item-level delete (LREM/SREM/HDEL) request."""
+
+    queue_name: str
+    family: str
+    redis_type: str
+    selector: str  # raw value (LIST/SET) or field name (HASH)
+
+
+def _classify_queues(
+    queues: Iterable[RedisQueue],
+) -> tuple[list[str], list[str], list[str]]:
+    """Bucket `RedisQueue` rows into (deletable_keys, refused_keys, families)."""
+
+    deletable: list[str] = []
+    refused: list[str] = []
+    families: set[str] = set()
+    for queue in queues:
+        family = find_family(queue.name)
+        if family is None:
+            refused.append(queue.name)
+            continue
+        if not family.is_deletable:
+            refused.append(queue.name)
+            continue
+        deletable.append(queue.name)
+        families.add(family.name)
+    return deletable, refused, sorted(families)
+
+
+def _classify_items(
+    items: Iterable[RedisQueueItem],
+) -> tuple[list[_PendingItem], list[str], list[str]]:
+    """Bucket `RedisQueueItem` rows into (pending_ops, refused_keys, families)."""
+
+    pending: list[_PendingItem] = []
+    refused: list[str] = []
+    families: set[str] = set()
+    for item in items:
+        family = find_family(item.queue_name)
+        if family is None or not family.is_deletable:
+            refused.append(f"{item.queue_name}#{item.index_or_field}")
+            continue
+        # The HASH selector is the field name; SET selector is the
+        # member value; LIST uses the raw value (not the index) since
+        # LREM is value-based — admin pagination already gave us the
+        # decoded value as `raw_value`.
+        if family.redis_type == "hash":
+            selector = item.index_or_field
+        else:
+            selector = item.raw_value or ""
+        pending.append(
+            _PendingItem(
+                queue_name=item.queue_name,
+                family=family.name,
+                redis_type=family.redis_type,
+                selector=selector,
+            )
+        )
+        families.add(family.name)
+    return pending, refused, sorted(families)
+
+
+def _batched(iterable: Sequence, size: int) -> Iterable[Sequence]:
+    for i in range(0, len(iterable), size):
+        yield iterable[i : i + size]
+
+
+def _execute_key_deletes(redis, keys: Sequence[str]) -> int:
+    """Run `DEL` for every key in `keys`, batched via pipelines.
+
+    Returns the number of keys that existed and were deleted (sum of
+    pipeline replies, since `DEL` returns 0 for missing keys).
+    """
+
+    if not keys:
+        return 0
+    deleted = 0
+    batch_size = redis_admin_settings.DELETE_BATCH_SIZE
+    for batch in _batched(list(keys), batch_size):
+        pipe = redis.pipeline(transaction=False)
+        for key in batch:
+            pipe.delete(key)
+        for reply in pipe.execute():
+            try:
+                deleted += int(reply or 0)
+            except (TypeError, ValueError):
+                pass
+    return deleted
+
+
+def _execute_item_deletes(redis, items: Sequence[_PendingItem]) -> int:
+    """Run LREM/SREM/HDEL for every pending item, batched via pipelines."""
+
+    if not items:
+        return 0
+    deleted = 0
+    batch_size = redis_admin_settings.DELETE_BATCH_SIZE
+    for batch in _batched(list(items), batch_size):
+        pipe = redis.pipeline(transaction=False)
+        for item in batch:
+            if item.redis_type == "list":
+                # `count=0` removes all matching values from the list,
+                # which mirrors what an operator would expect when
+                # picking a row out of the items changelist.
+                pipe.lrem(item.queue_name, 0, item.selector)
+            elif item.redis_type == "set":
+                pipe.srem(item.queue_name, item.selector)
+            elif item.redis_type == "hash":
+                pipe.hdel(item.queue_name, item.selector)
+            else:
+                # Strings have no item-level delete; for STRING families
+                # the queue-level DEL path handles removal. Refuse here
+                # rather than silently no-op.
+                log.warning(
+                    "redis_admin: refusing item delete on STRING family %s key %s",
+                    item.family,
+                    item.queue_name,
+                )
+                pipe.echo("noop")
+        for reply in pipe.execute():
+            try:
+                deleted += int(reply or 0)
+            except (TypeError, ValueError):
+                pass
+    return deleted
+
+
+def _record_audit(
+    *,
+    user,
+    scope: str,
+    count: int,
+    refused: Sequence[str],
+    sample: Sequence[str],
+    families: Sequence[str],
+    dry_run: bool,
+) -> None:
+    """Write a `LogEntry` row so operators can reconstruct what cleared what.
+
+    Best-effort: a logging failure must never roll back the actual
+    delete. The change_message is JSON for grep-ability.
+    """
+
+    try:
+        ct = ContentType.objects.get_for_model(RedisQueue)
+        message = json.dumps(
+            {
+                "scope": scope,
+                "dry_run": dry_run,
+                "count": count,
+                "families": list(families),
+                "sample": list(sample),
+                "refused": list(refused)[:_AUDIT_SAMPLE_SIZE],
+            }
+        )
+        user_id = getattr(user, "id", None) or getattr(user, "pk", None)
+        if user_id is None:
+            log.warning("redis_admin: skipping audit log; no user supplied")
+            return
+        LogEntry.objects.log_action(
+            user_id=user_id,
+            content_type_id=ct.id,
+            object_id="",
+            object_repr=f"redis_admin.{scope}",
+            action_flag=DELETION,
+            change_message=message,
+        )
+    except Exception:  # pragma: no cover - audit must never crash delete
+        log.exception("redis_admin: failed to write audit LogEntry")
+
+
+def redis_delete(
+    targets: Iterable[RedisQueue | RedisQueueItem],
+    *,
+    user,
+    dry_run: bool = False,
+) -> DeleteResult:
+    """Delete every item in `targets` from Redis, with safety + audit.
+
+    `targets` may be a mix of `RedisQueue` (top-level DEL) and
+    `RedisQueueItem` (LREM/SREM/HDEL) — the family registry decides
+    which command to issue. Lock-flagged families (`is_deletable=False`)
+    are refused regardless of how they were surfaced.
+
+    `user` is the Django user driving the action; used to attribute the
+    `LogEntry`. `dry_run=True` returns the same shape but issues no
+    mutations.
+    """
+
+    queue_targets: list[RedisQueue] = []
+    item_targets: list[RedisQueueItem] = []
+    for target in targets:
+        if isinstance(target, RedisQueueItem):
+            item_targets.append(target)
+        elif isinstance(target, RedisQueue | RedisLock):
+            # `RedisLock` reaches us only via the URL-tampering safety
+            # net described above; the family registry will refuse it
+            # in `_classify_queues` because its family has
+            # `is_deletable=False`. Cast to `RedisQueue` for the rest
+            # of the pipeline since the field shape matches.
+            queue_targets.append(target)
+        else:
+            log.warning(
+                "redis_admin.redis_delete: ignoring unknown target type %r",
+                type(target),
+            )
+
+    deletable_keys, refused_keys, queue_families = _classify_queues(queue_targets)
+    pending_items, refused_items, item_families = _classify_items(item_targets)
+
+    refused = tuple(refused_keys + refused_items)
+    families = tuple(sorted(set(queue_families) | set(item_families)))
+
+    sample_source = list(deletable_keys) + [
+        f"{p.queue_name}#{p.selector}" for p in pending_items
+    ]
+    sample = tuple(sample_source[:_AUDIT_SAMPLE_SIZE])
+
+    if dry_run:
+        result = DeleteResult(
+            count=len(deletable_keys) + len(pending_items),
+            sample=sample,
+            families=families,
+            dry_run=True,
+            refused=refused,
+        )
+    else:
+        redis = _conn.get_connection()
+        keys_deleted = _execute_key_deletes(redis, deletable_keys)
+        items_deleted = _execute_item_deletes(redis, pending_items)
+        result = DeleteResult(
+            count=keys_deleted + items_deleted,
+            sample=sample,
+            families=families,
+            dry_run=False,
+            refused=refused,
+        )
+
+    scope = (
+        "queue+item"
+        if queue_targets and item_targets
+        else ("queue" if queue_targets else "item")
+    )
+    _record_audit(
+        user=user,
+        scope=scope,
+        count=result.count,
+        refused=refused,
+        sample=sample,
+        families=families,
+        dry_run=dry_run,
+    )
+    return result

--- a/apps/codecov-api/redis_admin/settings.py
+++ b/apps/codecov-api/redis_admin/settings.py
@@ -22,3 +22,14 @@ ITEM_PAGE_SIZE: int = getattr(settings, "REDIS_ADMIN_ITEM_PAGE_SIZE", 100)
 # Maximum bytes of a single Redis value rendered in the admin item view; values
 # larger than this are truncated with a "(... N bytes truncated)" suffix.
 MAX_DECODE_BYTES: int = getattr(settings, "REDIS_ADMIN_MAX_DECODE_BYTES", 4_096)
+
+# Hard cap on the number of items materialised from a single SET/HASH key during
+# admin browsing (M4). LIST keys use bounded LRANGE windows so they aren't
+# constrained here. SCAN-based readers stop streaming once they reach this cap
+# so a runaway 10M-element SET can't OOM the api process.
+MAX_ITEMS_PER_KEY: int = getattr(settings, "REDIS_ADMIN_MAX_ITEMS_PER_KEY", 5_000)
+
+# Pipeline batch size for delete operations (M5). Keeps a single delete action
+# from blocking Redis with a single oversized MULTI when an operator clears
+# thousands of keys at once.
+DELETE_BATCH_SIZE: int = getattr(settings, "REDIS_ADMIN_DELETE_BATCH_SIZE", 500)

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/items_inline_change_form.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/items_inline_change_form.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_form.html" %}
+
+{# Renders a tabular-inline-style "Items" block right after the readonly
+   field sets. The HTML is built server-side in `admin._render_items_inline`
+   because the `RedisQueueItem` model is unmanaged (no FK back to the
+   parent queue), so a real `TabularInline` won't work. #}
+{% block after_field_sets %}
+{{ block.super }}
+{% if redis_admin_items_inline %}{{ redis_admin_items_inline }}{% endif %}
+{% endblock %}

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -303,6 +303,54 @@ class RedisLockAdminSmokeTest(TestCase):
         assert "delete_selected" not in body
 
 
+class RedisQueueAdminChangePageTest(TestCase):
+    """Clicking a row on the changelist opens the per-key inspector."""
+
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+
+        self.user = UserFactory(is_staff=True, is_superuser=True)
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def test_change_page_renders_for_keys_with_slashes(self):
+        # Reproduces the user-reported NotImplementedError: a `latest_upload/
+        # 123/<sha>` key is the changelist row's pk, so Django's admin
+        # url-quotes the slashes (`/` → `_2F`) and looks the row up via
+        # `queryset.get(name=…)`.
+        self.redis.set(
+            "latest_upload/123/8ebf8abc9d07cceb42ead4b94edb494d52eefd2f", "1"
+        )
+        url = "/admin/redis_admin/redisqueue/latest_5Fupload_2F123_2F8ebf8abc9d07cceb42ead4b94edb494d52eefd2f/change/"
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Family + repoid render in the inspector pane.
+        assert "latest_upload" in body
+        assert "123" in body
+        # Save buttons must be suppressed; only Delete (and history) render.
+        assert 'name="_save"' not in body
+        assert 'name="_continue"' not in body
+        assert 'name="_addanother"' not in body
+        # Superuser sees the delete link.
+        assert "delete/" in body
+
+    def test_change_page_404s_when_redis_key_missing(self):
+        url = "/admin/redis_admin/redisqueue/no_2Dsuch_2Fkey/change/"
+        response = self.client.get(url)
+        # Django's admin returns a 302 → "?" or a 404 for a missing object;
+        # both are fine, the important part is no 500 from
+        # NotImplementedError.
+        assert response.status_code in (302, 404)
+
+
 class RedisQueueAdminDeleteActionsTest(TestCase):
     """M5.2 end-to-end: dry-run action, real delete, non-superuser blocked."""
 

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -414,6 +414,50 @@ class RedisQueueAdminChangePageTest(TestCase):
         # NotImplementedError.
         assert response.status_code in (302, 404)
 
+    def test_change_page_renders_inline_items_preview_for_list_queue(self):
+        # Operator clicks a backed-up `uploads/<repoid>/<sha>` queue;
+        # the change page should show the queue's items inline so they
+        # can investigate without a second tab.
+        for i in range(3):
+            self.redis.rpush("uploads/123/abc123", f'{{"upload_id": {i}}}'.encode())
+
+        url = "/admin/redis_admin/redisqueue/uploads_2F123_2Fabc123/change/"
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # The items render as a Django tabular inline (matching the
+        # admin's `TabularInline` look). The wrapper, headers, and
+        # row values should all be present. Values are HTML-escaped
+        # by `format_html`, so look for the escaped form.
+        assert 'class="js-inline-admin-formset inline-group"' in body
+        assert "Index / field" in body
+        for i in range(3):
+            assert f"upload_id&quot;: {i}" in body
+        # Each row should link to the per-item inspector for drill-in.
+        assert (
+            "/admin/redis_admin/redisqueueitem/uploads_2F123_2Fabc123_230/change/"
+            in body
+        )
+        # And the footer link points at the full items changelist.
+        assert "queue_name__exact=uploads/123/abc123" in body
+
+    def test_change_page_renders_inline_items_preview_for_string_key(self):
+        # `latest_upload/<repoid>/<sha>` is a STRING; the held value
+        # should appear in the preview.
+        self.redis.set(
+            "latest_upload/123/8ebf8abc9d07cceb42ead4b94edb494d52eefd2f",
+            "the-stored-id",
+        )
+
+        url = "/admin/redis_admin/redisqueue/latest_5Fupload_2F123_2F8ebf8abc9d07cceb42ead4b94edb494d52eefd2f/change/"
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "the-stored-id" in body
+        assert "(value)" in body
+
 
 class RedisQueueAdminDeleteActionsTest(TestCase):
     """M5.2 end-to-end: dry-run action, real delete, non-superuser blocked."""

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import fakeredis
 import pytest
+from django.contrib.admin.models import LogEntry
 from django.test import TestCase
 
 from redis_admin import conn as redis_admin_conn
@@ -256,3 +257,135 @@ class RedisAdminFiltersAndSearchTest(TestCase):
         assert response.status_code == 200
         body = response.content.decode("utf-8")
         assert "/admin/core/commit/?q=cafef00dcafef00d" in body
+
+
+class RedisLockAdminSmokeTest(TestCase):
+    """M4.3 end-to-end checks for the read-only locks changelist."""
+
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+
+        self.user = UserFactory(is_staff=True)
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def test_lock_changelist_lists_lock_keys_only(self):
+        # Mix of lock and queue keys; only the lock ones should show up
+        # on /redislock/ and only the queue ones on /redisqueue/.
+        self.redis.set("upload_lock_1234_abc", "1")
+        self.redis.set("ta_flake_lock:1234", "1")
+        self.redis.set("upload_finisher_gate_1234_abc", "1")
+        self.redis.rpush("uploads/1234/abc", "payload")
+
+        response = self.client.get("/admin/redis_admin/redislock/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "upload_lock_1234_abc" in body
+        assert "ta_flake_lock:1234" in body
+        assert "upload_finisher_gate_1234_abc" in body
+        # Queue keys must not bleed into the locks page.
+        assert "uploads/1234/abc" not in body
+
+    def test_locks_changelist_has_no_delete_action(self):
+        self.redis.set("upload_lock_1_abc", "1")
+
+        response = self.client.get("/admin/redis_admin/redislock/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # The default "Delete selected" action must be stripped.
+        assert "delete_selected" not in body
+
+
+class RedisQueueAdminDeleteActionsTest(TestCase):
+    """M5.2 end-to-end: dry-run action, real delete, non-superuser blocked."""
+
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+
+        self.client = Client()
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def _populate(self):
+        self.redis.rpush("uploads/1/aaa", "p1")
+        self.redis.rpush("uploads/1/bbb", "p2")
+
+    def test_non_superuser_cannot_see_delete_selected(self):
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+        self._populate()
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Non-superusers can dry-run but never see the destructive action.
+        assert "Delete selected" not in body
+        assert "Dry-run" in body
+
+    def test_clear_dry_run_action_does_not_delete(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate()
+
+        response = self.client.post(
+            "/admin/redis_admin/redisqueue/",
+            {
+                "action": "clear_dry_run",
+                "_selected_action": ["uploads/1/aaa", "uploads/1/bbb"],
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "Dry-run: would delete 2" in body
+        # Keys must still be in Redis after a dry-run.
+        assert self.redis.exists("uploads/1/aaa") == 1
+        assert self.redis.exists("uploads/1/bbb") == 1
+        # Audit trail: dry-runs are recorded.
+        assert LogEntry.objects.count() >= 1
+
+    def test_delete_selected_actually_clears_keys(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate()
+
+        # Stage 1: post the bulk action and accept Django's confirmation page.
+        response = self.client.post(
+            "/admin/redis_admin/redisqueue/",
+            {
+                "action": "delete_selected",
+                "_selected_action": ["uploads/1/aaa", "uploads/1/bbb"],
+            },
+        )
+        # The confirmation page is a 200, the actual delete needs `post`.
+        assert response.status_code == 200
+
+        # Stage 2: confirm the deletion.
+        response = self.client.post(
+            "/admin/redis_admin/redisqueue/",
+            {
+                "action": "delete_selected",
+                "_selected_action": ["uploads/1/aaa", "uploads/1/bbb"],
+                "post": "yes",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        # Both keys should now be gone.
+        assert self.redis.exists("uploads/1/aaa") == 0
+        assert self.redis.exists("uploads/1/bbb") == 0
+        # Audit log should record the real delete.
+        assert LogEntry.objects.count() >= 1

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -19,6 +19,7 @@ from django.test import TestCase
 
 from redis_admin import conn as redis_admin_conn
 from shared.django_apps.codecov_auth.tests.factories import UserFactory
+from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
 from utils.test_utils import Client
 
 
@@ -257,6 +258,31 @@ class RedisAdminFiltersAndSearchTest(TestCase):
         assert response.status_code == 200
         body = response.content.decode("utf-8")
         assert "/admin/core/commit/?q=cafef00dcafef00d" in body
+
+    def test_repo_display_column_renders_service_owner_name(self):
+        owner = OwnerFactory(service="github", username="codecov")
+        repo = RepositoryFactory(author=owner, name="example")
+        self.redis.rpush(f"uploads/{repo.repoid}/abc", "x")
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert f"uploads/{repo.repoid}/abc" in body
+        assert "github:codecov/example" in body
+
+    def test_repo_display_column_falls_back_to_dash_when_repo_missing(self):
+        # Redis still has a queue for a repoid that no longer exists in
+        # the DB (e.g. repo was deleted); the column degrades gracefully
+        # rather than 500ing the changelist.
+        self.redis.rpush("uploads/9999999/abc", "x")
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Fallback is the em-dash placeholder.
+        assert "—" in body
 
 
 class RedisLockAdminSmokeTest(TestCase):

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -129,6 +129,44 @@ class RedisQueueItemAdminSmokeTest(TestCase):
         assert ">0<" in body or ">0 " in body
         assert ">2<" in body or ">2 " in body
 
+    def test_item_change_page_renders_for_list_item(self):
+        # Reproduces the user-reported NotImplementedError: clicking an
+        # item row on the changelist hits `/<pk_token>/change/`, which
+        # calls `queryset.get(pk_token=…)`. The pk_token is
+        # `<queue>#<index>` for LIST items, url-encoded by Django so
+        # `/` → `_2F` and `#` → `_23`.
+        self.redis.rpush("uploads/123/abcdef", "first-payload")
+        self.redis.rpush("uploads/123/abcdef", "second-payload")
+        url = "/admin/redis_admin/redisqueueitem/uploads_2F123_2Fabcdef_230/change/"
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # The first item's value renders on the readonly page.
+        assert "first-payload" in body
+        # No save buttons because the item is a strict read-only inspector.
+        assert 'name="_save"' not in body
+
+    def test_item_change_page_for_string_key(self):
+        self.redis.set("latest_upload/1/sha", "string-payload")
+        url = "/admin/redis_admin/redisqueueitem/latest_5Fupload_2F1_2Fsha_23v/change/"
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "string-payload" in body
+
+    def test_item_change_page_404s_for_missing_index(self):
+        self.redis.rpush("uploads/1/sha", "only-one")
+        # Index 99 doesn't exist; admin should 302/404 rather than 500.
+        url = "/admin/redis_admin/redisqueueitem/uploads_2F1_2Fsha_2399/change/"
+
+        response = self.client.get(url)
+
+        assert response.status_code in (302, 404)
+
     def test_items_changelist_with_unknown_queue_renders_empty(self):
         response = self.client.get(
             "/admin/redis_admin/redisqueueitem/",

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -18,6 +18,8 @@ from redis_admin.families import (
     _celery_decode_value,
     _celery_pattern,
     _intermediate_report_pattern,
+    _lock_attempts_pattern,
+    _lock_pattern_factory,
     _parse_coordination_lock_key,
     _parse_intermediate_report_key,
     _parse_latest_upload_key,
@@ -371,3 +373,125 @@ def test_iter_keys_does_not_double_yield_lock_attempts(patched_redis):
         if k == "lock_attempts:upload_lock_1_abc"
     ]
     assert rows == [("lock_attempts:upload_lock_1_abc", "lock_attempts")]
+
+
+# ---- Lock SCAN pattern pushdown regressions (Bugbot review on PR #888) ----
+
+
+def test_ta_notifier_fence_pattern_pushes_down_commitid():
+    """Bugbot PR #888: the previous `_lock_pattern_factory(sep=":")` set
+    `has_commit = (sep == "_") = False`, so any `commitid_prefix`
+    filter caused `pattern_for` to return None and skip the family
+    entirely — even though `ta_notifier_fence:{repoid}_{commitid}`
+    actually does encode a commit. Now `has_commit=True` is explicit.
+    """
+
+    pattern_for = _lock_pattern_factory(
+        "ta_notifier_fence", prefix_sep=":", has_commit=True
+    )
+
+    assert pattern_for({}) == "ta_notifier_fence:*"
+    assert pattern_for({"repoid": 42}) == "ta_notifier_fence:42_*"
+    assert (
+        pattern_for({"repoid": 42, "commitid_prefix": "abc"})
+        == "ta_notifier_fence:42_abc*"
+    )
+    # commitid-only without repoid still falls back to the family
+    # wildcard (Redis MATCH globs can't anchor "skip the repoid").
+    assert pattern_for({"commitid_prefix": "abc"}) == "ta_notifier_fence:*"
+
+
+def test_ta_flake_lock_pattern_drops_when_filtered_by_commitid():
+    """`ta_flake_lock:{repoid}` truly has no commit segment, so
+    `has_commit=False` is correct here — and a `commitid_prefix`
+    filter must drop the family from the SCAN entirely.
+    """
+
+    pattern_for = _lock_pattern_factory(
+        "ta_flake_lock", prefix_sep=":", has_commit=False
+    )
+
+    assert pattern_for({}) == "ta_flake_lock:*"
+    assert pattern_for({"repoid": 7}) == "ta_flake_lock:7*"
+    assert pattern_for({"commitid_prefix": "abc"}) is None
+    assert pattern_for({"repoid": 7, "commitid_prefix": "abc"}) is None
+
+
+def test_upload_finisher_gate_pattern_uses_underscore_prefix_sep():
+    """`upload_finisher_gate_{repoid}_{commitid}` keeps the same
+    `_` separator on both boundaries; explicit `prefix_sep="_"`,
+    `has_commit=True` documents that.
+    """
+
+    pattern_for = _lock_pattern_factory(
+        "upload_finisher_gate", prefix_sep="_", has_commit=True
+    )
+
+    assert pattern_for({"repoid": 99}) == "upload_finisher_gate_99_*"
+    assert (
+        pattern_for({"repoid": 99, "commitid_prefix": "deadbeef"})
+        == "upload_finisher_gate_99_deadbeef*"
+    )
+
+
+def test_lock_attempts_pattern_uses_embedded_repoid_position():
+    """Bugbot PR #888: the previous factory call generated
+    `lock_attempts:{repoid}*`, but actual keys are
+    `lock_attempts:{coordination_lock_name}` where the coord-lock-
+    name is `<type>_lock_<repoid>_<commit>...`. The repoid lives
+    deep inside the suffix, so we pushdown the embedded structure
+    via `*_lock_<repoid>_*` instead.
+    """
+
+    assert _lock_attempts_pattern({}) == "lock_attempts:*"
+    assert _lock_attempts_pattern({"repoid": 42}) == "lock_attempts:*_lock_42_*"
+    assert (
+        _lock_attempts_pattern({"repoid": 42, "commitid_prefix": "abc"})
+        == "lock_attempts:*_lock_42_abc*"
+    )
+    # commitid-only is unsafe to push down (commitid digits could
+    # collide with repoid digits at any position) — fall back to
+    # the family wildcard and let the post-scan parse_key filter
+    # finish the job.
+    assert _lock_attempts_pattern({"commitid_prefix": "abc"}) == "lock_attempts:*"
+
+
+def test_iter_keys_finds_lock_attempts_filtered_by_repoid(patched_redis):
+    """End-to-end regression for bugbot bug #4: searching the locks
+    admin by `repoid:42` must surface `lock_attempts:upload_lock_42_*`
+    keys (previously the pushdown SCAN-MATCH excluded them).
+    """
+
+    patched_redis.set("lock_attempts:upload_lock_42_abc", "1")
+    patched_redis.set("lock_attempts:upload_lock_99_xyz", "1")
+
+    rows = {k for k, _ in iter_keys(patched_redis, family="lock_attempts", repoid=42)}
+
+    assert rows == {"lock_attempts:upload_lock_42_abc"}
+
+
+def test_iter_keys_finds_ta_notifier_fence_filtered_by_repoid_and_commit(
+    patched_redis,
+):
+    """End-to-end regression for bugbot bug #1: a `repoid:42
+    commitid:abc` filter on the locks admin must include
+    `ta_notifier_fence` keys (previously the family was skipped
+    entirely because `_lock_pattern_factory` returned `None` whenever
+    `commitid_prefix` was set against a `sep=":"` family).
+    """
+
+    patched_redis.set("ta_notifier_fence:42_abcdef", "1")
+    patched_redis.set("ta_notifier_fence:42_other00", "1")
+    patched_redis.set("ta_notifier_fence:99_abcdef", "1")
+
+    rows = {
+        k
+        for k, _ in iter_keys(
+            patched_redis,
+            family="ta_notifier_fence",
+            repoid=42,
+            commitid_prefix="abc",
+        )
+    }
+
+    assert rows == {"ta_notifier_fence:42_abcdef"}

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -6,13 +6,27 @@ tests don't need a Redis (fake or real) at all.
 
 from __future__ import annotations
 
+import base64
+import json
+
 import fakeredis
 import pytest
 
 from redis_admin import conn as redis_admin_conn
 from redis_admin.families import (
     FAMILIES,
+    _celery_decode_value,
+    _celery_pattern,
+    _intermediate_report_pattern,
+    _parse_coordination_lock_key,
+    _parse_intermediate_report_key,
+    _parse_latest_upload_key,
+    _parse_lock_attempts_key,
     _parse_ta_flake_key,
+    _parse_ta_flake_lock_key,
+    _parse_ta_notifier_fence_key,
+    _parse_upload_finisher_gate_key,
+    _parse_upload_processing_state_key,
     _parse_uploads_key,
     _ta_flake_pattern,
     _uploads_pattern,
@@ -132,3 +146,228 @@ def test_families_registry_exposes_uploads_and_ta_flake_key():
     names = {f.name for f in FAMILIES}
     assert "uploads" in names
     assert "ta_flake_key" in names
+
+
+# ---- M4.1: latest_upload / upload-processing-state / intermediate-report ----
+
+
+def test_parse_latest_upload_default_report_type():
+    parsed = _parse_latest_upload_key("latest_upload/1234/abcdef0")
+    assert parsed.family == "latest_upload"
+    assert parsed.repoid == 1234
+    assert parsed.commitid == "abcdef0"
+    assert parsed.report_type == "coverage"
+
+
+def test_parse_latest_upload_typed_report_type():
+    parsed = _parse_latest_upload_key("latest_upload/42/sha/test_results")
+    assert parsed.report_type == "test_results"
+
+
+def test_parse_upload_processing_state_extracts_state_segment():
+    parsed = _parse_upload_processing_state_key(
+        "upload-processing-state/123/abc/in_progress"
+    )
+    assert parsed.family == "upload-processing-state"
+    assert parsed.repoid == 123
+    assert parsed.commitid == "abc"
+    assert parsed.state == "in_progress"
+
+
+def test_parse_intermediate_report_extracts_upload_id():
+    parsed = _parse_intermediate_report_key("intermediate-report/upload-99")
+    assert parsed.family == "intermediate-report"
+    assert parsed.upload_id == "upload-99"
+    assert parsed.repoid is None  # not derivable from the key alone
+
+
+def test_intermediate_report_pattern_drops_when_repoid_filter_set():
+    """Filtering by repoid against intermediate-report can never match,
+    so the pushdown returns None and `iter_keys` skips the family.
+    """
+
+    assert _intermediate_report_pattern({}) == "intermediate-report/*"
+    assert _intermediate_report_pattern({"repoid": 5}) is None
+    assert _intermediate_report_pattern({"commitid_prefix": "abc"}) is None
+
+
+def test_iter_keys_classifies_new_m4_families(patched_redis):
+    patched_redis.set("latest_upload/1/abc", "1")
+    patched_redis.sadd("upload-processing-state/1/abc/started", "x")
+    patched_redis.hset("intermediate-report/u1", mapping={"f": "v"})
+
+    classified = {k: f.name for k, f in iter_keys(patched_redis)}
+    assert classified["latest_upload/1/abc"] == "latest_upload"
+    assert (
+        classified["upload-processing-state/1/abc/started"] == "upload-processing-state"
+    )
+    assert classified["intermediate-report/u1"] == "intermediate-report"
+
+
+# ---- M4.2: celery_broker family + kombu envelope decoder -------------------
+
+
+def test_celery_pattern_skips_when_repoid_filter_set():
+    """Celery queue *keys* don't carry repoid; filtering by repoid means
+    every celery queue would post-scan-drop, so skip the SCAN entirely.
+    """
+
+    assert _celery_pattern({}) == "enterprise_*"
+    assert _celery_pattern({"repoid": 5}) is None
+    assert _celery_pattern({"commitid_prefix": "abc"}) is None
+
+
+def test_celery_broker_family_resolves_known_queue_names():
+    """`fixed_keys` for `celery_broker` includes the BaseCeleryConfig
+    defaults so `iter_keys` finds the well-known queues without needing
+    an `enterprise_*` SCAN to discover them.
+    """
+    family = next(f for f in FAMILIES if f.name == "celery_broker")
+    assert "celery" in family.fixed_keys
+    assert "healthcheck" in family.fixed_keys
+
+
+def test_iter_keys_yields_celery_queues_via_fixed_keys(patched_redis):
+    patched_redis.rpush("celery", '{"task": "x"}')
+    patched_redis.rpush("healthcheck", '{"task": "y"}')
+    patched_redis.rpush("enterprise_uploadcoverage", '{"task": "z"}')
+    patched_redis.rpush("uploads/1/abc", "x")  # different family
+
+    classified = {k: f.name for k, f in iter_keys(patched_redis)}
+    assert classified["celery"] == "celery_broker"
+    assert classified["healthcheck"] == "celery_broker"
+    assert classified["enterprise_uploadcoverage"] == "celery_broker"
+    assert classified["uploads/1/abc"] == "uploads"
+
+
+def test_celery_decode_value_extracts_task_repoid_commit():
+    """The kombu envelope decoder pulls task / repoid / commitid out of
+    a real-shaped JSON+base64 envelope and prefixes the raw payload so
+    operators can scan a queue without re-decoding by hand.
+    """
+
+    body = json.dumps([[], {"repoid": 7, "commitid": "abcdef0123"}, {}])
+    body_b64 = base64.b64encode(body.encode("utf-8")).decode("ascii")
+    envelope = json.dumps(
+        {
+            "body": body_b64,
+            "headers": {"task": "app.tasks.upload.Upload", "id": "task-uuid-1"},
+        }
+    )
+
+    decoded = _celery_decode_value(envelope)
+    assert decoded.startswith("[task=app.tasks.upload.Upload repoid=7 commit=abcdef0]")
+    assert envelope in decoded  # raw payload is preserved after the prefix
+
+
+def test_celery_decode_value_falls_back_for_non_json_payload():
+    """Anything that doesn't look like a kombu envelope is rendered
+    unchanged so we don't 500 the admin on an unexpected message.
+    """
+
+    assert _celery_decode_value("not-json") == "not-json"
+
+
+# ---- M4.3: lock families ---------------------------------------------------
+
+
+def test_parse_coordination_lock_extracts_repoid_commit_report_type():
+    parsed = _parse_coordination_lock_key("upload_lock_123_abcdef0")
+    assert parsed.family == "coordination_lock"
+    assert parsed.repoid == 123
+    assert parsed.commitid == "abcdef0"
+    assert parsed.report_type is None
+
+
+def test_parse_coordination_lock_with_report_type_suffix():
+    """`bundle_analysis_processing_lock_123_abc_bundle_analysis` shape
+    keeps the report_type suffix. Multi-word report types stay joined."""
+
+    parsed = _parse_coordination_lock_key(
+        "bundle_analysis_processing_lock_123_abc_bundle_analysis"
+    )
+    assert parsed.repoid == 123
+    assert parsed.commitid == "abc"
+    assert parsed.report_type == "bundle_analysis"
+
+
+def test_parse_lock_attempts_unwraps_embedded_lock_name():
+    parsed = _parse_lock_attempts_key("lock_attempts:upload_lock_42_abcdef")
+    assert parsed.family == "lock_attempts"
+    assert parsed.repoid == 42
+    assert parsed.commitid == "abcdef"
+
+
+def test_parse_ta_flake_lock_extracts_repoid():
+    parsed = _parse_ta_flake_lock_key("ta_flake_lock:99")
+    assert parsed.repoid == 99
+
+
+def test_parse_upload_finisher_gate_extracts_repoid_commit():
+    parsed = _parse_upload_finisher_gate_key("upload_finisher_gate_123_abcdef0")
+    assert parsed.repoid == 123
+    assert parsed.commitid == "abcdef0"
+
+
+def test_parse_ta_notifier_fence_extracts_repoid_commit():
+    parsed = _parse_ta_notifier_fence_key("ta_notifier_fence:123_abcdef0")
+    assert parsed.repoid == 123
+    assert parsed.commitid == "abcdef0"
+
+
+def test_find_family_routes_lock_attempts_before_coordination_lock():
+    """`lock_attempts:upload_lock_…` keys contain `_lock_` so the broad
+    `*_lock_*` family would also match them; `find_family` must respect
+    registration order and return the more-specific `lock_attempts:*`
+    family.
+    """
+    fam = find_family("lock_attempts:upload_lock_1_abc")
+    assert fam is not None and fam.name == "lock_attempts"
+
+
+def test_lock_families_are_marked_undeletable_and_lock_category():
+    """Defence in depth: every lock-shaped family must have
+    `is_deletable=False` and `category="lock"` so M5's delete service
+    refuses to touch them and they don't leak into the queue admin.
+    """
+    lock_names = {
+        "lock_attempts",
+        "ta_flake_lock",
+        "ta_notifier_fence",
+        "upload_finisher_gate",
+        "coordination_lock",
+    }
+    for fam in FAMILIES:
+        if fam.name in lock_names:
+            assert fam.is_deletable is False, fam.name
+            assert fam.category == "lock", fam.name
+        else:
+            assert fam.category == "queue", fam.name
+
+
+def test_iter_keys_with_category_lock_only_returns_locks(patched_redis):
+    patched_redis.rpush("uploads/1/abc", "x")
+    patched_redis.set("upload_lock_1_abc", "owned")
+    patched_redis.set("ta_flake_lock:1", "owned")
+
+    queue_keys = {k for k, _ in iter_keys(patched_redis, category="queue")}
+    lock_keys = {k for k, _ in iter_keys(patched_redis, category="lock")}
+
+    assert queue_keys == {"uploads/1/abc"}
+    assert lock_keys == {"upload_lock_1_abc", "ta_flake_lock:1"}
+
+
+def test_iter_keys_does_not_double_yield_lock_attempts(patched_redis):
+    """`lock_attempts:upload_lock_…` matches both `lock_attempts:*` and
+    the broader `*_lock_*`; `iter_keys` must dedupe so the row appears
+    once.
+    """
+
+    patched_redis.set("lock_attempts:upload_lock_1_abc", "1")
+
+    rows = [
+        (k, f.name)
+        for k, f in iter_keys(patched_redis, category="lock")
+        if k == "lock_attempts:upload_lock_1_abc"
+    ]
+    assert rows == [("lock_attempts:upload_lock_1_abc", "lock_attempts")]

--- a/apps/codecov-api/redis_admin/tests/test_item_queryset.py
+++ b/apps/codecov-api/redis_admin/tests/test_item_queryset.py
@@ -104,23 +104,87 @@ def test_filter_by_unknown_queue_name_returns_empty(patched_redis):
     assert RedisQueueItem.objects.filter(queue_name__exact="missing").count() == 0
 
 
-def test_set_and_hash_queues_report_zero_until_milestone_4(patched_redis):
-    # M2 only handles LIST. SET/HASH/STRING families arrive in M4; until then
-    # the item view reports zero so the changelist renders cleanly without
-    # blowing up.
-    patched_redis.sadd("upload-processing-state/1/abc", "x", "y")
-    patched_redis.hset("intermediate-report/1/abc", mapping={"a": "1", "b": "2"})
+def test_set_queue_items_use_sscan_and_sort_lexically(patched_redis):
+    """M4: SET items render via SSCAN, sorted so admin pagination is stable."""
 
-    set_qs = RedisQueueItem.objects.filter(
-        queue_name__exact="upload-processing-state/1/abc"
+    patched_redis.sadd("upload-processing-state/1/abc/in_progress", "z", "a", "m")
+
+    qs = RedisQueueItem.objects.filter(
+        queue_name__exact="upload-processing-state/1/abc/in_progress"
     )
-    hash_qs = RedisQueueItem.objects.filter(
-        queue_name__exact="intermediate-report/1/abc"
+
+    rows = list(qs)
+    assert qs.count() == 3
+    # Sorted lexically so page-to-page navigation is stable across requests.
+    assert [row.raw_value for row in rows] == ["a", "m", "z"]
+    # pk_token uses the deterministic ordinal so items are unique-keyed.
+    assert {row.pk_token for row in rows} == {
+        "upload-processing-state/1/abc/in_progress#m:0",
+        "upload-processing-state/1/abc/in_progress#m:1",
+        "upload-processing-state/1/abc/in_progress#m:2",
+    }
+
+
+def test_hash_queue_items_use_hscan_sorted_by_field(patched_redis):
+    """M4: HASH items render via HSCAN, sorted by field name."""
+
+    patched_redis.hset(
+        "intermediate-report/upload-99",
+        mapping={"zeta": "3", "alpha": "1", "beta": "2"},
     )
-    assert set_qs.count() == 0
-    assert hash_qs.count() == 0
-    assert list(set_qs) == []
-    assert list(hash_qs) == []
+
+    qs = RedisQueueItem.objects.filter(
+        queue_name__exact="intermediate-report/upload-99"
+    )
+
+    rows = list(qs)
+    assert qs.count() == 3
+    assert [row.index_or_field for row in rows] == ["alpha", "beta", "zeta"]
+    assert [row.raw_value for row in rows] == ["1", "2", "3"]
+    assert [row.pk_token for row in rows] == [
+        "intermediate-report/upload-99#f:alpha",
+        "intermediate-report/upload-99#f:beta",
+        "intermediate-report/upload-99#f:zeta",
+    ]
+
+
+def test_string_queue_renders_a_single_item(patched_redis):
+    """M4: STRING (e.g. `latest_upload/...`) shows the value as one item."""
+
+    patched_redis.set("latest_upload/1/abc", "1234567890")
+
+    qs = RedisQueueItem.objects.filter(queue_name__exact="latest_upload/1/abc")
+
+    rows = list(qs)
+    assert qs.count() == 1
+    assert len(rows) == 1
+    assert rows[0].index_or_field == "(value)"
+    assert rows[0].raw_value == "1234567890"
+    assert rows[0].pk_token == "latest_upload/1/abc#v"
+
+
+def test_string_queue_count_is_zero_when_key_missing(patched_redis):
+    qs = RedisQueueItem.objects.filter(queue_name__exact="latest_upload/missing/key")
+    assert qs.count() == 0
+    assert list(qs) == []
+
+
+def test_set_items_capped_by_max_items_per_key(patched_redis, monkeypatch):
+    """A pathologically large SET stops streaming once we hit the cap."""
+
+    monkeypatch.setattr(redis_admin_settings, "MAX_ITEMS_PER_KEY", 5)
+    for i in range(20):
+        patched_redis.sadd("upload-processing-state/1/abc/in_progress", f"m{i:02d}")
+
+    qs = RedisQueueItem.objects.filter(
+        queue_name__exact="upload-processing-state/1/abc/in_progress"
+    )
+
+    # count() still reports the true SCARD so the paginator's totals stay
+    # honest; only materialised pages are truncated.
+    assert qs.count() == 20
+    rows = list(qs)
+    assert len(rows) == 5
 
 
 def test_delete_raises_until_milestone_5(patched_redis):

--- a/apps/codecov-api/redis_admin/tests/test_services.py
+++ b/apps/codecov-api/redis_admin/tests/test_services.py
@@ -227,3 +227,32 @@ class TestRedisDeleteService(TestCase):
         message = json.loads(entries.first().change_message)
         assert message["count"] == 0
         assert "upload_lock_1_abc" in message["refused"]
+
+    def test_item_delete_refuses_celery_lists(self):
+        """Bugbot PR #888: `_classify_items` used `item.raw_value` as
+        the LREM selector. For families with `decode_value` (today:
+        `celery_broker`), `raw_value` carries the
+        `[task=… repoid=… commit=…]` display prefix that's NOT in
+        Redis, so LREM matches zero rows. Refuse item-level
+        LIST/SET delete for those families and let operators clear
+        the whole queue from `RedisQueueAdmin` instead.
+        """
+
+        self.server.rpush("celery", b"raw-payload-bytes")
+        # Simulate what `_build_list_items` produces for a celery
+        # row: raw_value carries the decode-prefix.
+        item = RedisQueueItem(
+            pk_token="celery#0",
+            queue_name="celery",
+            index_or_field="0",
+            raw_value="[task=app.foo repoid=42 commit=abc] raw-payload-bytes",
+        )
+
+        result = redis_delete([item], user=self.user, dry_run=False)
+
+        assert result.count == 0
+        assert "celery#0" in result.refused
+        # Most importantly: the original Redis payload is still
+        # there. Without the refusal, LREM would silently no-op
+        # against the prefixed selector and report success.
+        assert self.server.llen("celery") == 1

--- a/apps/codecov-api/redis_admin/tests/test_services.py
+++ b/apps/codecov-api/redis_admin/tests/test_services.py
@@ -1,0 +1,229 @@
+"""Unit tests for `redis_admin.services.redis_delete`.
+
+Covers the matrix that's invariant across admin entry points:
+
+- DEL on whole keys for queue families
+- LREM/SREM/HDEL on items (services-only path; the admin doesn't wire
+  per-item delete in M5 but the service is the single chokepoint, so
+  unit-test it directly)
+- Lock families refuse deletion
+- dry_run=True performs zero mutations
+- Audit `LogEntry` is written on every call
+- Pipelining batches don't blow up on > batch_size targets
+"""
+
+from __future__ import annotations
+
+import json
+
+import fakeredis
+import pytest
+from django.contrib.admin.models import DELETION, LogEntry
+from django.test import TestCase
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin import settings as redis_admin_settings
+from redis_admin.models import RedisLock, RedisQueue, RedisQueueItem
+from redis_admin.services import redis_delete
+from shared.django_apps.codecov_auth.tests.factories import UserFactory
+
+
+@pytest.fixture
+def patched_redis(monkeypatch) -> fakeredis.FakeStrictRedis:
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(redis_admin_conn, "get_connection", lambda: server)
+    return server
+
+
+def _make_queue(name: str, family: str = "uploads", redis_type: str = "LIST"):
+    return RedisQueue(name=name, family=family, redis_type=redis_type, depth=0)
+
+
+def _make_lock(name: str, family: str):
+    return RedisLock(name=name, family=family, redis_type="STRING", depth=0)
+
+
+@pytest.mark.django_db
+class TestRedisDeleteService(TestCase):
+    def setUp(self):
+        self.user = UserFactory(is_staff=True, is_superuser=True)
+        self.server = fakeredis.FakeStrictRedis()
+        self._patcher = self._patch_connection()
+
+    def _patch_connection(self):
+        # Module-level monkeypatch so the service sees our fakeredis.
+        original = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.server  # type: ignore
+        self.addCleanup(setattr, redis_admin_conn, "get_connection", original)
+        return None
+
+    def test_dry_run_performs_no_mutations(self):
+        self.server.rpush("uploads/1/abc", "x")
+        self.server.rpush("uploads/2/def", "y")
+
+        result = redis_delete(
+            [_make_queue("uploads/1/abc"), _make_queue("uploads/2/def")],
+            user=self.user,
+            dry_run=True,
+        )
+
+        assert result.dry_run is True
+        assert result.count == 2
+        assert set(result.sample) == {"uploads/1/abc", "uploads/2/def"}
+        assert "uploads" in result.families
+        # Both keys still in redis.
+        assert self.server.exists("uploads/1/abc") == 1
+        assert self.server.exists("uploads/2/def") == 1
+
+    def test_real_run_deletes_keys(self):
+        self.server.rpush("uploads/1/abc", "x")
+        self.server.rpush("uploads/2/def", "y")
+
+        result = redis_delete(
+            [_make_queue("uploads/1/abc"), _make_queue("uploads/2/def")],
+            user=self.user,
+            dry_run=False,
+        )
+
+        assert result.dry_run is False
+        assert result.count == 2
+        assert self.server.exists("uploads/1/abc") == 0
+        assert self.server.exists("uploads/2/def") == 0
+
+    def test_locks_are_refused_even_on_real_run(self):
+        """Lock-flagged families MUST NOT be deletable from this service.
+        This is the last line of defence against an operator mistake;
+        the lock admin already hides the delete UI but the service
+        refuses regardless of how the row was constructed.
+        """
+
+        self.server.set("upload_lock_1_abc", "owned")
+        self.server.set("ta_flake_lock:1", "owned")
+
+        result = redis_delete(
+            [
+                _make_lock("upload_lock_1_abc", family="coordination_lock"),
+                _make_lock("ta_flake_lock:1", family="ta_flake_lock"),
+            ],
+            user=self.user,
+            dry_run=False,
+        )
+
+        assert result.count == 0
+        assert set(result.refused) == {"upload_lock_1_abc", "ta_flake_lock:1"}
+        # Locks remain in redis.
+        assert self.server.exists("upload_lock_1_abc") == 1
+        assert self.server.exists("ta_flake_lock:1") == 1
+
+    def test_unknown_families_are_refused(self):
+        """Sanity: a key that doesn't match any family (operator typed
+        a name into a URL) must refuse rather than `DEL` blindly.
+        """
+        self.server.set("totally-random-key", "v")
+
+        result = redis_delete(
+            [_make_queue("totally-random-key", family="???")],
+            user=self.user,
+            dry_run=False,
+        )
+
+        assert result.count == 0
+        assert "totally-random-key" in result.refused
+        assert self.server.exists("totally-random-key") == 1
+
+    def test_audit_log_entry_written_on_dry_run(self):
+        self.server.rpush("uploads/1/abc", "x")
+
+        redis_delete([_make_queue("uploads/1/abc")], user=self.user, dry_run=True)
+
+        entries = LogEntry.objects.filter(user=self.user, action_flag=DELETION)
+        assert entries.count() == 1
+        message = json.loads(entries.first().change_message)
+        assert message["dry_run"] is True
+        assert message["count"] == 1
+        assert message["scope"] == "queue"
+        assert "uploads" in message["families"]
+
+    def test_audit_log_entry_written_on_real_run(self):
+        self.server.rpush("uploads/1/abc", "x")
+
+        redis_delete([_make_queue("uploads/1/abc")], user=self.user, dry_run=False)
+
+        entries = LogEntry.objects.filter(user=self.user, action_flag=DELETION)
+        assert entries.count() == 1
+        message = json.loads(entries.first().change_message)
+        assert message["dry_run"] is False
+        assert message["count"] == 1
+        assert "uploads/1/abc" in message["sample"]
+
+    def test_pipeline_batching_handles_more_than_one_batch(self):
+        """A single redis_delete call > DELETE_BATCH_SIZE keys must still
+        complete; we run smaller batches to avoid one giant MULTI.
+        """
+        # Force batch size = 5 via monkeypatch so we don't have to add
+        # 500+ keys in the test.
+        original = redis_admin_settings.DELETE_BATCH_SIZE
+        redis_admin_settings.DELETE_BATCH_SIZE = 5
+        try:
+            for i in range(12):
+                self.server.rpush(f"uploads/1/sha{i:02d}", "x")
+            queues = [_make_queue(f"uploads/1/sha{i:02d}") for i in range(12)]
+
+            result = redis_delete(queues, user=self.user, dry_run=False)
+            assert result.count == 12
+            for i in range(12):
+                assert self.server.exists(f"uploads/1/sha{i:02d}") == 0
+        finally:
+            redis_admin_settings.DELETE_BATCH_SIZE = original
+
+    def test_item_lrem_deletes_specific_value(self):
+        """Service-level item delete is functional (admin doesn't wire
+        it in M5, but the service is the chokepoint and must work).
+        """
+        self.server.rpush("uploads/1/abc", "keep-1", "drop-me", "keep-2")
+        item = RedisQueueItem(
+            pk_token="uploads/1/abc#1",
+            queue_name="uploads/1/abc",
+            index_or_field="1",
+            raw_value="drop-me",
+        )
+
+        result = redis_delete([item], user=self.user, dry_run=False)
+
+        assert result.count == 1
+        remaining = [v.decode() for v in self.server.lrange("uploads/1/abc", 0, -1)]
+        assert remaining == ["keep-1", "keep-2"]
+
+    def test_item_hdel_uses_index_or_field_as_selector(self):
+        """HASH items use the field name as selector, not the value."""
+
+        self.server.hset("intermediate-report/u1", mapping={"alpha": "1", "beta": "2"})
+        item = RedisQueueItem(
+            pk_token="intermediate-report/u1#f:alpha",
+            queue_name="intermediate-report/u1",
+            index_or_field="alpha",
+            raw_value="1",
+        )
+
+        result = redis_delete([item], user=self.user, dry_run=False)
+
+        assert result.count == 1
+        assert self.server.hget("intermediate-report/u1", "alpha") is None
+        assert self.server.hget("intermediate-report/u1", "beta") == b"2"
+
+    def test_audit_log_written_when_only_refused(self):
+        """Even a fully-refused call writes an audit row so an attempt
+        to clear locks shows up in the operator history.
+        """
+        self.server.set("upload_lock_1_abc", "owned")
+        redis_delete(
+            [_make_lock("upload_lock_1_abc", family="coordination_lock")],
+            user=self.user,
+            dry_run=False,
+        )
+
+        entries = LogEntry.objects.filter(user=self.user, action_flag=DELETION)
+        assert entries.count() == 1
+        message = json.loads(entries.first().change_message)
+        assert message["count"] == 0
+        assert "upload_lock_1_abc" in message["refused"]


### PR DESCRIPTION
Stacked on #887 (M2 + M3), which is itself stacked on #885 (M1).

## Summary

**M4 — surface more of Redis in the admin**

- Register families for `latest_upload`, `upload-processing-state`, `intermediate-report`, `celery_broker`. Each carries a parser (so repoid/commitid pivots keep working) and a SCAN-MATCH pushdown (so an operator filtering by repoid won't trigger a full keyspace scan).
- Teach `RedisItemQuerySet` to materialise SET (SSCAN), HASH (HSCAN), and STRING (GET) keys, capped at `MAX_ITEMS_PER_KEY` (5_000) so a runaway hash can't OOM the changelist.
- Add a kombu envelope decoder for celery items: each row gets prefixed with `[task=… repoid=… commit=…]` so backed-up celery queues are triagable without copy/pasting payloads into a base64 decoder.
- Add a separate `RedisLock` model + `RedisLockAdmin` covering `*_lock_*`, `upload_finisher_gate_*`, `ta_flake_lock:*`, `lock_attempts:*`, `ta_notifier_fence:*`, and the various coordination locks. Locks are **read-only by construction**: families flagged `is_deletable=False`, `delete_selected` action stripped, `has_delete_permission` hard-coded `False`. Operators investigate stuck tasks here; release stays the worker's `LockManager` job.

**M5 — deletion with audit + dry-run**

- New `redis_admin/services.py::redis_delete` is the single chokepoint for any Redis mutation from the admin. It batches `DEL` / `LREM` / `SREM` / `HDEL` through a pipeline (`DELETE_BATCH_SIZE=500`), refuses any target whose family is `is_deletable=False`, and writes a `LogEntry` for every call (including dry-runs) so we have a paper trail.
- `RedisQueueAdmin` wires `delete_queryset` / `delete_model` through the service and adds a `clear_dry_run` action so staff can preview scope before a superuser actually deletes. Destructive delete is gated on `is_superuser`; `is_staff` keeps read + dry-run.
- Support `pk__in` / `name__in` on `RedisQueueQuerySet` so Django's built-in bulk-action plumbing reaches the service without a fresh SCAN.
- `RedisQueueItemAdmin` is now strictly read-only: per-item LREM/SREM/HDEL would need pk_token round-tripping that's hard to audit, so operators clear the whole queue instead.

## Test plan

- [x] `redis_admin/` ruff + ruff format clean
- [x] `pytest redis_admin/` — 98 passing (26 new for M4 + M5)
  - parsers for all new families (latest_upload, upload-processing-state, intermediate-report, lock variants)
  - kombu envelope decoder + fallback for malformed payloads
  - locks admin: lists locks only, no delete action
  - `redis_delete` service: dry-run, real, lock refusal, audit log, pipeline batching, item-level LREM/HDEL
  - end-to-end: non-superuser can't see "Delete selected", dry-run is non-destructive, "Delete selected" actually clears keys
- [ ] Manual smoke against staging: confirm `clear_dry_run` action shows a sensible scope before a real delete

## Stack

- #885 — M1: read-only Redis keys in admin
- #887 — M2 + M3: per-queue items, filters/search/repo+commit links (stacked on M1)
- **this PR** — M4 + M5: new families, locks, deletion service (stacked on M2+M3)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds admin-driven Redis deletion (bulk + single-key) and expands the surfaced keyspace; mistakes or parser/pattern bugs could clear the wrong Redis data despite superuser gating and family-level refusals.
> 
> **Overview**
> Expands `redis_admin` to surface additional Redis key families (`latest_upload`, `upload-processing-state`, `intermediate-report`, `celery_broker`) including SCAN pushdowns and item decoding (Celery kombu envelope summarization).
> 
> Adds support for browsing non-LIST key contents in the items view (SET/HASH/STRING) with per-key materialization caps and stable ordering, plus a new read-only `RedisLock` model/admin that isolates lock/fence keys from regular queues and removes delete actions.
> 
> Introduces an audited mutation path via `services.redis_delete` (pipeline-batched `DEL`/`LREM`/`SREM`/`HDEL`, dry-run, lock-family refusal, admin `LogEntry` logging) and wires `RedisQueueAdmin` bulk/single delete through it (delete gated to superusers, staff gets dry-run). Also makes queue/item change pages strict read-only inspectors and injects an inline items preview on queue/lock change pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd95ae9ed090b2a7bda8ca89d2f52001f3b2f1d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->