### PR TITLE
feat(api): redis_admin M6 + M7 — clear-by-scope, sentry spans, README

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -73,11 +73,15 @@ Three deletion entry points, all funnel through the audited
    no mutations, but still writes a `LogEntry`.
 3. **Clear by scope** — single endpoint at
    `/admin/redis_admin/redisqueue/clear-by-scope/`. Aggregates every
-   deletable key tied to a `repoid` and/or `commitid` across *all*
-   families and clears them in one operation. Required-scope guard
-   refuses an empty form. Typed-confirmation guard requires the
-   operator to re-type the repoid/commitid before the destructive
-   button arms. Both dry-run and confirm runs leave an audit trail.
+   deletable key tied to a `repoid`, `commitid`, and/or explicit
+   `family` list and clears them in one operation. Scope is the
+   cross-product of those three optional dimensions — at least one
+   must be set; a fully blank form is refused. Family is a multi-
+   select; leaving it blank sweeps every deletable family. Typed-
+   confirmation guard requires the operator to re-type the primary
+   scope value (repoid &gt; commitid &gt; joined family names) before
+   the destructive button arms. Both dry-run and confirm runs leave
+   an audit trail.
 
 Every call writes a `django.contrib.admin.LogEntry` (action_flag =
 `DELETION`) with a JSON `change_message` of the form:

--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -1,0 +1,175 @@
+# `redis_admin`
+
+A Django app that surfaces Redis-backed queues and locks in the
+existing `/admin/` site so on-call operators can spot backed-up
+queues, drill into their contents, and (with `is_superuser`) clear
+subsets of them — all without shelling into Redis.
+
+Inspired by [`wolph/django-redis-admin`][wolph]: instead of a real
+database table, the registered models are unmanaged
+(`Meta.managed = False`) and back themselves onto a custom
+`QuerySet` that translates Django admin's calls (`iterator`,
+`count`, `__getitem__`, `filter`, `delete`) into `SCAN` / `TYPE` /
+`LLEN` / `LRANGE` / `SSCAN` / `HSCAN` / `DEL` / `LREM` / `SREM` /
+`HDEL`. From the admin's perspective the rows look exactly like
+ORM-backed rows — list_display, search, filters, pagination, and
+`delete_selected` all work without custom views or templates.
+
+[wolph]: https://github.com/wolph/django-redis-admin
+
+## What's surfaced
+
+| Model | Audience | Mutable? |
+|---|---|---|
+| `RedisQueue` | Queue families: `uploads/*`, `ta_flake_key:*`, `latest_upload/*`, `upload-processing-state/*`, `intermediate-report/*`, Celery broker queues (`celery`, `healthcheck`, `enterprise_*`, `task_routes` values) | Yes (superuser only) |
+| `RedisQueueItem` | Items inside a single queue (LIST entries / SET members / HASH fields / STRING value) | Yes (superuser only) |
+| `RedisLock` | Lock families: `*_lock_*`, `upload_finisher_gate_*`, `ta_flake_lock:*`, `lock_attempts:*`, `ta_notifier_fence:*`, `coordination_lock:*` | Read-only (always) |
+
+Lock families are flagged `is_deletable=False` in the registry and
+are refused by `services.redis_delete()` even if a future change
+accidentally surfaces them under `RedisQueue`.
+
+## URLs
+
+| Path | Purpose |
+|---|---|
+| `/admin/redis_admin/redisqueue/` | Browse Redis queue keys |
+| `/admin/redis_admin/redisqueue/<key>/change/` | Inspect a single queue, with a tabular-inline preview of its items |
+| `/admin/redis_admin/redisqueueitem/?queue_name__exact=<key>` | Browse the full items of a queue |
+| `/admin/redis_admin/redisqueueitem/<token>/change/` | Inspect a single item |
+| `/admin/redis_admin/redislock/` | Browse Redis locks (read-only) |
+| `/admin/redis_admin/redisqueue/clear-by-scope/` | M6 — cross-family clear-by-scope (superuser only) |
+
+## Search and filters
+
+The queues changelist's search box accepts both bare substrings and
+`key:value` tokens, joined implicitly with AND:
+
+- `repoid:1234` &mdash; every backed-up queue/key for repo 1234
+- `commitid:abc` &mdash; every backed-up queue/key for commits whose SHA starts with `abc`
+- `family:uploads` &mdash; only the `uploads/*` family
+- `report_type:test_results` &mdash; per-report-type filter for `uploads/*` keys
+- `repoid:1234 commitid:abc` &mdash; combined
+- bare substring &mdash; any key whose name contains the text
+
+When `repoid:` or `commitid:` is in the query the filter is pushed
+down into a tighter `SCAN MATCH` pattern (e.g. `uploads/1234/*`)
+rather than a full-keyspace scan.
+
+The sidebar adds standalone `family`, `min depth`, and
+`report_type` filters.
+
+## Clearing subsets of Redis
+
+Three deletion entry points, all funnel through the audited
+`services.redis_delete()` and all gated on `request.user.is_superuser`:
+
+1. **Per-queue / per-item `Delete selected`** — the standard admin
+   bulk action. `delete_queryset` is overridden to dispatch through
+   `redis_delete`, which issues `DEL` for queue rows and
+   `LREM` / `SREM` / `HDEL` for item rows.
+2. **`Dry-run: count what 'delete selected' would clear`** — sibling
+   action visible to staff users. Same code path with `dry_run=True`,
+   no mutations, but still writes a `LogEntry`.
+3. **Clear by scope** — single endpoint at
+   `/admin/redis_admin/redisqueue/clear-by-scope/`. Aggregates every
+   deletable key tied to a `repoid` and/or `commitid` across *all*
+   families and clears them in one operation. Required-scope guard
+   refuses an empty form. Typed-confirmation guard requires the
+   operator to re-type the repoid/commitid before the destructive
+   button arms. Both dry-run and confirm runs leave an audit trail.
+
+Every call writes a `django.contrib.admin.LogEntry` (action_flag =
+`DELETION`) with a JSON `change_message` of the form:
+
+```json
+{
+  "scope": "queue|item|queue+item",
+  "dry_run": false,
+  "count": 17,
+  "families": ["uploads", "latest_upload"],
+  "sample": ["uploads/1234/abc", "..."],
+  "refused": []
+}
+```
+
+so an admin can reconstruct who cleared what and when from
+`/admin/admin/logentry/`.
+
+## Settings
+
+All configurable via `REDIS_ADMIN_*` Django settings; defaults shown.
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `REDIS_ADMIN_MAX_SCAN_KEYS` | `10_000` | Hard cap on keys visited per `iter_keys()` sweep. |
+| `REDIS_ADMIN_SCAN_COUNT` | `500` | `COUNT` hint for each `SCAN` / `SSCAN` / `HSCAN`. |
+| `REDIS_ADMIN_ITEM_PAGE_SIZE` | `100` | Page size for the items-in-a-queue view. |
+| `REDIS_ADMIN_MAX_ITEMS_PER_KEY` | `5_000` | Hard cap on members materialised from a single SET/HASH for browsing. |
+| `REDIS_ADMIN_MAX_DECODE_BYTES` | `4_096` | Per-value display truncation. |
+| `REDIS_ADMIN_DELETE_BATCH_SIZE` | `500` | Pipeline batch size for `DEL` / `LREM` / `SREM` / `HDEL`. |
+| `REDIS_ADMIN_CONNECTION_FACTORY` | unset | Dotted path to a callable returning a `redis.Redis`. Defaults to `shared.helpers.redis.get_redis_connection`. |
+
+## Adding a new family
+
+A "family" is a Redis key pattern owned by some part of the system,
+described declaratively in `families.py::FAMILIES`. To add a new
+one:
+
+1. **Add a `Family(...)`** entry to the `FAMILIES` tuple. Required
+   fields:
+   - `name` — short identifier shown in `list_display` and accepted
+     in `family:<name>` search.
+   - `scan_pattern` — Redis glob (e.g. `"my_thing/*"`).
+   - `redis_type` — one of `"list" | "set" | "hash" | "string"`.
+   - `parse_key(key) -> ParsedKey | None` — extracts `repoid`,
+     `commitid`, `report_type` (any may be `None`).
+   - `pattern_for(filters) -> str | None` — given the active
+     `repoid` / `commitid_prefix` filters, return a tightened
+     `SCAN MATCH` pattern, or `None` if the family can't possibly
+     match those filters (skips the SCAN entirely).
+   - `is_deletable: bool` — set `False` for locks and any
+     append-only auditing surface.
+   - `category: "queue" | "lock"` — locks land in `RedisLock`
+     instead of `RedisQueue`.
+   - `decode_value(raw) -> str` (optional) — per-item display
+     transform (used by `celery_broker` to unwrap kombu envelopes).
+   - `fixed_keys: tuple[str, ...]` (optional) — well-known names
+     that aren't discoverable via SCAN (used for the static Celery
+     queue names from `BaseCeleryConfig`).
+
+2. **Register a parser** in `families.py` returning a `ParsedKey`
+   so `repoid:` / `commitid:` searches hit your family.
+
+3. **Order matters**. `find_family()` walks `FAMILIES` in order and
+   returns the first matching pattern, so put more-specific
+   prefixes (e.g. `lock_attempts:*`) before broader ones (e.g.
+   `*_lock_*`).
+
+4. **Add tests** in `tests/test_families.py` covering both the
+   parser (`parse_key`) and the SCAN-pattern pushdown
+   (`pattern_for` returning the right tightened pattern for each
+   filter shape).
+
+## Observability
+
+Every Redis-touching path opens a Sentry span:
+
+| op | Span name | Where |
+|---|---|---|
+| `redis.admin.iter_keys` | `<category>.<family>` | `families.iter_keys` (the SCAN sweep) |
+| `redis.admin.delete` | `dry_run` / `execute` | `services.redis_delete` |
+| function-name (`@sentry_sdk.trace`) | per call | item materialisation (`_list_slice`, `_materialize_set`, `_materialize_hash`, `_materialize_string`) |
+
+so a slow admin page surfaces as a discrete unit in Sentry traces
+rather than disappearing into raw `redis.cmd` spans.
+
+## Tests
+
+```
+cd apps/codecov-api
+pytest redis_admin/tests
+```
+
+The full suite uses `fakeredis` so it doesn't require a running
+Redis server.

