### PR TITLE
feat(api): redis_admin routes celery_broker family to broker Redis

### DIFF
--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -18,6 +18,7 @@ prefix-style tokens in addition to plain substrings:
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
+from typing import Any
 from urllib.parse import urlencode
 
 from django.contrib import admin, messages
@@ -448,18 +449,27 @@ class RedisQueueAdmin(admin.ModelAdmin):
         (`is_deletable=False`) regardless of how a key was surfaced.
         """
 
-        redis = _conn.get_connection()
         family_iter: Iterable[str | None]
         if families:
             family_iter = list(families)
         else:
             family_iter = [None]
 
+        # See `RedisQueueQuerySet._fetch_all` — same per-family
+        # connection-kind cache so a clear-by-scope that spans the cache
+        # and broker Redis instances opens at most one client per kind.
+        clients: dict[str, Any] = {}
+
+        def _client_for(family) -> Any:
+            kind = family.connection_kind
+            if kind not in clients:
+                clients[kind] = _conn.get_connection(kind=kind)
+            return clients[kind]
+
         targets: list[RedisQueue] = []
         seen: set[str] = set()
         for family_name in family_iter:
             for key, family in iter_keys(
-                redis,
                 family=family_name,
                 repoid=repoid,
                 commitid_prefix=commitid or None,
@@ -469,7 +479,7 @@ class RedisQueueAdmin(admin.ModelAdmin):
                     continue
                 if key in seen:
                     continue
-                obj = _build_redis_queue(self.model, key, family, redis)
+                obj = _build_redis_queue(self.model, key, family, _client_for(family))
                 # `iter_keys` already pushed the filter into SCAN MATCH,
                 # but glob `*` matches `/` so re-verify the parsed
                 # values.

--- a/apps/codecov-api/redis_admin/conn.py
+++ b/apps/codecov-api/redis_admin/conn.py
@@ -55,9 +55,7 @@ _FACTORY_SETTINGS: dict[str, str] = {
 def _resolve_factory(dotted: str, *, setting_name: str) -> Callable[[], Any]:
     module_path, _, attr = dotted.rpartition(".")
     if not module_path:
-        raise ValueError(
-            f"{setting_name} must be a dotted path, got {dotted!r}"
-        )
+        raise ValueError(f"{setting_name} must be a dotted path, got {dotted!r}")
     module = import_module(module_path)
     return getattr(module, attr)
 

--- a/apps/codecov-api/redis_admin/conn.py
+++ b/apps/codecov-api/redis_admin/conn.py
@@ -1,34 +1,96 @@
 """Single entry point for Redis access from the redis_admin app.
 
-By default we hand out the same connection used everywhere else in the
-codebase via `shared.helpers.redis.get_redis_connection`. Tests and operators
-can swap in a custom factory by setting `REDIS_ADMIN_CONNECTION_FACTORY` to a
-dotted path of a zero-arg callable returning a `redis.Redis`-compatible
-instance.
+We expose two named connections:
+
+- ``"default"`` — the cache Redis at ``services.redis_url``, used by
+  every family whose data lives on the main app Redis (uploads/, locks,
+  intermediate-report, …). This is also what
+  ``shared.helpers.redis.get_redis_connection`` returns.
+- ``"broker"`` — the Celery broker at ``services.celery_broker``. In
+  production this is a *different* Memorystore instance from the cache
+  Redis (see ``terraform/codecov/cluster/secrets.tf`` —
+  ``google_redis_instance.cache`` vs. ``google_redis_instance.celery``)
+  and is exposed via a separate Secret Manager entry
+  (``…-memorystore-celery-url``). The api pod already binds it to the
+  ``SERVICES__CELERY_BROKER`` env var; without routing the
+  ``celery_broker`` family through it the admin can't see any of the
+  Celery queue keys (KEDA & Grafana monitor the broker Redis directly,
+  which is why a 195k-deep ``bundles_analysis`` backlog showed up there
+  but not in the admin changelist).
+
+Dev / enterprise deploys typically run a single Redis. They leave
+``services.celery_broker`` unset and the broker kind transparently falls
+back to the default cache URL, mirroring what ``BaseCeleryConfig`` does.
+
+Tests and operators can swap in custom factories per kind:
+
+- ``REDIS_ADMIN_CONNECTION_FACTORY`` overrides ``"default"``.
+- ``REDIS_ADMIN_BROKER_CONNECTION_FACTORY`` overrides ``"broker"``.
+
+Each is a dotted path to a zero-arg callable returning a
+``redis.Redis``-compatible instance.
 """
 
 from collections.abc import Callable
 from importlib import import_module
-from typing import Any
+from typing import Any, Literal
 
 from django.conf import settings
+from redis import Redis
 
-from shared.helpers.redis import get_redis_connection
+from shared.config import get_config
+from shared.helpers.redis import get_redis_connection, get_redis_url
+
+ConnectionKind = Literal["default", "broker"]
+
+# Per-kind setting names so a single factory can't accidentally
+# short-circuit both kinds at once (the broker variant ships separately
+# so we can roll it out behind its own flag/factory if needed).
+_FACTORY_SETTINGS: dict[str, str] = {
+    "default": "REDIS_ADMIN_CONNECTION_FACTORY",
+    "broker": "REDIS_ADMIN_BROKER_CONNECTION_FACTORY",
+}
 
 
-def _resolve_factory(dotted: str) -> Callable[[], Any]:
+def _resolve_factory(dotted: str, *, setting_name: str) -> Callable[[], Any]:
     module_path, _, attr = dotted.rpartition(".")
     if not module_path:
         raise ValueError(
-            f"REDIS_ADMIN_CONNECTION_FACTORY must be a dotted path, got {dotted!r}"
+            f"{setting_name} must be a dotted path, got {dotted!r}"
         )
     module = import_module(module_path)
     return getattr(module, attr)
 
 
-def get_connection() -> Any:
-    factory_path = getattr(settings, "REDIS_ADMIN_CONNECTION_FACTORY", None)
+def _broker_connection() -> Any:
+    """Build a client for the Celery broker Redis.
+
+    Falls back to ``services.redis_url`` when ``services.celery_broker``
+    is unset so single-Redis deploys (dev, most enterprise) keep working
+    without any extra config — same fallback ``BaseCeleryConfig`` uses.
+    """
+
+    url = get_config("services", "celery_broker") or get_redis_url()
+    return Redis.from_url(url)
+
+
+def get_connection(kind: ConnectionKind = "default") -> Any:
+    """Return a Redis client for the requested connection ``kind``.
+
+    The ``kind`` argument is keyword-defaulted so existing zero-arg
+    callsites (and the simple ``lambda: server`` patches in tests) keep
+    working unchanged.
+    """
+
+    setting_name = _FACTORY_SETTINGS.get(kind)
+    if setting_name is None:
+        raise ValueError(f"unknown redis_admin connection kind: {kind!r}")
+
+    factory_path = getattr(settings, setting_name, None)
     if factory_path:
-        factory = _resolve_factory(factory_path)
+        factory = _resolve_factory(factory_path, setting_name=setting_name)
         return factory()
+
+    if kind == "broker":
+        return _broker_connection()
     return get_redis_connection()

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -715,6 +715,7 @@ def iter_keys(
     """
 
     if redis is not None:
+
         def resolve_client(kind: ConnectionKind) -> Any:
             return redis
     else:

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -33,6 +33,12 @@ log = logging.getLogger(__name__)
 
 RedisType = Literal["list", "set", "hash", "string"]
 
+# Which Redis connection a family lives on. `default` = cache Redis at
+# `services.redis_url`; `broker` = Celery broker at
+# `services.celery_broker`, which is a separate Memorystore instance in
+# production. See `redis_admin.conn` for the URL plumbing.
+ConnectionKind = Literal["default", "broker"]
+
 
 @dataclass(frozen=True)
 class ParsedKey:
@@ -537,6 +543,13 @@ class Family:
     # with a `[task=... repoid=... commit=...]` prefix without
     # special-casing the queryset itself.
     decode_value: Callable[[str], str] | None = None
+    # Which Redis instance owns this family's keys. Production splits
+    # the Celery broker onto its own Memorystore (see
+    # `redis_admin.conn`) — `celery_broker` is the only family that
+    # opts in today, but keeping this as a per-family knob means future
+    # split-Redis surfaces (e.g. a dedicated rate-limit cluster) can
+    # plug in the same way.
+    connection_kind: ConnectionKind = "default"
 
     def build_scan_pattern(self, filters: Mapping[str, Any]) -> str | None:
         if self.pattern_for is None:
@@ -590,6 +603,10 @@ FAMILIES: tuple[Family, ...] = (
         pattern_for=_celery_pattern,
         fixed_keys=_resolve_celery_queue_names(),
         decode_value=_celery_decode_value,
+        # Celery queues live on the broker Redis (`services.celery_broker`),
+        # which in production is a separate Memorystore from the cache Redis
+        # the rest of the families use. See `redis_admin.conn` for details.
+        connection_kind="broker",
     ),
     # ---- Locks (M4.3) -----------------------------------------------------
     # Order matters: more-specific prefixes go BEFORE the broad