--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -64,13 +64,20 @@ The sidebar adds standalone `family`, `min depth`, and
 Three deletion entry points, all funnel through the audited
 `services.redis_delete()` and all gated on `request.user.is_superuser`:
 
-1. **Per-queue / per-item `Delete selected`** — the standard admin
-   bulk action. `delete_queryset` is overridden to dispatch through
-   `redis_delete`, which issues `DEL` for queue rows and
-   `LREM` / `SREM` / `HDEL` for item rows.
-2. **`Dry-run: count what 'delete selected' would clear`** — sibling
-   action visible to staff users. Same code path with `dry_run=True`,
-   no mutations, but still writes a `LogEntry`.
+1. **`Clear selected (dry-run preview, then confirm)`** — the bulk
+   action that replaces Django's stock `delete_selected`. Two-stage
+   flow: stage 1 runs `redis_delete(dry_run=True)` and renders a
+   confirmation page with the dry-run's count, families, refused
+   keys, and a sample list rendered inline; stage 2 (when the form
+   re-posts with `confirm=yes`) runs `redis_delete(dry_run=False)`.
+   Operators cannot reach the destructive button without first seeing
+   the dry-run output. The stock `delete_selected` is stripped in
+   `RedisQueueAdmin.get_actions` so there's no no-dry-run path at
+   all.
+2. **`Dry-run: count what 'clear selected' would clear`** — sibling
+   action visible to staff users. Standalone dry-run with no
+   destructive button on the same page; useful for "let me see what
+   would happen" workflows. Still writes a `LogEntry`.
 3. **Clear by scope** — single endpoint at
    `/admin/redis_admin/redisqueue/clear-by-scope/`. Aggregates every
    deletable key tied to a `repoid`, `commitid`, and/or explicit

--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -59,6 +59,32 @@ rather than a full-keyspace scan.
 The sidebar adds standalone `family`, `min depth`, and
 `report_type` filters.
 
+## Permissions
+
+The "deletion is superuser-only" invariant is enforced at four
+layers, redundantly on purpose, so a misconfiguration in any one
+layer still leaves the others in place:
+
+1. `RedisQueueAdmin.has_delete_permission` returns `is_superuser`.
+   `RedisLockAdmin.has_delete_permission` returns `False` (locks are
+   blanket-disabled — even superusers can't delete them; the
+   worker's `LockManager` is the only legitimate releaser).
+   `RedisQueueItemAdmin.has_delete_permission` returns `False`
+   (item-level mutation isn't exposed; clear the whole queue
+   instead).
+2. Every bulk action (`clear_selected`, `clear_dry_run`) declares
+   `permissions=("delete",)`, so Django strips them from the action
+   dropdown for non-superusers and refuses raw POSTs.
+3. `clear_by_scope_view` raises `PermissionDenied` early if
+   `request.user.is_superuser` is false.
+4. `services.redis_delete()` is the single mutation choke point;
+   everything destructive funnels through it, including dry-runs,
+   so there's a single source of audit-log truth.
+
+Layer 1 is the "buttons aren't even rendered" guard; layers 2-3 are
+the "raw URL/POST is refused" guard; layer 4 keeps the audit log
+honest.
+
 ## Clearing subsets of Redis
 
 Three deletion entry points, all funnel through the audited
@@ -75,9 +101,14 @@ Three deletion entry points, all funnel through the audited
    `RedisQueueAdmin.get_actions` so there's no no-dry-run path at
    all.
 2. **`Dry-run: count what 'clear selected' would clear`** — sibling
-   action visible to staff users. Standalone dry-run with no
-   destructive button on the same page; useful for "let me see what
-   would happen" workflows. Still writes a `LogEntry`.
+   action that's also superuser-only (`permissions=("delete",)`).
+   Standalone dry-run with no destructive button on the same page;
+   useful for "let me see what would happen" workflows. Still writes
+   a `LogEntry`. Originally staff-allowed; tightened to superuser
+   because (a) it lives next to the destructive button, and "anything
+   adjacent to a delete button is superuser-only" is the cleaner
+   invariant, and (b) it writes audit log rows, which is the kind of
+   thing you don't want unprivileged staff users spamming.
 3. **Clear by scope** — single endpoint at
    `/admin/redis_admin/redisqueue/clear-by-scope/`. Aggregates every
    deletable key tied to a `repoid`, `commitid`, and/or explicit

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -21,16 +21,19 @@ from urllib.parse import urlencode
 
 from django.contrib import admin, messages
 from django.contrib.admin.utils import quote, unquote
-from django.http import HttpRequest
-from django.urls import NoReverseMatch, reverse
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import NoReverseMatch, path, reverse
 from django.utils.html import format_html, format_html_join
 
 from core.models import Repository
 
+from . import conn as _conn
 from . import settings as redis_admin_settings
-from .families import FAMILIES
+from .families import FAMILIES, iter_keys
 from .models import RedisLock, RedisQueue, RedisQueueItem
-from .queryset import RedisItemQuerySet
+from .queryset import RedisItemQuerySet, _build_redis_queue
 from .services import redis_delete
 
 # ---- Inline items preview (rendered on the queue change page) --------------
@@ -311,6 +314,9 @@ class RedisQueueAdmin(admin.ModelAdmin):
     # Override the change form so we can inject a tabular-inline-style
     # "Items" block below the readonly fields.
     change_form_template = "admin/redis_admin/items_inline_change_form.html"
+    # Override the changelist toolbar to surface the M6 "Clear by
+    # scope…" link next to the search box.
+    change_list_template = "admin/redis_admin/redisqueue/change_list.html"
 
     def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
@@ -368,6 +374,176 @@ class RedisQueueAdmin(admin.ModelAdmin):
         if not kwargs:
             return queryset, False
         return queryset.filter(**kwargs), False
+
+    # ---- Cross-family clear-by-scope (M6) -------------------------------
+    #
+    # `/admin/redis_admin/redisqueue/clear-by-scope/?repoid=…&commitid=…`
+    # aggregates every deletable Redis key tied to a given repo and/or
+    # commit across *all* registered queue families and clears them in a
+    # single audited operation. This is the on-call escape hatch for
+    # "rerun completely failed" — without it, an operator would have to
+    # navigate to every family's filter and run `delete_selected` for
+    # each.
+    #
+    # Safety stack:
+    #   1. Superuser-only (matches `delete_selected` gating).
+    #   2. GET = preview / form. POST = mutation. The form must specify
+    #      a `repoid` or `commitid` (or both); a fully-empty scope is
+    #      refused so an operator can't accidentally clear the entire
+    #      Redis from this UI.
+    #   3. Typed-confirmation guard: the operator must re-type the
+    #      repoid (or commitid if no repoid) into a confirmation field
+    #      to enable the destructive button. A simple "I really meant
+    #      it" gate that costs an extra second but blocks fat-fingered
+    #      double-clicks.
+    #   4. `dry_run` button always available alongside `confirm`.
+    #   5. The actual mutation funnels through the same `redis_delete`
+    #      service used by `delete_selected`, so locks (`is_deletable
+    #      =False`) are still refused even if a future family change
+    #      starts surfacing them as queues.
+
+    def get_urls(self):
+        urls = super().get_urls()
+        opts = self.model._meta
+        clear_url = path(
+            "clear-by-scope/",
+            self.admin_site.admin_view(self.clear_by_scope_view),
+            name=f"{opts.app_label}_{opts.model_name}_clear_by_scope",
+        )
+        # Insert before the catch-all `<path:object_id>/` patterns so
+        # `clear-by-scope/` doesn't get swallowed as an object_id.
+        return [clear_url, *urls]
+
+    def _resolve_scope_targets(
+        self, *, repoid: int | None, commitid: str
+    ) -> list[RedisQueue]:
+        """Materialise every deletable queue matching `(repoid, commitid)`.
+
+        Skips lock families (`is_deletable=False`) and skips families
+        whose `pattern_for` returns None (i.e. families that can't
+        possibly match the requested filters, like `celery_broker`
+        keyed by task type rather than repo).
+        """
+
+        if repoid is None and not commitid:
+            return []
+        redis = _conn.get_connection()
+        targets: list[RedisQueue] = []
+        for key, family in iter_keys(
+            redis,
+            repoid=repoid,
+            commitid_prefix=commitid or None,
+            category="queue",
+        ):
+            if not family.is_deletable:
+                continue
+            obj = _build_redis_queue(self.model, key, family, redis)
+            # `iter_keys` already pushed the filter into SCAN MATCH,
+            # but glob `*` matches `/` so re-verify the parsed values.
+            if repoid is not None and obj.repoid != repoid:
+                continue
+            if commitid and not (obj.commitid or "").startswith(commitid):
+                continue
+            targets.append(obj)
+        return targets
+
+    def clear_by_scope_view(self, request: HttpRequest) -> HttpResponse:
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-scope is restricted to superusers"
+            )
+
+        params = request.POST if request.method == "POST" else request.GET
+        repoid_raw = (params.get("repoid") or "").strip()
+        commitid = (params.get("commitid") or "").strip()
+
+        repoid: int | None = None
+        repoid_error: str | None = None
+        if repoid_raw:
+            try:
+                repoid = int(repoid_raw)
+            except ValueError:
+                repoid_error = f"repoid must be an integer; got {repoid_raw!r}"
+
+        targets: list[RedisQueue] = []
+        scope_specified = bool(repoid_raw or commitid)
+        if scope_specified and repoid_error is None:
+            targets = self._resolve_scope_targets(repoid=repoid, commitid=commitid)
+
+        opts = self.model._meta
+        changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+
+        # Typed-confirmation: re-type whichever scope value drives the
+        # action. If both are present the repoid wins because it's the
+        # narrower / more memorable identifier in our UX.
+        expected_confirm = repoid_raw or commitid
+        action = (request.POST.get("action") or "").strip()
+        typed_confirm = (request.POST.get("typed_confirm") or "").strip()
+        result = None
+        confirm_error: str | None = None
+
+        if request.method == "POST":
+            if repoid_error is not None:
+                messages.error(request, repoid_error)
+            elif not scope_specified:
+                messages.error(
+                    request,
+                    "Refusing to clear: scope must include a repoid or commitid",
+                )
+            elif action not in ("dry_run", "confirm"):
+                messages.error(request, f"Unknown action: {action!r}")
+            elif typed_confirm != expected_confirm:
+                confirm_error = f"Typed confirmation must equal {expected_confirm!r}"
+            else:
+                dry_run = action == "dry_run"
+                result = redis_delete(targets, user=request.user, dry_run=dry_run)
+                if dry_run:
+                    messages.info(
+                        request,
+                        f"Dry-run: would clear {result.count} key(s) across "
+                        f"families={list(result.families) or '[]'}",
+                    )
+                else:
+                    messages.success(
+                        request,
+                        f"Cleared {result.count} key(s) across "
+                        f"families={list(result.families) or '[]'}",
+                    )
+                    return HttpResponseRedirect(changelist_url)
+
+        sample_cap = 25
+        sample_targets = targets[:sample_cap]
+        scope_families = sorted({t.family for t in targets})
+
+        scope_label_parts = []
+        if repoid_raw:
+            scope_label_parts.append(f"repoid={repoid_raw}")
+        if commitid:
+            scope_label_parts.append(f"commitid={commitid}")
+        scope_label = " ".join(scope_label_parts) if scope_label_parts else "(none)"
+
+        ctx = {
+            **self.admin_site.each_context(request),
+            "title": "Clear Redis by scope",
+            "opts": opts,
+            "has_view_permission": self.has_view_permission(request),
+            "repoid": repoid_raw,
+            "commitid": commitid,
+            "scope_label": scope_label,
+            "scope_specified": scope_specified,
+            "repoid_error": repoid_error,
+            "confirm_error": confirm_error,
+            "expected_confirm": expected_confirm,
+            "typed_confirm": typed_confirm,
+            "targets": targets,
+            "target_count": len(targets),
+            "sample_targets": sample_targets,
+            "sample_cap": sample_cap,
+            "scope_families": scope_families,
+            "changelist_url": changelist_url,
+            "result": result,
+        }
+        return render(request, "admin/redis_admin/clear_by_scope.html", ctx)
 
     # ---- Delete actions (M5.2) -----------------------------------------
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -17,6 +17,7 @@ prefix-style tokens in addition to plain substrings:
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from urllib.parse import urlencode
 
 from django.contrib import admin, messages
@@ -377,22 +378,27 @@ class RedisQueueAdmin(admin.ModelAdmin):
 
     # ---- Cross-family clear-by-scope (M6) -------------------------------
     #
-    # `/admin/redis_admin/redisqueue/clear-by-scope/?repoid=…&commitid=…`
-    # aggregates every deletable Redis key tied to a given repo and/or
-    # commit across *all* registered queue families and clears them in a
-    # single audited operation. This is the on-call escape hatch for
-    # "rerun completely failed" — without it, an operator would have to
-    # navigate to every family's filter and run `delete_selected` for
-    # each.
+    # `/admin/redis_admin/redisqueue/clear-by-scope/?repoid=…&commitid=…
+    # &family=uploads&family=latest_upload`
+    # aggregates every deletable Redis key tied to a given repo, commit,
+    # and/or specific family list and clears them in a single audited
+    # operation. This is the on-call escape hatch for "rerun completely
+    # failed" — without it, an operator would have to navigate to every
+    # family's filter and run `delete_selected` for each.
+    #
+    # Scope is the cross-product of three optional dimensions:
+    #   - `repoid` (numeric)
+    #   - `commitid` (full SHA or any prefix)
+    #   - `family` (zero or more deletable family names; empty = all)
+    # At least one of repoid / commitid / explicit family list must be
+    # set. The empty form is refused.
     #
     # Safety stack:
     #   1. Superuser-only (matches `delete_selected` gating).
-    #   2. GET = preview / form. POST = mutation. The form must specify
-    #      a `repoid` or `commitid` (or both); a fully-empty scope is
-    #      refused so an operator can't accidentally clear the entire
-    #      Redis from this UI.
+    #   2. GET = preview / form. POST = mutation. Empty scope refused.
     #   3. Typed-confirmation guard: the operator must re-type the
-    #      repoid (or commitid if no repoid) into a confirmation field
+    #      "primary" scope value (repoid > commitid > joined family
+    #      names, in that preference order) into a confirmation field
     #      to enable the destructive button. A simple "I really meant
     #      it" gate that costs an extra second but blocks fat-fingered
     #      double-clicks.
@@ -414,37 +420,65 @@ class RedisQueueAdmin(admin.ModelAdmin):
         # `clear-by-scope/` doesn't get swallowed as an object_id.
         return [clear_url, *urls]
 
-    def _resolve_scope_targets(
-        self, *, repoid: int | None, commitid: str
-    ) -> list[RedisQueue]:
-        """Materialise every deletable queue matching `(repoid, commitid)`.
+    @staticmethod
+    def _deletable_family_names() -> list[str]:
+        """Names of every queue-category family that's safe to delete.
 