@@ -688,9 +705,29 @@ def iter_keys(
     `RedisQueueQuerySet`. `category` separates queue families (default
     `RedisQueue` audience) from lock families (`RedisLock` audience).
     Total work is bounded by `MAX_SCAN_KEYS`.
+
+    When `redis` is `None` (the production path) each family is iterated
+    against the connection it owns via `family.connection_kind` —
+    `celery_broker` runs against the Celery broker Redis while everyone
+    else runs against the cache Redis. Passing an explicit `redis`
+    overrides routing and uses that single client for every family,
+    which is the shape tests rely on (one fakeredis backs all kinds).
     """
 
-    redis = redis if redis is not None else _conn.get_connection()
+    if redis is not None:
+        def resolve_client(kind: ConnectionKind) -> Any:
+            return redis
+    else:
+        # Cache one client per kind so iter_keys at most opens two
+        # connections per call (default + broker), regardless of how
+        # many families we sweep.
+        client_cache: dict[ConnectionKind, Any] = {}
+
+        def resolve_client(kind: ConnectionKind) -> Any:
+            if kind not in client_cache:
+                client_cache[kind] = _conn.get_connection(kind=kind)
+            return client_cache[kind]
+
     cap = redis_admin_settings.MAX_SCAN_KEYS
     count = redis_admin_settings.SCAN_COUNT
     filters: dict[str, Any] = {
@@ -711,7 +748,7 @@ def iter_keys(
         except AttributeError:  # pragma: no cover - older sentry sdks
             pass
         yield from _iter_keys_inner(
-            redis,
+            resolve_client,
             family=family,
             category=category,
             cap=cap,
@@ -721,7 +758,7 @@ def iter_keys(
 
 
 def _iter_keys_inner(
-    redis,
+    resolve_client: Callable[[ConnectionKind], Any],
     *,
     family: str | None,
     category: Literal["queue", "lock"] | None,
@@ -753,10 +790,12 @@ def _iter_keys_inner(
         if pattern is None:
             continue
 
+        client = resolve_client(fam.connection_kind)
+
         for key in fam.fixed_keys:
             if key in yielded:
                 continue
-            if redis.exists(key):
+            if client.exists(key):
                 yielded.add(key)
                 yield key, fam
                 seen += 1
@@ -770,7 +809,7 @@ def _iter_keys_inner(
         if not pattern:
             continue
 
-        for raw_key in redis.scan_iter(match=pattern, count=count):
+        for raw_key in client.scan_iter(match=pattern, count=count):
             key = _decode(raw_key)
             if key in yielded:
                 continue

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -281,7 +281,17 @@ class RedisQueueQuerySet:
             self._result_cache = []
             return []
 
-        redis = _conn.get_connection()
+        # Cache one client per connection-kind so families that share a
+        # kind reuse a single Redis client across the page (the broker
+        # kind is the only non-default kind today, but the cache scales
+        # transparently if more get added).
+        clients: dict[str, Any] = {}
+
+        def _client_for(family: Family) -> Any:
+            kind = family.connection_kind
+            if kind not in clients:
+                clients[kind] = _conn.get_connection(kind=kind)
+            return clients[kind]
 
         # `pk__in=[...]` / `pk=name` from admin bulk actions: skip SCAN
         # and resolve each requested name directly against the family
@@ -304,14 +314,17 @@ class RedisQueueQuerySet:
                     continue
                 if family.category != self._category:
                     continue
+                redis = _client_for(family)
                 if not redis.exists(name):
                     continue
                 items.append(_build_redis_queue(self.model, name, family, redis))
         else:
+            # Don't pass an explicit redis to iter_keys here so it routes
+            # SCAN / EXISTS against the connection each family owns. The
+            # builder picks the matching client per yielded family.
             items = [
-                _build_redis_queue(self.model, key, family, redis)
+                _build_redis_queue(self.model, key, family, _client_for(family))
                 for key, family in iter_keys(
-                    redis,
                     family=self._filters.get("family"),
                     repoid=self._filters.get("repoid"),
                     commitid_prefix=self._filters.get("commitid_prefix"),
@@ -504,11 +517,11 @@ class RedisItemQuerySet:
                 f"pk_token must look like 'queue#locator'; got {pk_token!r}"
             )
 
-        redis = _conn.get_connection()
+        bound = self._clone(queue_name=queue_name)
+        redis = bound._connection()
         if not redis.exists(queue_name):
             raise self.model.DoesNotExist(f"Redis key {queue_name!r} does not exist")
 
-        bound = self._clone(queue_name=queue_name)
         kind = bound._resolve_type(redis)
 
         if kind == "list":
@@ -589,6 +602,20 @@ class RedisItemQuerySet:
         if not self.queue_name:
             return None
         return find_family(self.queue_name)
+
+    def _connection(self) -> Any:
+        """Return the Redis client that owns this queryset's queue.
+
+        Routes off the resolved family's `connection_kind` so a queue
+        belonging to `celery_broker` reads from the broker Redis instead
+        of the (default) cache Redis. Unknown families fall back to the
+        default kind, which preserves prior behavior for any operator
+        URL-tampering paths.
+        """
+
+        family = self._resolve_family()
+        kind = family.connection_kind if family is not None else "default"
+        return _conn.get_connection(kind=kind)
 
     def _resolve_type(self, redis) -> str | None:
         """Best-effort lookup of the Redis type for `self.queue_name`."""
@@ -712,7 +739,7 @@ class RedisItemQuerySet:
     def count(self) -> int:
         if not self.queue_name:
             return 0
-        redis = _conn.get_connection()
+        redis = self._connection()
         kind = self._resolve_type(redis)
         if kind == "list":
             return int(redis.llen(self.queue_name) or 0)
@@ -754,7 +781,7 @@ class RedisItemQuerySet:
     def __getitem__(self, item):
         if not self.queue_name:
             return [] if isinstance(item, slice) else None
-        redis = _conn.get_connection()
+        redis = self._connection()
         kind = self._resolve_type(redis)
         if kind not in ("list", "set", "hash", "string"):
             return [] if isinstance(item, slice) else None

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -25,6 +25,7 @@ import json
 import logging
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
+from typing import Any
 
 import sentry_sdk
 from django.contrib.admin.models import DELETION, LogEntry
@@ -32,7 +33,7 @@ from django.contrib.contenttypes.models import ContentType
 
 from . import conn as _conn
 from . import settings as redis_admin_settings
-from .families import find_family
+from .families import ConnectionKind, find_family
 from .models import RedisLock, RedisQueue, RedisQueueItem
 
 log = logging.getLogger(__name__)
@@ -317,9 +318,43 @@ def _redis_delete(
             refused=refused,
         )
     else:
-        redis = _conn.get_connection()
-        keys_deleted = _execute_key_deletes(redis, deletable_keys)
-        items_deleted = _execute_item_deletes(redis, pending_items)
+        # Bucket deletes by the family's connection kind so each pipeline
+        # is dispatched against the Redis instance that actually owns
+        # those keys. In production, `celery_broker` lives on a separate
+        # Memorystore from everything else (see `redis_admin.conn`); a
+        # mixed selection (e.g. an admin "clear-by-scope" sweep across
+        # `uploads` + `celery_broker`) needs both clients to fully apply.
+        clients: dict[ConnectionKind, Any] = {}
+
+        def _client_for(kind: ConnectionKind) -> Any:
+            if kind not in clients:
+                clients[kind] = _conn.get_connection(kind=kind)
+            return clients[kind]
+
+        keys_by_kind: dict[ConnectionKind, list[str]] = {}
+        for name in deletable_keys:
+            family = find_family(name)
+            key_kind: ConnectionKind = (
+                family.connection_kind if family is not None else "default"
+            )
+            keys_by_kind.setdefault(key_kind, []).append(name)
+
+        items_by_kind: dict[ConnectionKind, list[_PendingItem]] = {}
+        for pending in pending_items:
+            family = find_family(pending.queue_name)
+            item_kind: ConnectionKind = (
+                family.connection_kind if family is not None else "default"
+            )
+            items_by_kind.setdefault(item_kind, []).append(pending)
+
+        keys_deleted = sum(
+            _execute_key_deletes(_client_for(kind), kind_keys)
+            for kind, kind_keys in keys_by_kind.items()
+        )
+        items_deleted = sum(
+            _execute_item_deletes(_client_for(kind), kind_items)
+            for kind, kind_items in items_by_kind.items()
+        )
         result = DeleteResult(
             count=keys_deleted + items_deleted,
             sample=sample,

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -27,7 +27,7 @@ class RedisAdminSmokeTest(TestCase):
     def setUp(self):
         self.redis = fakeredis.FakeStrictRedis()
         self._orig_get_connection = redis_admin_conn.get_connection
-        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
 
         self.user = UserFactory(is_staff=True)
         self.client = Client()
@@ -84,7 +84,7 @@ class RedisQueueItemAdminSmokeTest(TestCase):
     def setUp(self):
         self.redis = fakeredis.FakeStrictRedis()
         self._orig_get_connection = redis_admin_conn.get_connection
-        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
 
         self.user = UserFactory(is_staff=True)
         self.client = Client()
@@ -190,7 +190,7 @@ class RedisAdminFiltersAndSearchTest(TestCase):
     def setUp(self):
         self.redis = fakeredis.FakeStrictRedis()
         self._orig_get_connection = redis_admin_conn.get_connection
-        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
 
         self.user = UserFactory(is_staff=True)
         self.client = Client()
@@ -329,7 +329,7 @@ class RedisLockAdminSmokeTest(TestCase):
     def setUp(self):
         self.redis = fakeredis.FakeStrictRedis()
         self._orig_get_connection = redis_admin_conn.get_connection
-        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
 
         self.user = UserFactory(is_staff=True)
         self.client = Client()
@@ -373,7 +373,7 @@ class RedisQueueAdminChangePageTest(TestCase):
     def setUp(self):
         self.redis = fakeredis.FakeStrictRedis()
         self._orig_get_connection = redis_admin_conn.get_connection
-        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
 
         self.user = UserFactory(is_staff=True, is_superuser=True)
         self.client = Client()
@@ -465,7 +465,7 @@ class RedisQueueAdminDeleteActionsTest(TestCase):
     def setUp(self):
         self.redis = fakeredis.FakeStrictRedis()
         self._orig_get_connection = redis_admin_conn.get_connection
-        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
 
         self.client = Client()
 
@@ -646,7 +646,7 @@ class RedisAdminClearByScopeTest(TestCase):
     def setUp(self):
         self.redis = fakeredis.FakeStrictRedis()
         self._orig_get_connection = redis_admin_conn.get_connection
-        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
         self.client = Client()
 
     def tearDown(self):
@@ -1023,7 +1023,7 @@ class RedisAdminSuperuserOnlyDeletionTest(TestCase):
     def setUp(self):
         self.redis = fakeredis.FakeStrictRedis()
         self._orig_get_connection = redis_admin_conn.get_connection
-        redis_admin_conn.get_connection = lambda: self.redis  # type: ignore[assignment]
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
         self.client = Client()
 
         self.redis.rpush("uploads/1/aaa", "p1")

--- a/apps/codecov-api/redis_admin/tests/test_conn.py
+++ b/apps/codecov-api/redis_admin/tests/test_conn.py
@@ -1,0 +1,138 @@
+"""Unit tests for `redis_admin.conn` connection-kind routing.
+
+The production deployment uses two distinct Redis instances — the
+"cache" Memorystore reachable via `services.redis_url` and the Celery
+broker Memorystore at `services.celery_broker`. These tests pin the
+contract that `get_connection(kind=...)` honors that split, both for
+real config-driven URLs and for the `REDIS_ADMIN_*_CONNECTION_FACTORY`
+override hooks used by tests / operators.
+"""
+
+from __future__ import annotations
+
+import fakeredis
+import pytest
+from django.test.utils import override_settings
+
+from redis_admin import conn as redis_admin_conn
+
+# Where this test module's fakeredis factories live so the dotted-path
+# resolver can import them. The setting accepts any zero-arg callable.
+_DEFAULT_FACTORY = "redis_admin.tests.test_conn._make_default_server"
+_BROKER_FACTORY = "redis_admin.tests.test_conn._make_broker_server"
+
+_default_server = fakeredis.FakeStrictRedis()
+_broker_server = fakeredis.FakeStrictRedis()
+
+
+def _make_default_server():
+    return _default_server
+
+
+def _make_broker_server():
+    return _broker_server
+
+
+def test_get_connection_default_kind_uses_default_factory():
+    with override_settings(REDIS_ADMIN_CONNECTION_FACTORY=_DEFAULT_FACTORY):
+        assert redis_admin_conn.get_connection() is _default_server
+        assert redis_admin_conn.get_connection(kind="default") is _default_server
+
+
+def test_get_connection_broker_kind_uses_broker_factory():
+    with override_settings(
+        REDIS_ADMIN_CONNECTION_FACTORY=_DEFAULT_FACTORY,
+        REDIS_ADMIN_BROKER_CONNECTION_FACTORY=_BROKER_FACTORY,
+    ):
+        assert redis_admin_conn.get_connection(kind="broker") is _broker_server
+        # Default kind unaffected by the broker setting.
+        assert redis_admin_conn.get_connection(kind="default") is _default_server
+
+
+def test_get_connection_broker_falls_back_to_default_when_broker_factory_unset(
+    monkeypatch,
+):
+    """When `REDIS_ADMIN_BROKER_CONNECTION_FACTORY` is not configured we
+    construct the broker client off `services.celery_broker` (or the
+    default cache URL when that's also unset). Stub
+    `_broker_connection` so the test doesn't try to open a real socket
+    and assert it was the path taken."""
+
+    sentinel = object()
+    monkeypatch.setattr(redis_admin_conn, "_broker_connection", lambda: sentinel)
+    with override_settings(REDIS_ADMIN_BROKER_CONNECTION_FACTORY=None):
+        assert redis_admin_conn.get_connection(kind="broker") is sentinel
+
+
+def _stub_config(monkeypatch, mapping: dict[tuple[str, ...], str | None]) -> None:
+    """Make `redis_admin.conn.get_config` and `get_redis_url` deterministic.
+
+    `mapping` is keyed by the args tuple `get_config(*args)` is called
+    with so we can answer both `("services", "celery_broker")` and the
+    fallback `("services", "redis_url")` from one place.
+    """
+
+    def fake_get_config(*args, **_kwargs):
+        return mapping.get(args)
+
+    monkeypatch.setattr(redis_admin_conn, "get_config", fake_get_config)
+    # `_broker_connection` falls through to `get_redis_url()` when
+    # `services.celery_broker` is unset; route that through the same
+    # mapping so a single fixture covers both lookups.
+    monkeypatch.setattr(
+        redis_admin_conn,
+        "get_redis_url",
+        lambda: mapping.get(("services", "redis_url")) or "redis://default:6379",
+    )
+
+
+def test_broker_connection_falls_back_to_redis_url_when_celery_broker_unset(
+    monkeypatch,
+):
+    """`_broker_connection()` mirrors `BaseCeleryConfig`: prefer
+    `services.celery_broker`, fall back to `services.redis_url`. Single-
+    Redis dev/enterprise deploys rely on this fallback so they don't
+    have to set both URLs."""
+
+    _stub_config(
+        monkeypatch,
+        {("services", "redis_url"): "redis://localhost:6379"},
+    )
+
+    client = redis_admin_conn._broker_connection()
+    # `redis-py` exposes the resolved URL via the connection pool's
+    # connection_kwargs; "host" is set from the URL.
+    pool = client.connection_pool
+    assert pool.connection_kwargs.get("host") == "localhost"
+
+
+def test_broker_connection_prefers_celery_broker_over_redis_url(monkeypatch):
+    _stub_config(
+        monkeypatch,
+        {
+            ("services", "redis_url"): "redis://cache-host:6379",
+            ("services", "celery_broker"): "redis://broker-host:6379",
+        },
+    )
+
+    client = redis_admin_conn._broker_connection()
+    assert client.connection_pool.connection_kwargs.get("host") == "broker-host"
+
+
+def test_unknown_kind_raises():
+    with pytest.raises(ValueError, match="unknown redis_admin connection kind"):
+        redis_admin_conn.get_connection(kind="bogus")  # type: ignore[arg-type]
+
+
+def test_factory_must_be_dotted_path():
+    with override_settings(REDIS_ADMIN_CONNECTION_FACTORY="not_a_dotted_path"):
+        with pytest.raises(ValueError, match="REDIS_ADMIN_CONNECTION_FACTORY"):
+            redis_admin_conn.get_connection()
+
+
+def test_broker_factory_must_be_dotted_path():
+    with override_settings(REDIS_ADMIN_BROKER_CONNECTION_FACTORY="bare_name"):
+        with pytest.raises(
+            ValueError, match="REDIS_ADMIN_BROKER_CONNECTION_FACTORY"
+        ):
+            redis_admin_conn.get_connection(kind="broker")

--- a/apps/codecov-api/redis_admin/tests/test_conn.py
+++ b/apps/codecov-api/redis_admin/tests/test_conn.py
@@ -132,7 +132,5 @@ def test_factory_must_be_dotted_path():
 
 def test_broker_factory_must_be_dotted_path():
     with override_settings(REDIS_ADMIN_BROKER_CONNECTION_FACTORY="bare_name"):
-        with pytest.raises(
-            ValueError, match="REDIS_ADMIN_BROKER_CONNECTION_FACTORY"
-        ):
+        with pytest.raises(ValueError, match="REDIS_ADMIN_BROKER_CONNECTION_FACTORY"):
             redis_admin_conn.get_connection(kind="broker")

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -40,7 +40,9 @@ from redis_admin.families import (
 @pytest.fixture
 def patched_redis(monkeypatch) -> fakeredis.FakeStrictRedis:
     server = fakeredis.FakeStrictRedis()
-    monkeypatch.setattr(redis_admin_conn, "get_connection", lambda: server)
+    monkeypatch.setattr(
+        redis_admin_conn, "get_connection", lambda kind="default": server
+    )
     return server
 
 
@@ -240,6 +242,79 @@ def test_iter_keys_yields_celery_queues_via_fixed_keys(patched_redis):
     assert classified["healthcheck"] == "celery_broker"
     assert classified["enterprise_uploadcoverage"] == "celery_broker"
     assert classified["uploads/1/abc"] == "uploads"
+
+
+def test_celery_broker_family_routes_to_broker_connection_kind():
+    """Pin the production routing decision: the `celery_broker` family
+    must declare it lives on the Celery broker Redis. Every other
+    family stays on the default cache Redis (the historical assumption
+    pre-PR).
+    """
+
+    by_name = {f.name: f for f in FAMILIES}
+    assert by_name["celery_broker"].connection_kind == "broker"
+    for name, family in by_name.items():
+        if name == "celery_broker":
+            continue
+        assert family.connection_kind == "default", (
+            f"family {name!r} unexpectedly opted into a non-default "
+            f"connection_kind={family.connection_kind!r}"
+        )
+
+
+def test_iter_keys_routes_per_family_when_no_explicit_redis(monkeypatch):
+    """`iter_keys()` (no explicit redis) must hit the connection each
+    family owns. Pre-PR, an admin sweep saw the cache Redis only and
+    missed Celery broker keys entirely. We model that here with two
+    fakeredis servers and assert keys land on the right side of the
+    split.
+    """
+
+    cache_server = fakeredis.FakeStrictRedis()
+    broker_server = fakeredis.FakeStrictRedis()
+
+    cache_server.rpush("uploads/1/abc", "x")
+    broker_server.rpush("enterprise_test", '{"task": "y"}')
+    # Guard against accidentally picking up keys from the wrong server
+    # — if routing were swapped, we'd see these under the wrong family.
+    cache_server.rpush("enterprise_wrong", '{"task": "leak"}')
+    broker_server.rpush("uploads/2/wrong", "leak")
+
+    def fake_get_connection(kind="default"):
+        return broker_server if kind == "broker" else cache_server
+
+    monkeypatch.setattr(redis_admin_conn, "get_connection", fake_get_connection)
+
+    classified = {k: f.name for k, f in iter_keys()}
+
+    # `uploads/` is the default-kind family → only the cache server's
+    # uploads/1/abc surfaces; uploads/2/wrong sits on the broker server
+    # and must not be visible.
+    assert classified.get("uploads/1/abc") == "uploads"
+    assert "uploads/2/wrong" not in classified
+
+    # `celery_broker` is the broker-kind family → only the broker
+    # server's enterprise_test surfaces; enterprise_wrong on the cache
+    # server is invisible to the admin.
+    assert classified.get("enterprise_test") == "celery_broker"
+    assert "enterprise_wrong" not in classified
+
+
+def test_iter_keys_with_explicit_redis_uses_single_client_for_all_families(
+    patched_redis,
+):
+    """Back-compat: passing an explicit redis bypasses per-family
+    routing and uses that one client for every family. This is the
+    shape every test in this module relies on (one fakeredis backs
+    cache + broker).
+    """
+
+    patched_redis.rpush("uploads/1/abc", "x")
+    patched_redis.rpush("enterprise_test", '{"task": "y"}')
+
+    classified = {k: f.name for k, f in iter_keys(patched_redis)}
+    assert classified["uploads/1/abc"] == "uploads"
+    assert classified["enterprise_test"] == "celery_broker"
 
 
 def test_celery_decode_value_extracts_task_repoid_commit():

--- a/apps/codecov-api/redis_admin/tests/test_item_queryset.py
+++ b/apps/codecov-api/redis_admin/tests/test_item_queryset.py
@@ -13,7 +13,9 @@ from redis_admin.models import RedisQueueItem
 @pytest.fixture
 def patched_redis(monkeypatch) -> fakeredis.FakeStrictRedis:
     server = fakeredis.FakeStrictRedis()
-    monkeypatch.setattr(redis_admin_conn, "get_connection", lambda: server)
+    monkeypatch.setattr(
+        redis_admin_conn, "get_connection", lambda kind="default": server
+    )
     return server
 
 

--- a/apps/codecov-api/redis_admin/tests/test_queryset.py
+++ b/apps/codecov-api/redis_admin/tests/test_queryset.py
@@ -19,7 +19,9 @@ from redis_admin.models import RedisQueue
 @pytest.fixture
 def patched_redis(monkeypatch) -> fakeredis.FakeStrictRedis:
     server = fakeredis.FakeStrictRedis()
-    monkeypatch.setattr(redis_admin_conn, "get_connection", lambda: server)
+    monkeypatch.setattr(
+        redis_admin_conn, "get_connection", lambda kind="default": server
+    )
     return server
 
 

--- a/apps/codecov-api/redis_admin/tests/test_services.py
+++ b/apps/codecov-api/redis_admin/tests/test_services.py
@@ -254,9 +254,7 @@ class TestRedisDeleteService(TestCase):
 
         original = redis_admin_conn.get_connection
         redis_admin_conn.get_connection = (  # type: ignore[assignment]
-            lambda kind="default": (
-                broker_server if kind == "broker" else cache_server
-            )
+            lambda kind="default": (broker_server if kind == "broker" else cache_server)
         )
         try:
             result = redis_delete(

--- a/apps/codecov-api/redis_admin/tests/test_services.py
+++ b/apps/codecov-api/redis_admin/tests/test_services.py
@@ -31,7 +31,9 @@ from shared.django_apps.codecov_auth.tests.factories import UserFactory
 @pytest.fixture
 def patched_redis(monkeypatch) -> fakeredis.FakeStrictRedis:
     server = fakeredis.FakeStrictRedis()
-    monkeypatch.setattr(redis_admin_conn, "get_connection", lambda: server)
+    monkeypatch.setattr(
+        redis_admin_conn, "get_connection", lambda kind="default": server
+    )
     return server
 
 
@@ -53,7 +55,9 @@ class TestRedisDeleteService(TestCase):
     def _patch_connection(self):
         # Module-level monkeypatch so the service sees our fakeredis.
         original = redis_admin_conn.get_connection
-        redis_admin_conn.get_connection = lambda: self.server  # type: ignore
+        redis_admin_conn.get_connection = (  # type: ignore[assignment]
+            lambda kind="default": self.server
+        )
         self.addCleanup(setattr, redis_admin_conn, "get_connection", original)
         return None
 
@@ -227,6 +231,57 @@ class TestRedisDeleteService(TestCase):
         message = json.loads(entries.first().change_message)
         assert message["count"] == 0
         assert "upload_lock_1_abc" in message["refused"]
+
+    def test_mixed_family_delete_routes_to_per_kind_redis(self):
+        """A single redis_delete that spans cache + broker families
+        must dispatch each batch against the Redis instance that owns
+        those keys. We model the production split with two fakeredis
+        servers and verify keys are deleted on the matching side and
+        untouched on the other.
+        """
+
+        cache_server = fakeredis.FakeStrictRedis()
+        broker_server = fakeredis.FakeStrictRedis()
+
+        cache_server.rpush("uploads/1/abc", "x")
+        broker_server.rpush("enterprise_test", "y")
+        # Cross-server "ghosts" — keys with a name that *would* belong
+        # to the other family but living on the wrong Redis. They must
+        # be left untouched, since the service should never try to
+        # DEL a cache-family key against the broker (and vice versa).
+        cache_server.rpush("enterprise_ghost", "ghost-1")
+        broker_server.rpush("uploads/2/ghost", "ghost-2")
+
+        original = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = (  # type: ignore[assignment]
+            lambda kind="default": (
+                broker_server if kind == "broker" else cache_server
+            )
+        )
+        try:
+            result = redis_delete(
+                [
+                    _make_queue("uploads/1/abc"),
+                    _make_queue(
+                        "enterprise_test",
+                        family="celery_broker",
+                        redis_type="LIST",
+                    ),
+                ],
+                user=self.user,
+                dry_run=False,
+            )
+        finally:
+            redis_admin_conn.get_connection = original  # type: ignore[assignment]
+
+        assert result.count == 2
+        # Targeted keys gone from their respective servers...
+        assert cache_server.exists("uploads/1/abc") == 0
+        assert broker_server.exists("enterprise_test") == 0
+        # ...and the cross-server ghosts are still intact, proving the
+        # delete didn't fan out into the wrong instance.
+        assert cache_server.exists("enterprise_ghost") == 1
+        assert broker_server.exists("uploads/2/ghost") == 1
 
     def test_item_delete_refuses_celery_lists(self):
         """Bugbot PR #888: `_classify_items` used `item.raw_value` as


### PR DESCRIPTION
## Summary

The codecov production deployment runs two distinct Memorystore Redis instances — a "cache" Redis at `services.redis_url` and a separate Celery broker at `services.celery_broker` (see `terraform/codecov/cluster/secrets.tf`, which provisions `google_redis_instance.cache` and `google_redis_instance.celery` separately and exposes them via `…-memorystore-url` and `…-memorystore-celery-url` Secret Manager entries respectively). The api pod already loads both URLs into env (`SERVICES__REDIS_URL` and `SERVICES__CELERY_BROKER` in `k8s-v2/charts/codecovApi/conf/env.yaml`), but `redis_admin` only ever opened the cache Redis.

The visible symptom of this split: filtering the changelist by `family=celery_broker` returned zero rows in production, even when KEDA + Grafana reported a 195k-deep `bundles_analysis` backlog. The Celery queue keys live on the broker Redis, which the admin had no way to reach.

This PR teaches `redis_admin` to route each family at the connection layer:

- **`redis_admin.conn`**
  - `get_connection(kind=...)` accepts `"default"` (existing behavior; cache Redis via `shared.helpers.redis.get_redis_connection`) or `"broker"` (Celery broker via `services.celery_broker`).
  - `_broker_connection()` falls back to `services.redis_url` when `services.celery_broker` is unset, mirroring `BaseCeleryConfig` so single-Redis dev / enterprise deploys keep working without extra config.
  - New `REDIS_ADMIN_BROKER_CONNECTION_FACTORY` setting parallels the existing default override hook for tests / operator escape hatches.
- **`Family.connection_kind`** marks which Redis a family lives on. `celery_broker` opts in to `"broker"`; everything else stays on `"default"`.
- **`iter_keys`** lazily resolves a client per `family.connection_kind` (with a per-call cache so each kind is opened at most once). Passing an explicit `redis` keeps existing single-fakeredis test fixtures working unchanged.
- **`RedisQueueQuerySet._fetch_all`**, **`RedisItemQuerySet`**, **`services.redis_delete`**, and **`admin._resolve_scope_targets`** all dispatch each Redis call against the right client. Mixed-family deletes bucket their pipelines so a clear-by-scope sweep DELs cache-Redis keys and broker-Redis keys on their respective instances (and never cross-fires).

## Tests

- `redis_admin/tests/test_conn.py` (new): factory overrides per kind, unknown kind raises, broker fallback to `services.redis_url`, broker prefers `services.celery_broker` when set.
- `redis_admin/tests/test_families.py`:
  - Contract test that `celery_broker` is the only broker-kind family.
  - `iter_keys()` (no explicit redis) routes across two fakeredis servers — uploads land on the default server, broker queues on the broker server, and ghost keys on the wrong server stay invisible.
  - Back-compat: passing an explicit redis still uses one client for all families.
- `redis_admin/tests/test_services.py`: `redis_delete` with mixed cache + broker targets DELs each on its own server and leaves cross-server "ghost" keys intact.
- All existing tests still pass; the only mechanical change to other test fixtures is updating the `lambda: server` patches to `lambda kind="default": server` so they accept the new keyword.

```
86 passed in 0.36s
```

(Service / admin smoke tests need Postgres and run in CI.)

## Test plan

- [ ] CI green
- [ ] Confirm in staging that the api pod's service account can read the `…-memorystore-celery-url` secret (the env binding already exists, so this should be a no-op, but worth verifying the IAM grant to be safe).
- [ ] After merge, deploy and verify the changelist surfaces the bundle-analysis Celery backlog under `family=celery_broker` (matching the depth Grafana / KEDA report).
- [ ] Sanity check single-Redis enterprise deploys via the `_broker_connection` fallback (broker URL unset → falls back to `services.redis_url`).

## Background

Investigation thread: a `family=celery_broker` filter showed zero rows in the changelist while Grafana reported ~195k items in the `bundles_analysis` Celery queue. Walking through `k8s-v2` and `terraform/codecov/cluster` confirmed two distinct Memorystore instances; the admin's `_conn.get_connection()` always read from the cache Redis, so the broker keys were structurally invisible.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which Redis instance admin reads/writes for some operations (including deletes), so misrouting could hide keys or delete from the wrong cluster; mitigated by per-kind client caching and added unit tests around routing and fallbacks.
> 
> **Overview**
> `redis_admin` now supports **multiple Redis connection kinds** and routes operations per key-family so the `celery_broker` queues are read and cleared from the Celery broker Redis instead of the default cache Redis.
> 
> This updates key enumeration (`iter_keys`), queue/item querysets, admin clear-by-scope, and `redis_delete` to pick the correct client (with per-kind client caching) and adds a broker connection implementation with a `services.celery_broker`→`services.redis_url` fallback plus a new `REDIS_ADMIN_BROKER_CONNECTION_FACTORY` override; tests are expanded/added to cover routing behavior and keep existing fakeredis patches compatible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffbc6d6e60c0311cad1ad7d9912f77f5e6f91041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->