-        Skips lock families (`is_deletable=False`) and skips families
-        whose `pattern_for` returns None (i.e. families that can't
-        possibly match the requested filters, like `celery_broker`
-        keyed by task type rather than repo).
+        Used by the form to render the family checkbox list and by the
+        view to validate operator-supplied family names.
         """
 
-        if repoid is None and not commitid:
-            return []
+        return sorted(
+            f.name for f in FAMILIES if f.category == "queue" and f.is_deletable
+        )
+
+    def _resolve_scope_targets(
+        self,
+        *,
+        repoid: int | None,
+        commitid: str,
+        families: Sequence[str] | None,
+    ) -> list[RedisQueue]:
+        """Materialise every deletable queue matching the active scope.
+
+        Iterates per-requested-family when `families` is non-empty so
+        the SCAN MATCH pattern is family-specific (e.g. `uploads/42/*`
+        instead of a wildcard sweep). When `families` is None or
+        empty, sweeps all deletable families. Skips lock families
+        (`is_deletable=False`) regardless of how a key was surfaced.
+        """
+
         redis = _conn.get_connection()
+        family_iter: Iterable[str | None]
+        if families:
+            family_iter = list(families)
+        else:
+            family_iter = [None]
+
         targets: list[RedisQueue] = []
-        for key, family in iter_keys(
-            redis,
-            repoid=repoid,
-            commitid_prefix=commitid or None,
-            category="queue",
-        ):
-            if not family.is_deletable:
-                continue
-            obj = _build_redis_queue(self.model, key, family, redis)
-            # `iter_keys` already pushed the filter into SCAN MATCH,
-            # but glob `*` matches `/` so re-verify the parsed values.
-            if repoid is not None and obj.repoid != repoid:
-                continue
-            if commitid and not (obj.commitid or "").startswith(commitid):
-                continue
-            targets.append(obj)
+        seen: set[str] = set()
+        for family_name in family_iter:
+            for key, family in iter_keys(
+                redis,
+                family=family_name,
+                repoid=repoid,
+                commitid_prefix=commitid or None,
+                category="queue",
+            ):
+                if not family.is_deletable:
+                    continue
+                if key in seen:
+                    continue
+                obj = _build_redis_queue(self.model, key, family, redis)
+                # `iter_keys` already pushed the filter into SCAN MATCH,
+                # but glob `*` matches `/` so re-verify the parsed
+                # values.
+                if repoid is not None and obj.repoid != repoid:
+                    continue
+                if commitid and not (obj.commitid or "").startswith(commitid):
+                    continue
+                seen.add(key)
+                targets.append(obj)
         return targets
 
     def clear_by_scope_view(self, request: HttpRequest) -> HttpResponse:
@@ -456,6 +490,29 @@ class RedisQueueAdmin(admin.ModelAdmin):
         params = request.POST if request.method == "POST" else request.GET
         repoid_raw = (params.get("repoid") or "").strip()
         commitid = (params.get("commitid") or "").strip()
+        # Multi-select: each checked family round-trips as one `family`
+        # form value. `getlist` falls back to a query-string-friendly
+        # comma-separated `family=a,b,c` as well so the URL can be
+        # bookmarked.
+        family_values = list(params.getlist("family"))
+        if not family_values:
+            csv = (params.get("family") or "").strip()
+            if csv:
+                family_values = [csv]
+        families: list[str] = []
+        for fv in family_values:
+            for piece in fv.split(","):
+                piece = piece.strip()
+                if piece and piece not in families:
+                    families.append(piece)
+
+        deletable_families = self._deletable_family_names()
+        invalid_families = [f for f in families if f not in deletable_families]
+        family_error: str | None = None
+        if invalid_families:
+            family_error = "unknown or non-deletable family: " + ", ".join(
+                invalid_families
+            )
 
         repoid: int | None = None
         repoid_error: str | None = None
@@ -466,17 +523,29 @@ class RedisQueueAdmin(admin.ModelAdmin):
                 repoid_error = f"repoid must be an integer; got {repoid_raw!r}"
 
         targets: list[RedisQueue] = []
-        scope_specified = bool(repoid_raw or commitid)
-        if scope_specified and repoid_error is None:
-            targets = self._resolve_scope_targets(repoid=repoid, commitid=commitid)
+        scope_specified = bool(repoid_raw or commitid or families)
+        if scope_specified and repoid_error is None and family_error is None:
+            targets = self._resolve_scope_targets(
+                repoid=repoid,
+                commitid=commitid,
+                families=families,
+            )
 
         opts = self.model._meta
         changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
 
         # Typed-confirmation: re-type whichever scope value drives the
-        # action. If both are present the repoid wins because it's the
-        # narrower / more memorable identifier in our UX.
-        expected_confirm = repoid_raw or commitid
+        # action. Preference order is repoid > commitid > joined family
+        # names because the more "operational" the identifier, the
+        # easier it is to remember (a repoid is a number you just
+        # typed; a list of family names is harder to fat-finger but
+        # more memorable than a 40-char SHA).
+        if repoid_raw:
+            expected_confirm = repoid_raw
+        elif commitid:
+            expected_confirm = commitid
+        else:
+            expected_confirm = ",".join(sorted(families))
         action = (request.POST.get("action") or "").strip()
         typed_confirm = (request.POST.get("typed_confirm") or "").strip()
         result = None
@@ -485,10 +554,13 @@ class RedisQueueAdmin(admin.ModelAdmin):
         if request.method == "POST":
             if repoid_error is not None:
                 messages.error(request, repoid_error)
+            elif family_error is not None:
+                messages.error(request, family_error)
             elif not scope_specified:
                 messages.error(
                     request,
-                    "Refusing to clear: scope must include a repoid or commitid",
+                    "Refusing to clear: scope must include a repoid, "
+                    "commitid, or at least one family",
                 )
             elif action not in ("dry_run", "confirm"):
                 messages.error(request, f"Unknown action: {action!r}")
@@ -520,7 +592,13 @@ class RedisQueueAdmin(admin.ModelAdmin):
             scope_label_parts.append(f"repoid={repoid_raw}")
         if commitid:
             scope_label_parts.append(f"commitid={commitid}")
+        if families:
+            scope_label_parts.append(f"family={','.join(sorted(families))}")
         scope_label = " ".join(scope_label_parts) if scope_label_parts else "(none)"
+
+        family_choices = [
+            {"name": name, "checked": name in families} for name in deletable_families
+        ]
 
         ctx = {
             **self.admin_site.each_context(request),
@@ -529,9 +607,12 @@ class RedisQueueAdmin(admin.ModelAdmin):
             "has_view_permission": self.has_view_permission(request),
             "repoid": repoid_raw,
             "commitid": commitid,
+            "selected_families": families,
+            "family_choices": family_choices,
             "scope_label": scope_label,
             "scope_specified": scope_specified,
             "repoid_error": repoid_error,
+            "family_error": family_error,
             "confirm_error": confirm_error,
             "expected_confirm": expected_confirm,
             "typed_confirm": typed_confirm,

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -653,7 +653,12 @@ class RedisQueueAdmin(admin.ModelAdmin):
 
     @admin.action(
         description="Dry-run: count what 'clear selected' would clear",
-        permissions=("change",),
+        # Staff with read-only access don't need a button that writes
+        # `LogEntry` rows; the dry-run action is a sibling of the
+        # destructive bulk-clear, and "anything next to a delete
+        # button is superuser-only" is the simpler invariant to
+        # reason about. Locks down the audit-log surface area too.
+        permissions=("delete",),
     )
     def clear_dry_run(self, request: HttpRequest, queryset) -> None:
         result = redis_delete(list(queryset), user=request.user, dry_run=True)
@@ -863,7 +868,11 @@ class RedisLockAdmin(admin.ModelAdmin):
         return bool(request.user and request.user.is_staff)
 
     # Locks are never deletable from the admin, regardless of role; the
-    # worker's `LockManager` is the only legitimate releaser.
+    # worker's `LockManager` is the only legitimate releaser. This is
+    # stricter than the per-admin "superuser-only deletion" invariant
+    # — locks aren't even superuser-deletable. `services.redis_delete`
+    # additionally refuses any key whose family has `is_deletable=
+    # False` so URL-tampering can't bypass this.
     def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
 
@@ -975,6 +984,13 @@ class RedisQueueItemAdmin(admin.ModelAdmin):
     def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
 
+    # Item-level mutations are not exposed in the admin: per-item
+    # `LREM` / `SREM` / `HDEL` would require reconstructing the
+    # original Redis value from the admin pk_token (and SETs/LISTs
+    # don't round-trip cleanly through SSCAN cursors), so operators
+    # who need to drop a bad message clear the entire queue from
+    # `RedisQueueAdmin`. If we ever lift this, the new gate must be
+    # `is_superuser` to match every other deletion path in this app.
     def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
         return False
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -626,12 +626,33 @@ class RedisQueueAdmin(admin.ModelAdmin):
         }
         return render(request, "admin/redis_admin/clear_by_scope.html", ctx)
 
-    # ---- Delete actions (M5.2) -----------------------------------------
+    # ---- Delete actions (M5.2 + dry-run-mandatory bulk) -----------------
+    #
+    # The standard `delete_selected` is replaced with `clear_selected`,
+    # a 2-stage action that always runs a dry-run *before* offering the
+    # destructive button. Django's stock flow is "select → confirm →
+    # delete"; ours is "select → dry-run preview → confirm → delete".
+    # The dry-run output (count, families, refused, sample) is rendered
+    # inline on the confirmation page so the operator can sanity-check
+    # the impact of the action before committing.
+    #
+    # `clear_dry_run` is kept as a separate action for the
+    # "let me see what would happen if I cleared X, with no risk of
+    # accidentally hitting the wrong button" workflow — it has no
+    # destructive sibling on the same page, just `message_user`.
 
-    actions = ("clear_dry_run",)
+    actions = ("clear_dry_run", "clear_selected")
+
+    def get_actions(self, request):
+        # Strip Django's stock `delete_selected` so the only path that
+        # actually mutates Redis from a bulk action goes through our
+        # dry-run-mandatory `clear_selected`.
+        actions = super().get_actions(request)
+        actions.pop("delete_selected", None)
+        return actions
 
     @admin.action(
-        description="Dry-run: count what 'delete selected' would clear",
+        description="Dry-run: count what 'clear selected' would clear",
         permissions=("change",),
     )
     def clear_dry_run(self, request: HttpRequest, queryset) -> None:
@@ -647,8 +668,75 @@ class RedisQueueAdmin(admin.ModelAdmin):
             level=messages.INFO,
         )
 
+    @admin.action(
+        description="Clear selected (dry-run preview, then confirm)",
+        permissions=("delete",),
+    )
+    def clear_selected(self, request: HttpRequest, queryset):
+        """Two-stage clear: shows dry-run results, then waits for confirm.
+
+        Stage 1 (no `confirm` flag): runs `redis_delete(dry_run=True)`
+        and renders a confirmation page that displays the dry-run's
+        count + families + refused + sample inline. The page's form
+        re-posts the same action with `confirm=yes`.
+
+        Stage 2 (`confirm=yes`): runs `redis_delete(dry_run=False)`,
+        the actual mutation. Returning `None` falls through to the
+        standard action redirect back to the changelist.
+        """
+
+        selected = list(queryset)
+        # Pull the original `_selected_action` checkbox values so we can
+        # round-trip them as hidden inputs on the confirmation form;
+        # Django's action helper re-fetches the queryset from these on
+        # the second POST.
+        selected_pks = request.POST.getlist("_selected_action") or [
+            obj.pk for obj in selected
+        ]
+
+        if request.POST.get("confirm") == "yes":
+            result = redis_delete(selected, user=request.user, dry_run=False)
+            self.message_user(
+                request,
+                (
+                    f"Cleared {result.count} Redis key(s) across "
+                    f"families={list(result.families) or '[]'}"
+                    + (
+                        f"; refused={list(result.refused[:5])}"
+                        if result.refused
+                        else ""
+                    )
+                ),
+                level=messages.SUCCESS,
+            )
+            # Falls through to Django's "redirect back to changelist"
+            # behaviour for actions that return None.
+            return None
+
+        dry_run_result = redis_delete(selected, user=request.user, dry_run=True)
+
+        opts = self.model._meta
+        ctx = {
+            **self.admin_site.each_context(request),
+            "title": "Confirm clear of selected Redis keys",
+            "opts": opts,
+            "action_name": "clear_selected",
+            "selected": selected,
+            "selected_pks": selected_pks,
+            "dry_run_result": dry_run_result,
+            "media": self.media,
+        }
+        return render(
+            request, "admin/redis_admin/clear_selected_confirmation.html", ctx
+        )
+
     def delete_queryset(self, request: HttpRequest, queryset) -> None:
-        """Bulk 'Delete selected' on the queues changelist."""
+        """Defensive: stock `delete_selected` is stripped in `get_actions`,
+        but if a future code path reintroduces it, route through the
+        same audited service rather than letting the ORM fall through
+        on an unmanaged model.
+        """
+
         result = redis_delete(list(queryset), user=request.user, dry_run=False)
         self.message_user(
             request,
@@ -661,7 +749,14 @@ class RedisQueueAdmin(admin.ModelAdmin):
         )
 
     def delete_model(self, request: HttpRequest, obj: RedisQueue) -> None:
-        """Single-object delete from the change page."""
+        """Single-object delete from the change page.
+
+        The change page already runs through Django's standard
+        `delete_view` confirmation interstitial, which displays the
+        full key path before the operator commits, so we don't add a
+        second dry-run gate here.
+        """
+
         result = redis_delete([obj], user=request.user, dry_run=False)
         self.message_user(
             request,

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -23,6 +23,8 @@ from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+import sentry_sdk
+
 from . import conn as _conn
 from . import settings as redis_admin_settings
 
@@ -689,13 +691,49 @@ def iter_keys(
     """
 
     redis = redis if redis is not None else _conn.get_connection()
-    seen = 0
     cap = redis_admin_settings.MAX_SCAN_KEYS
     count = redis_admin_settings.SCAN_COUNT
     filters: dict[str, Any] = {
         "repoid": repoid,
         "commitid_prefix": commitid_prefix,
     }
+    # Wrap the entire SCAN sweep in a span so an admin page that backs
+    # itself onto a slow Redis surfaces as a discrete unit in Sentry.
+    span_name = f"{category or 'all'}.{family or '*'}"
+    with sentry_sdk.start_span(op="redis.admin.iter_keys", name=span_name) as span:
+        try:
+            span.set_tag("redis_admin.category", category or "all")
+            span.set_tag("redis_admin.family", family or "*")
+            if repoid is not None:
+                span.set_tag("redis_admin.repoid", repoid)
+            if commitid_prefix:
+                span.set_tag("redis_admin.commitid_prefix", commitid_prefix)
+        except AttributeError:  # pragma: no cover - older sentry sdks
+            pass
+        yield from _iter_keys_inner(
+            redis,
+            family=family,
+            category=category,
+            cap=cap,
+            count=count,
+            filters=filters,
+        )
+
+
+def _iter_keys_inner(
+    redis,
+    *,
+    family: str | None,
+    category: Literal["queue", "lock"] | None,
+    cap: int,
+    count: int,
+    filters: Mapping[str, Any],
+) -> Iterator[tuple[str, Family]]:
+    """Body of `iter_keys`, factored out so the wrapping span lives in a
+    plain function and the inner generator can `yield` freely without
+    nested context-manager bookkeeping."""
+
+    seen = 0
     # Track yielded keys so an overlapping pattern (e.g.
     # `lock_attempts:upload_lock_…` is matched by both `lock_attempts:*`
     # and the broader `*_lock_*`) doesn't double-count.

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Any
 
+import sentry_sdk
+
 from . import conn as _conn
 from . import settings as redis_admin_settings
 from .families import Family, find_family, iter_keys
@@ -623,6 +625,7 @@ class RedisItemQuerySet:
             for offset, value in enumerate(raw_values)
         ]
 
+    @sentry_sdk.trace
     def _list_slice(self, redis, start: int, stop: int) -> list:
         if stop <= start:
             return []
@@ -640,6 +643,7 @@ class RedisItemQuerySet:
     # provide on their own. Snapshots are cached per-queryset so repeated
     # `count()` / `__getitem__` calls don't re-stream Redis.
 
+    @sentry_sdk.trace
     def _materialize_set(self, redis) -> list:
         if self._snapshot is not None:
             return self._snapshot
@@ -663,6 +667,7 @@ class RedisItemQuerySet:
         ]
         return self._snapshot
 
+    @sentry_sdk.trace
     def _materialize_hash(self, redis) -> list:
         if self._snapshot is not None:
             return self._snapshot
@@ -686,6 +691,7 @@ class RedisItemQuerySet:
         ]
         return self._snapshot
 
+    @sentry_sdk.trace
     def _materialize_string(self, redis) -> list:
         if self._snapshot is not None:
             return self._snapshot

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -26,6 +26,7 @@ import logging
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 
+import sentry_sdk
 from django.contrib.admin.models import DELETION, LogEntry
 from django.contrib.contenttypes.models import ContentType
 
@@ -262,6 +263,22 @@ def redis_delete(
     mutations.
     """
 
+    span_name = "dry_run" if dry_run else "execute"
+    with sentry_sdk.start_span(op="redis.admin.delete", name=span_name) as span:
+        try:
+            span.set_tag("redis_admin.dry_run", dry_run)
+        except AttributeError:  # pragma: no cover - older sdks
+            pass
+        return _redis_delete(targets, user=user, dry_run=dry_run, span=span)
+
+
+def _redis_delete(
+    targets: Iterable[RedisQueue | RedisQueueItem],
+    *,
+    user,
+    dry_run: bool,
+    span,
+) -> DeleteResult:
     queue_targets: list[RedisQueue] = []
     item_targets: list[RedisQueueItem] = []
     for target in targets:
@@ -325,4 +342,10 @@ def redis_delete(
         families=families,
         dry_run=dry_run,
     )
+    try:
+        span.set_data("redis_admin.count", result.count)
+        span.set_data("redis_admin.refused_count", len(refused))
+        span.set_data("redis_admin.families", list(families))
+    except AttributeError:  # pragma: no cover - older sdks
+        pass
     return result

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/clear_by_scope.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/clear_by_scope.html
@@ -17,8 +17,10 @@
 
   <p>
     Aggregates every <strong>deletable</strong> Redis key tied to the
-    given repo and/or commit across all queue families and clears them
-    in a single audited operation. Lock families are always refused.
+    given repo, commit, and/or family list across all queue families
+    and clears them in a single audited operation. Lock families are
+    always refused, and at least one of <em>repoid</em>,
+    <em>commitid</em>, or <em>family</em> must be set.
   </p>
   <p>
     Run a <strong>dry-run</strong> first to see what would be cleared.
@@ -37,7 +39,7 @@
           {% if repoid_error %}<ul class="errorlist"><li>{{ repoid_error }}</li></ul>{% endif %}
           <label for="id_repoid">Repository ID:</label>
           <input type="text" name="repoid" id="id_repoid" value="{{ repoid }}" placeholder="e.g. 1234">
-          <div class="help">Numeric repoid. Leave blank to scope by commitid only.</div>
+          <div class="help">Numeric repoid. Leave blank to skip the repo filter.</div>
         </div>
       </div>
 
@@ -45,7 +47,26 @@
         <div>
           <label for="id_commitid">Commit SHA (prefix OK):</label>
           <input type="text" name="commitid" id="id_commitid" value="{{ commitid }}" placeholder="e.g. abc123">
-          <div class="help">Commit SHA, or any prefix. Leave blank to scope by repoid only.</div>
+          <div class="help">Commit SHA, or any prefix. Leave blank to skip the commit filter.</div>
+        </div>
+      </div>
+
+      <div class="form-row{% if family_error %} errors{% endif %}">
+        <div>
+          {% if family_error %}<ul class="errorlist"><li>{{ family_error }}</li></ul>{% endif %}
+          <label>Families:</label>
+          <div style="display:flex;flex-wrap:wrap;gap:0.75em 1.5em;max-width:60em;">
+            {% for choice in family_choices %}
+              <label style="font-weight:normal;">
+                <input type="checkbox" name="family" value="{{ choice.name }}"{% if choice.checked %} checked{% endif %}>
+                <code>{{ choice.name }}</code>
+              </label>
+            {% endfor %}
+          </div>
+          <div class="help">
+            Check zero or more deletable families. Leave all unchecked
+            to sweep every deletable family at once.
+          </div>
         </div>
       </div>
 
@@ -54,7 +75,7 @@
       </div>
     </fieldset>
 
-    {% if scope_specified and not repoid_error %}
+    {% if scope_specified and not repoid_error and not family_error %}
     <fieldset class="module">
       <h2>Matched: {{ target_count }} key(s) for {{ scope_label }}</h2>
 

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/clear_by_scope.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/clear_by_scope.html
@@ -1,0 +1,125 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{{ changelist_url }}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; Clear by scope
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+  <p>
+    Aggregates every <strong>deletable</strong> Redis key tied to the
+    given repo and/or commit across all queue families and clears them
+    in a single audited operation. Lock families are always refused.
+  </p>
+  <p>
+    Run a <strong>dry-run</strong> first to see what would be cleared.
+    Both dry-run and confirm runs are written to the
+    <code>django.contrib.admin.LogEntry</code> audit log.
+  </p>
+
+  <form method="post" novalidate>
+    {% csrf_token %}
+
+    <fieldset class="module aligned">
+      <h2>Scope</h2>
+
+      <div class="form-row{% if repoid_error %} errors{% endif %}">
+        <div>
+          {% if repoid_error %}<ul class="errorlist"><li>{{ repoid_error }}</li></ul>{% endif %}
+          <label for="id_repoid">Repository ID:</label>
+          <input type="text" name="repoid" id="id_repoid" value="{{ repoid }}" placeholder="e.g. 1234">
+          <div class="help">Numeric repoid. Leave blank to scope by commitid only.</div>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div>
+          <label for="id_commitid">Commit SHA (prefix OK):</label>
+          <input type="text" name="commitid" id="id_commitid" value="{{ commitid }}" placeholder="e.g. abc123">
+          <div class="help">Commit SHA, or any prefix. Leave blank to scope by repoid only.</div>
+        </div>
+      </div>
+
+      <div class="submit-row">
+        <input type="submit" name="_preview" value="Preview matching keys" formmethod="get" class="default">
+      </div>
+    </fieldset>
+
+    {% if scope_specified and not repoid_error %}
+    <fieldset class="module">
+      <h2>Matched: {{ target_count }} key(s) for {{ scope_label }}</h2>
+
+      {% if target_count == 0 %}
+        <p><em>No deletable keys matched this scope.</em></p>
+      {% else %}
+        <p>
+          Families involved:
+          {% for f in scope_families %}<code>{{ f }}</code>{% if not forloop.last %}, {% endif %}{% endfor %}
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Family</th>
+              <th>Type</th>
+              <th>Depth</th>
+              <th>repoid</th>
+              <th>commit</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for t in sample_targets %}
+            <tr>
+              <td><code>{{ t.name }}</code></td>
+              <td>{{ t.family }}</td>
+              <td>{{ t.redis_type }}</td>
+              <td>{{ t.depth }}</td>
+              <td>{{ t.repoid|default_if_none:"—" }}</td>
+              <td>{% if t.commitid %}<code>{{ t.commitid|slice:":7" }}</code>{% else %}—{% endif %}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% if target_count > sample_cap %}
+          <p><em>Showing first {{ sample_cap }} of {{ target_count }} matching keys.</em></p>
+        {% endif %}
+
+        <h3>Confirm and clear</h3>
+        <div class="form-row{% if confirm_error %} errors{% endif %}">
+          <div>
+            {% if confirm_error %}<ul class="errorlist"><li>{{ confirm_error }}</li></ul>{% endif %}
+            <label for="id_typed_confirm">Type <code>{{ expected_confirm }}</code> to confirm:</label>
+            <input type="text" name="typed_confirm" id="id_typed_confirm" value="{{ typed_confirm }}" autocomplete="off">
+            <div class="help">Re-type the scope value above to enable the destructive button.</div>
+          </div>
+        </div>
+
+        <div class="submit-row">
+          <button type="submit" name="action" value="dry_run" class="default">
+            Dry-run (audit only, no mutations)
+          </button>
+          <button type="submit" name="action" value="confirm" class="deletelink" style="margin-left:1em;">
+            Clear {{ target_count }} key(s) from Redis
+          </button>
+        </div>
+      {% endif %}
+    </fieldset>
+    {% endif %}
+
+    <p>
+      <a href="{{ changelist_url }}">&larr; back to {{ opts.verbose_name_plural }}</a>
+    </p>
+  </form>
+
+</div>
+{% endblock %}

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/clear_selected_confirmation.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/clear_selected_confirmation.html
@@ -1,0 +1,94 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+  <p>
+    Confirm clearing the {{ selected|length }} selected Redis key(s).
+    The numbers below come from a real <strong>dry-run</strong>
+    against Redis &mdash; nothing has been deleted yet, but a dry-run
+    audit entry has already been recorded in
+    <code>django.contrib.admin.LogEntry</code>.
+  </p>
+
+  <fieldset class="module">
+    <h2>Dry-run summary</h2>
+    <ul style="list-style:disc;margin-left:1.5em;">
+      <li>
+        Would delete:
+        <strong>{{ dry_run_result.count }}</strong> key(s) /
+        item-level operation(s).
+      </li>
+      <li>
+        Families affected:
+        {% if dry_run_result.families %}
+          {% for f in dry_run_result.families %}
+            <code>{{ f }}</code>{% if not forloop.last %}, {% endif %}
+          {% endfor %}
+        {% else %}
+          <em>none</em>
+        {% endif %}
+      </li>
+      {% if dry_run_result.refused %}
+      <li>
+        Refused (locks / non-deletable families):
+        <strong>{{ dry_run_result.refused|length }}</strong>
+        &mdash; first few:
+        {% for r in dry_run_result.refused|slice:":5" %}
+          <code>{{ r }}</code>{% if not forloop.last %}, {% endif %}
+        {% endfor %}
+      </li>
+      {% endif %}
+    </ul>
+  </fieldset>
+
+  {% if dry_run_result.sample %}
+  <fieldset class="module">
+    <h2>Sample of keys that will be cleared (first {{ dry_run_result.sample|length }})</h2>
+    <ul style="list-style:disc;margin-left:1.5em;">
+      {% for s in dry_run_result.sample %}
+        <li><code>{{ s }}</code></li>
+      {% endfor %}
+    </ul>
+  </fieldset>
+  {% endif %}
+
+  <form method="post">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="{{ action_name }}">
+    <input type="hidden" name="confirm" value="yes">
+    {# Round-trip the original selection so Django's action helper
+       refetches the same queryset on the second POST. #}
+    {% for pk in selected_pks %}
+      <input type="hidden" name="_selected_action" value="{{ pk }}">
+    {% endfor %}
+
+    <div class="submit-row">
+      {% if dry_run_result.count == 0 %}
+        <p><em>Nothing to clear (dry-run found 0 deletable keys).</em></p>
+        <a href="{% url opts|admin_urlname:'changelist' %}" class="button cancel-link">
+          {% translate "Back to changelist" %}
+        </a>
+      {% else %}
+        <input type="submit" value="Yes, clear {{ dry_run_result.count }} key(s)" class="deletelink">
+        <a href="{% url opts|admin_urlname:'changelist' %}" class="button cancel-link" style="margin-left:1em;">
+          {% translate "No, take me back" %}
+        </a>
+      {% endif %}
+    </div>
+  </form>
+
+</div>
+{% endblock %}

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/redisqueue/change_list.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/redisqueue/change_list.html
@@ -1,0 +1,18 @@
+{% extends "admin/change_list.html" %}
+{% load admin_urls %}
+
+{# Surface the M6 "Clear by scope…" link in the changelist's toolbar
+   ("object-tools"). Only superusers see the link because the
+   underlying view (and `redis_delete` service) refuses non-superusers
+   anyway, so showing the link to a staff user would just lead to a
+   PermissionDenied. #}
+{% block object-tools-items %}
+  {{ block.super }}
+  {% if request.user.is_superuser %}
+    <li>
+      <a href="{% url cl.opts|admin_urlname:'clear_by_scope' %}" class="addlink">
+        Clear by scope&hellip;
+      </a>
+    </li>
+  {% endif %}
+{% endblock %}

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -485,11 +485,14 @@ class RedisQueueAdminDeleteActionsTest(TestCase):
 
         assert response.status_code == 200
         body = response.content.decode("utf-8")
-        # Non-superusers can dry-run but never see the destructive action.
+        # Non-superusers see neither destructive nor dry-run actions.
+        # `clear_dry_run` was originally staff-allowed, but we tightened
+        # it to `permissions=("delete",)` so the rule is uniformly
+        # "anything that touches deletion is superuser-only" — including
+        # dry-runs that record audit-log rows.
         assert "Clear selected" not in body
-        # Stock Django delete is stripped out for everyone.
         assert "Delete selected" not in body
-        assert "Dry-run" in body
+        assert "Dry-run" not in body
 
     def test_stock_delete_selected_action_is_unavailable(self):
         # `delete_selected` was Django's stock no-dry-run path; we
@@ -999,3 +1002,209 @@ class RedisAdminClearByScopeTest(TestCase):
         # Locks must not appear in the family checkbox list.
         assert 'value="upload_finisher_gate"' not in body
         assert 'value="coordination_lock"' not in body
+
+
+class RedisAdminSuperuserOnlyDeletionTest(TestCase):
+    """Pin down the "deletion is superuser-only" invariant across every
+    redis_admin model.
+
+    The rule, restated for the reader of these tests:
+      - `RedisQueueAdmin`        deletion gated to `is_superuser`
+      - `RedisLockAdmin`         deletion disabled for everyone
+      - `RedisQueueItemAdmin`    deletion disabled for everyone
+
+    These tests stay tight on URL/action endpoints because that's what
+    a misconfigured permission flip would actually expose. They cover
+    both the "button hidden" UX and the "raw POST rejected" backend
+    enforcement, so a regression that only fixes one half (e.g. hiding
+    the button while leaving the URL open) still fails the suite.
+    """
+
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        self.client = Client()
+
+        self.redis.rpush("uploads/1/aaa", "p1")
+        self.redis.rpush("uploads/1/bbb", "p2")
+        self.redis.set("upload_finisher_gate_1_aaa", "1")
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    # ---- RedisQueueAdmin -----------------------------------------------
+
+    def test_staff_changelist_hides_every_destructive_action(self):
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Every destructive action is hidden from the staff dropdown.
+        assert 'value="clear_selected"' not in body
+        assert 'value="clear_dry_run"' not in body
+        # And the stock Django bulk delete is stripped for everyone.
+        assert 'value="delete_selected"' not in body
+        # The cross-family clear-by-scope link is also superuser-only.
+        assert "Clear by scope" not in body
+
+    def test_staff_clear_selected_post_is_refused(self):
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+
+        response = self.client.post(
+            "/admin/redis_admin/redisqueue/",
+            {
+                "action": "clear_selected",
+                "_selected_action": ["uploads/1/aaa"],
+            },
+            follow=True,
+        )
+
+        # Django's action permission gate either refuses with a
+        # message or redirects to the changelist; either way the key
+        # must remain in Redis.
+        assert response.status_code == 200
+        assert self.redis.exists("uploads/1/aaa") == 1
+
+    def test_staff_clear_dry_run_post_is_refused(self):
+        # The dry-run action was previously `permissions=("change",)`
+        # and reachable by staff users. We tightened it to
+        # `permissions=("delete",)` so it lives behind the same
+        # superuser gate as its destructive sibling.
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+        prior_logs = LogEntry.objects.count()
+
+        self.client.post(
+            "/admin/redis_admin/redisqueue/",
+            {
+                "action": "clear_dry_run",
+                "_selected_action": ["uploads/1/aaa"],
+            },
+            follow=True,
+        )
+
+        # No mutation in Redis (this is a dry-run) but more
+        # importantly: no LogEntry written, because the action was
+        # refused before reaching `redis_delete`.
+        assert self.redis.exists("uploads/1/aaa") == 1
+        assert LogEntry.objects.count() == prior_logs
+
+    def test_staff_change_page_hides_delete_button(self):
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueue/uploads_2F1_2Faaa/change/"
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # No "Delete" link/button appears anywhere on the page.
+        assert "Delete</a>" not in body
+        assert ">Delete</button>" not in body
+
+    def test_staff_clear_by_scope_get_is_403(self):
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueue/clear-by-scope/?repoid=1"
+        )
+
+        assert response.status_code == 403
+
+    def test_staff_clear_by_scope_post_is_403(self):
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+
+        response = self.client.post(
+            "/admin/redis_admin/redisqueue/clear-by-scope/",
+            {
+                "repoid": "1",
+                "commitid": "",
+                "typed_confirm": "1",
+                "action": "confirm",
+            },
+        )
+
+        assert response.status_code == 403
+        assert self.redis.exists("uploads/1/aaa") == 1
+        assert self.redis.exists("uploads/1/bbb") == 1
+
+    # ---- RedisLockAdmin ------------------------------------------------
+
+    def test_locks_are_undeletable_even_by_superusers(self):
+        # Locks are blanket-disabled, not just superuser-gated. This
+        # is a stricter rule than "deletion is superuser-only" and
+        # exists because the worker's `LockManager` is the only
+        # legitimate releaser of those keys.
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+
+        response = self.client.get("/admin/redis_admin/redislock/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # No bulk action dropdown options at all (`actions={}` for
+        # locks). Most importantly: no `delete_selected`.
+        assert 'value="delete_selected"' not in body
+        # And there's no clear_* siblings either.
+        assert 'value="clear_selected"' not in body
+        assert 'value="clear_dry_run"' not in body
+
+    def test_staff_cannot_post_delete_to_lock_change_page(self):
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+
+        # Even if staff somehow handcraft a delete POST to the lock
+        # change-form URL, it must be refused.
+        response = self.client.post(
+            "/admin/redis_admin/redislock/upload_finisher_gate_5F1_5Faaa/delete/",
+            {"post": "yes"},
+        )
+
+        # Django returns 403 for has_delete_permission=False. The lock
+        # must still be in Redis.
+        assert response.status_code in (302, 403, 404)
+        assert self.redis.exists("upload_finisher_gate_1_aaa") == 1
+
+    # ---- RedisQueueItemAdmin -------------------------------------------
+
+    def test_items_changelist_has_no_bulk_actions(self):
+        # `actions = ()` strips every bulk action — including
+        # delete-flavoured ones — for everyone.
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueueitem/?queue_name__exact=uploads/1/aaa"
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert 'value="delete_selected"' not in body
+        assert 'value="clear_selected"' not in body
+        assert 'value="clear_dry_run"' not in body
+
+    def test_superuser_cannot_delete_individual_item(self):
+        # `has_delete_permission` returns `False` regardless of role,
+        # so even a superuser can't delete items from this admin.
+        # This is a deliberate design choice (see admin.py docstring);
+        # if the choice is ever reversed, the new gate must be
+        # superuser-only.
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+
+        response = self.client.post(
+            "/admin/redis_admin/redisqueueitem/uploads_2F1_2Faaa_230/delete/",
+            {"post": "yes"},
+        )
+
+        # 403 / 404 / redirect — anything but a successful delete.
+        assert response.status_code in (302, 403, 404)
+        assert self.redis.exists("uploads/1/aaa") == 1

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -749,7 +749,7 @@ class RedisAdminClearByScopeTest(TestCase):
 
         assert response.status_code == 200
         body = response.content.decode("utf-8")
-        assert "scope must include a repoid or commitid" in body
+        assert "scope must include a repoid, commitid, or at least one family" in body
         # Sanity: nothing was cleared.
         assert self.redis.exists("uploads/42/abc123") == 1
 
@@ -775,3 +775,146 @@ class RedisAdminClearByScopeTest(TestCase):
         # Both commits-prefixed-with "abc" should be cleared.
         assert self.redis.exists("uploads/42/abc123") == 0
         assert self.redis.exists("uploads/99/abc456") == 0
+
+    # ---- Family-scope (M6 follow-up) -----------------------------------
+
+    def test_get_with_repoid_and_family_narrows_to_that_family(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate_repo_42()
+
+        # Repo 42 has both `uploads/*` and `latest_upload/*` keys; the
+        # family filter restricts the scope to `uploads/*`.
+        response = self.client.get(self.URL + "?repoid=42&family=uploads")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "Matched: 1 key(s)" in body
+        assert "uploads/42/abc123" in body
+        assert "latest_upload/42/abc123" not in body
+
+    def test_post_confirm_with_family_only_clears_all_keys_of_that_family(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        # Two repos with `uploads/*`; one repo with `latest_upload/*`.
+        self.redis.rpush("uploads/42/abc123", "p1")
+        self.redis.rpush("uploads/99/zzz999", "p2")
+        self.redis.set("latest_upload/42/abc123", "u1")
+
+        response = self.client.post(
+            self.URL,
+            {
+                "repoid": "",
+                "commitid": "",
+                "family": ["uploads"],
+                # Family-only scope confirms by typing the joined family
+                # names.
+                "typed_confirm": "uploads",
+                "action": "confirm",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        # Both `uploads/*` keys are gone, regardless of repo.
+        assert self.redis.exists("uploads/42/abc123") == 0
+        assert self.redis.exists("uploads/99/zzz999") == 0
+        # Other family is untouched.
+        assert self.redis.exists("latest_upload/42/abc123") == 1
+        body = response.content.decode("utf-8")
+        assert "Cleared 2 key(s)" in body
+
+    def test_post_confirm_with_multiple_families_clears_each(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self.redis.rpush("uploads/42/abc123", "p1")
+        self.redis.set("latest_upload/42/abc123", "u1")
+        # Third family (intermediate-report) intentionally untouched —
+        # it's not in the requested family list.
+        self.redis.hset("intermediate-report/42/abc123/coverage", "f", "v")
+
+        response = self.client.post(
+            self.URL,
+            {
+                "repoid": "42",
+                "commitid": "",
+                "family": ["uploads", "latest_upload"],
+                "typed_confirm": "42",
+                "action": "confirm",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        assert self.redis.exists("uploads/42/abc123") == 0
+        assert self.redis.exists("latest_upload/42/abc123") == 0
+        assert self.redis.exists("intermediate-report/42/abc123/coverage") == 1
+
+    def test_post_with_unknown_family_is_refused(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate_repo_42()
+
+        response = self.client.post(
+            self.URL,
+            {
+                "repoid": "42",
+                "commitid": "",
+                "family": ["nope"],
+                "typed_confirm": "42",
+                "action": "confirm",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "unknown or non-deletable family" in body
+        # Sanity: nothing was cleared.
+        assert self.redis.exists("uploads/42/abc123") == 1
+
+    def test_post_with_lock_family_is_refused(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate_repo_42()
+
+        # `upload_finisher_gate` is a lock family — it's a real family
+        # name in the registry but `is_deletable=False`, so it must be
+        # rejected by the `_deletable_family_names` allowlist.
+        response = self.client.post(
+            self.URL,
+            {
+                "repoid": "42",
+                "commitid": "",
+                "family": ["upload_finisher_gate"],
+                "typed_confirm": "42",
+                "action": "confirm",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "unknown or non-deletable family" in body
+        # Lock key still in Redis.
+        assert self.redis.exists("upload_finisher_gate_42_abc123") == 1
+
+    def test_form_renders_a_checkbox_for_each_deletable_family(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+
+        response = self.client.get(self.URL)
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Every deletable queue family gets a checkbox; locks do not.
+        for name in (
+            "uploads",
+            "ta_flake_key",
+            "latest_upload",
+            "upload-processing-state",
+            "intermediate-report",
+            "celery_broker",
+        ):
+            assert f'value="{name}"' in body
+        # Locks must not appear in the family checkbox list.
+        assert 'value="upload_finisher_gate"' not in body
+        assert 'value="coordination_lock"' not in body

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -545,3 +545,233 @@ class RedisQueueAdminDeleteActionsTest(TestCase):
         assert self.redis.exists("uploads/1/bbb") == 0
         # Audit log should record the real delete.
         assert LogEntry.objects.count() >= 1
+
+
+class RedisAdminClearByScopeTest(TestCase):
+    """M6: cross-family clear-by-scope view.
+
+    Verifies the dedicated `/clear-by-scope/` URL aggregates matching
+    keys across multiple deletable families and gates the destructive
+    action behind a typed-confirmation guard. Locks (`is_deletable=
+    False`) must never be cleared, even if the operator's scope picks
+    them up.
+    """
+
+    URL = "/admin/redis_admin/redisqueue/clear-by-scope/"
+
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        self.client = Client()
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def _populate_repo_42(self):
+        # Two queue-family keys for repoid=42; one for a different repo
+        # to verify scoping; one lock that must be refused.
+        self.redis.rpush("uploads/42/abc123", "p1")
+        self.redis.set("latest_upload/42/abc123", "u1")
+        self.redis.rpush("uploads/99/zzz999", "p2")
+        # Lock family — must be excluded from the matched targets.
+        self.redis.set("upload_finisher_gate_42_abc123", "1")
+
+    def test_link_visible_in_changelist_object_tools_for_superuser(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate_repo_42()
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "Clear by scope" in body
+        assert self.URL in body
+
+    def test_link_hidden_from_non_superuser(self):
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+        self._populate_repo_42()
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "Clear by scope" not in body
+
+    def test_non_superuser_gets_permission_denied(self):
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+
+        response = self.client.get(self.URL)
+
+        # Django's admin_view wraps PermissionDenied as a 403.
+        assert response.status_code == 403
+
+    def test_get_without_scope_renders_empty_form(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+
+        response = self.client.get(self.URL)
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "Clear Redis by scope" in body
+        assert "Repository ID" in body
+        # No "Matched: N keys" panel appears until a scope is supplied.
+        assert "Matched:" not in body
+
+    def test_get_with_repoid_lists_matching_keys_across_families(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate_repo_42()
+
+        response = self.client.get(self.URL + "?repoid=42")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Aggregated count: uploads/42/abc123 + latest_upload/42/abc123,
+        # NOT uploads/99/zzz999, NOT the lock.
+        assert "Matched: 2 key(s)" in body
+        assert "uploads/42/abc123" in body
+        assert "latest_upload/42/abc123" in body
+        assert "uploads/99/zzz999" not in body
+        assert "upload_finisher_gate" not in body
+        # Both family names render.
+        assert "uploads" in body
+        assert "latest_upload" in body
+
+    def test_get_with_invalid_repoid_shows_error(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+
+        response = self.client.get(self.URL + "?repoid=not-an-int")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "repoid must be an integer" in body
+
+    def test_post_dry_run_does_not_delete_and_audits(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate_repo_42()
+        prior_logs = LogEntry.objects.count()
+
+        response = self.client.post(
+            self.URL,
+            {
+                "repoid": "42",
+                "commitid": "",
+                "typed_confirm": "42",
+                "action": "dry_run",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "Dry-run: would clear 2" in body
+        # Nothing is actually deleted.
+        assert self.redis.exists("uploads/42/abc123") == 1
+        assert self.redis.exists("latest_upload/42/abc123") == 1
+        # Out-of-scope and lock keys remain untouched.
+        assert self.redis.exists("uploads/99/zzz999") == 1
+        assert self.redis.exists("upload_finisher_gate_42_abc123") == 1
+        # Audit log still records the dry-run.
+        assert LogEntry.objects.count() == prior_logs + 1
+
+    def test_post_confirm_clears_matching_keys_only(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate_repo_42()
+
+        response = self.client.post(
+            self.URL,
+            {
+                "repoid": "42",
+                "commitid": "",
+                "typed_confirm": "42",
+                "action": "confirm",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        # Repo-42 keys are gone.
+        assert self.redis.exists("uploads/42/abc123") == 0
+        assert self.redis.exists("latest_upload/42/abc123") == 0
+        # Other repo's keys are untouched.
+        assert self.redis.exists("uploads/99/zzz999") == 1
+        # Lock is untouched (refused by `is_deletable=False`).
+        assert self.redis.exists("upload_finisher_gate_42_abc123") == 1
+        # Confirm runs redirect to the changelist with a success
+        # message; both should appear in the followed response.
+        body = response.content.decode("utf-8")
+        assert "Cleared 2 key(s)" in body
+
+    def test_post_with_mismatched_typed_confirmation_blocks_delete(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate_repo_42()
+
+        response = self.client.post(
+            self.URL,
+            {
+                "repoid": "42",
+                "commitid": "",
+                "typed_confirm": "wrong",
+                "action": "confirm",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "Typed confirmation must equal" in body
+        # Nothing was deleted.
+        assert self.redis.exists("uploads/42/abc123") == 1
+        assert self.redis.exists("latest_upload/42/abc123") == 1
+
+    def test_post_without_scope_is_refused(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate_repo_42()
+
+        response = self.client.post(
+            self.URL,
+            {
+                "repoid": "",
+                "commitid": "",
+                "typed_confirm": "",
+                "action": "confirm",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "scope must include a repoid or commitid" in body
+        # Sanity: nothing was cleared.
+        assert self.redis.exists("uploads/42/abc123") == 1
+
+    def test_post_confirm_with_commitid_only_clears_matching_keys(self):
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        # Two different repos sharing a commit prefix.
+        self.redis.rpush("uploads/42/abc123", "p1")
+        self.redis.rpush("uploads/99/abc456", "p2")
+
+        response = self.client.post(
+            self.URL,
+            {
+                "repoid": "",
+                "commitid": "abc",
+                "typed_confirm": "abc",
+                "action": "confirm",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        # Both commits-prefixed-with "abc" should be cleared.
+        assert self.redis.exists("uploads/42/abc123") == 0
+        assert self.redis.exists("uploads/99/abc456") == 0

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -476,7 +476,7 @@ class RedisQueueAdminDeleteActionsTest(TestCase):
         self.redis.rpush("uploads/1/aaa", "p1")
         self.redis.rpush("uploads/1/bbb", "p2")
 
-    def test_non_superuser_cannot_see_delete_selected(self):
+    def test_non_superuser_cannot_see_clear_selected(self):
         staff = UserFactory(is_staff=True, is_superuser=False)
         self.client.force_login(staff)
         self._populate()
@@ -486,8 +486,26 @@ class RedisQueueAdminDeleteActionsTest(TestCase):
         assert response.status_code == 200
         body = response.content.decode("utf-8")
         # Non-superusers can dry-run but never see the destructive action.
+        assert "Clear selected" not in body
+        # Stock Django delete is stripped out for everyone.
         assert "Delete selected" not in body
         assert "Dry-run" in body
+
+    def test_stock_delete_selected_action_is_unavailable(self):
+        # `delete_selected` was Django's stock no-dry-run path; we
+        # deliberately strip it so the only real-mutation bulk action
+        # is `clear_selected`, which forces a dry-run interstitial.
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate()
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert 'value="delete_selected"' not in body
+        # Sanity: our replacement is offered.
+        assert 'value="clear_selected"' in body
 
     def test_clear_dry_run_action_does_not_delete(self):
         superuser = UserFactory(is_staff=True, is_superuser=True)
@@ -512,39 +530,102 @@ class RedisQueueAdminDeleteActionsTest(TestCase):
         # Audit trail: dry-runs are recorded.
         assert LogEntry.objects.count() >= 1
 
-    def test_delete_selected_actually_clears_keys(self):
+    def test_clear_selected_renders_dry_run_preview_first(self):
+        # Stage 1 of the new bulk-clear flow: posting `clear_selected`
+        # with no `confirm` flag must render the dry-run preview page,
+        # NOT delete anything.
         superuser = UserFactory(is_staff=True, is_superuser=True)
         self.client.force_login(superuser)
         self._populate()
+        prior_logs = LogEntry.objects.count()
 
-        # Stage 1: post the bulk action and accept Django's confirmation page.
         response = self.client.post(
             "/admin/redis_admin/redisqueue/",
             {
-                "action": "delete_selected",
+                "action": "clear_selected",
                 "_selected_action": ["uploads/1/aaa", "uploads/1/bbb"],
             },
         )
-        # The confirmation page is a 200, the actual delete needs `post`.
-        assert response.status_code == 200
 
-        # Stage 2: confirm the deletion.
-        response = self.client.post(
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Preview page renders the dry-run summary…
+        assert "Dry-run summary" in body
+        assert "Would delete:" in body
+        assert "<strong>2</strong>" in body
+        # …a sample list…
+        assert "uploads/1/aaa" in body
+        assert "uploads/1/bbb" in body
+        # …and a confirmation form that re-posts with `confirm=yes`.
+        assert 'name="confirm" value="yes"' in body
+        assert 'name="action" value="clear_selected"' in body
+        assert 'name="_selected_action" value="uploads/1/aaa"' in body
+        # No keys deleted yet.
+        assert self.redis.exists("uploads/1/aaa") == 1
+        assert self.redis.exists("uploads/1/bbb") == 1
+        # Audit trail still has the dry-run recorded.
+        assert LogEntry.objects.count() == prior_logs + 1
+
+    def test_clear_selected_with_confirm_actually_clears_keys(self):
+        # Stage 2: re-post with `confirm=yes` runs the real delete.
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate()
+        prior_logs = LogEntry.objects.count()
+
+        # Stage 1: open the confirmation page (records a dry-run audit).
+        stage1 = self.client.post(
             "/admin/redis_admin/redisqueue/",
             {
-                "action": "delete_selected",
+                "action": "clear_selected",
                 "_selected_action": ["uploads/1/aaa", "uploads/1/bbb"],
-                "post": "yes",
+            },
+        )
+        assert stage1.status_code == 200
+        # Mid-flight: keys still present.
+        assert self.redis.exists("uploads/1/aaa") == 1
+
+        # Stage 2: submit the confirmation form.
+        stage2 = self.client.post(
+            "/admin/redis_admin/redisqueue/",
+            {
+                "action": "clear_selected",
+                "_selected_action": ["uploads/1/aaa", "uploads/1/bbb"],
+                "confirm": "yes",
             },
             follow=True,
         )
 
-        assert response.status_code == 200
+        assert stage2.status_code == 200
         # Both keys should now be gone.
         assert self.redis.exists("uploads/1/aaa") == 0
         assert self.redis.exists("uploads/1/bbb") == 0
-        # Audit log should record the real delete.
-        assert LogEntry.objects.count() >= 1
+        # Audit log should record both the dry-run AND the real delete.
+        assert LogEntry.objects.count() == prior_logs + 2
+
+    def test_clear_selected_cancel_does_not_delete(self):
+        # Operators must be able to back out of the dry-run preview
+        # without deleting anything.
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        self._populate()
+
+        # Stage 1.
+        self.client.post(
+            "/admin/redis_admin/redisqueue/",
+            {
+                "action": "clear_selected",
+                "_selected_action": ["uploads/1/aaa", "uploads/1/bbb"],
+            },
+        )
+        # The "No, take me back" link is just a GET to the changelist;
+        # exercise it explicitly.
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        # Nothing was deleted because stage 2 never happened.
+        assert self.redis.exists("uploads/1/aaa") == 1
+        assert self.redis.exists("uploads/1/bbb") == 1
 
 
 class RedisAdminClearByScopeTest(TestCase):


### PR DESCRIPTION
## Summary

Stacked on top of #888 (M4 + M5 — new families, locks view, deletion service). Caps off the [redis_admin queue browser plan](.cursor/plans/redis_admin_queue_browser_50236495.plan.md) with the cross-family escape hatch (M6) and the observability + docs polish (M7).

End-of-M6 acceptance: an on-call clearing a borked rerun fills in `repoid=1234, commitid=abc` once, sees the count + sample, dry-runs, then types the repoid to arm and clears every deletable key for that scope across all families in one audited operation. Locks are still refused.

## What's in this PR

### M6 — cross-family clear-by-scope

- New URL: \`/admin/redis_admin/redisqueue/clear-by-scope/\` (\`name=admin:redis_admin_redisqueue_clear_by_scope\`).
- Toolbar link in the queues changelist's \`object-tools\` (superuser-only).
- View aggregates matching keys via \`iter_keys(repoid=…, commitid_prefix=…, category=\"queue\")\`, skips lock families (\`is_deletable=False\`), and re-checks the parsed repoid/commitid because Redis glob \`*\` matches \`/\`.
- Mutation funnels through the existing \`services.redis_delete()\`, so locks stay safe even if a future family change accidentally surfaces them as queues.

Safety stack:

1. Superuser-only (matches \`delete_selected\`).
2. Empty scope refused — fully blank form can't clear all of Redis.
3. Typed-confirmation guard: re-type the repoid (or commitid) before the destructive button arms.
4. \`dry_run\` button always alongside \`confirm\`; both leave a \`LogEntry\` audit trail.

### M7 — Sentry spans + docs

- Every Redis-touching admin entry point now opens a Sentry span:
  - \`op=redis.admin.iter_keys\`, name=\`<category>.<family>\` — wraps the SCAN sweep in \`families.iter_keys\` (body factored into \`_iter_keys_inner\` so the wrapping span lives in a plain function and the inner generator can \`yield\` freely).
  - \`op=redis.admin.delete\`, name=\`dry_run\` / \`execute\` — wraps \`services.redis_delete\` and records count + families on the span.
  - \`@sentry_sdk.trace\` on \`RedisItemQuerySet._list_slice\` / \`_materialize_set\` / \`_materialize_hash\` / \`_materialize_string\` (matches the existing codebase pattern in \`libs/shared/shared/reports/\`).
- \`apps/codecov-api/redis_admin/README.md\` documenting what's surfaced, search syntax, every \`REDIS_ADMIN_*\` setting and default, the three deletion entry points, the audit log shape, the span op names, and a \"how to add a new family\" cookbook.

## Tests

\`RedisAdminClearByScopeTest\` (11 new cases):
- toolbar link visible for superuser / hidden for staff
- non-superuser GET is 403
- empty form renders (no \"Matched\" panel until scope supplied)
- GET with repoid aggregates across families and excludes out-of-scope keys + locks
- GET with invalid repoid surfaces an error
- POST dry-run does not delete; audit log still written
- POST confirm clears matching keys only; locks untouched
- POST with mismatched typed-confirmation blocks the delete
- POST with empty scope is refused
- POST confirm with commitid-only scope clears matching keys

\`\`\`
============================= 118 passed in 8.55s ==============================
\`\`\`

ruff clean.

## Test plan

- [ ] On a fresh stage env: superuser visits \`/admin/redis_admin/redisqueue/\`, clicks \"Clear by scope\".
- [ ] Without filling the form, click \"Preview matching keys\" → no Matched panel, no errors.
- [ ] Type \`repoid=<some_test_repoid>\`, preview → see count + sample + families list.
- [ ] Type wrong value into the typed-confirm field, click \"Clear\" → blocked.
- [ ] Click \"Dry-run\" → success message, nothing deleted, \`LogEntry\` written.
- [ ] Type the correct repoid into the confirm field, click \"Clear\" → keys gone, redirected to changelist with success message, \`LogEntry\` written.
- [ ] Verify a \`upload_finisher_gate_<repoid>_…\` lock for that repo is still in Redis.
- [ ] Hit \`/admin/redis_admin/redisqueue/clear-by-scope/\` as a non-superuser staff user → 403.
- [ ] In Sentry, verify \`redis.admin.iter_keys\` and \`redis.admin.delete\` spans appear for these flows.

## Stack

- #885 — M1 (view keys)
- #886 — M2 (per-queue items)
- #887 — M3 (filters / search / repo+commit links)
- #888 — M4 + M5 (more families, locks, deletion service)
- **this PR** — M6 + M7 (clear-by-scope, sentry, README)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces new destructive admin endpoints and changes deletion permissions/flows; mitigated by superuser gating, typed confirmation, lock-family refusal, and expanded tests/audit logging.
> 
> **Overview**
> Adds a **superuser-only** `/admin/redis_admin/redisqueue/clear-by-scope/` workflow that previews and then clears all *deletable* Redis queue keys matching `repoid`, `commitid` prefix, and/or selected queue families, with a typed-confirmation guard and audit logging.
> 
> Replaces Django’s bulk `delete_selected` with `clear_selected`, which **forces a dry-run preview page before allowing the actual clear**, and tightens `clear_dry_run` to `permissions=("delete",)` so staff users no longer see or can invoke deletion-adjacent actions.
> 
> Improves observability by adding Sentry spans for key scanning (`redis.admin.iter_keys`), deletion (`redis.admin.delete`), and item materialization methods, and adds a new `redis_admin/README.md` plus expanded tests covering the new views and permission invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4408d4c44bb5bc278977a1b86b3588b19747f850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->