### PR TITLE
fix(api): redis_admin follow-up review fixes from PRs #885-#890

### DIFF
--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -68,10 +68,16 @@ def _render_items_inline(obj, *, max_rows: int = _ITEMS_PREVIEW_MAX_ROWS):
     snapshot = list(items_qs[:max_rows])
 
     full_url = reverse("admin:redis_admin_redisqueueitem_changelist")
+    # URL-encode the queue name so keys containing `&`, `#`, `?`, or other
+    # query-meaningful characters round-trip cleanly into the items
+    # changelist filter (`format_html` only HTML-escapes; it doesn't
+    # percent-encode). Mirrors the `items_link` helper on
+    # `RedisQueueAdmin`, which already uses `urlencode`.
+    full_link_query = urlencode({"queue_name__exact": obj.name})
     full_link = format_html(
-        '<a href="{}?queue_name__exact={}">view all items \u2192</a>',
+        '<a href="{}?{}">view all items \u2192</a>',
         full_url,
-        obj.name,
+        full_link_query,
     )
 
     heading = format_html("<h2>{}</h2>", "Items")

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -33,11 +33,12 @@ log = logging.getLogger(__name__)
 
 RedisType = Literal["list", "set", "hash", "string"]
 
-# Which Redis connection a family lives on. `default` = cache Redis at
-# `services.redis_url`; `broker` = Celery broker at
-# `services.celery_broker`, which is a separate Memorystore instance in
-# production. See `redis_admin.conn` for the URL plumbing.
-ConnectionKind = Literal["default", "broker"]
+# Which Redis connection a family lives on. Re-exported from
+# `redis_admin.conn` so callers can keep their `ConnectionKind`
+# imports family-shaped (`from .families import ConnectionKind`)
+# without spawning a duplicate definition that could silently drift
+# from the canonical one in `conn.py`.
+ConnectionKind = _conn.ConnectionKind
 
 
 @dataclass(frozen=True)

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -22,8 +22,32 @@ import sentry_sdk
 from . import conn as _conn
 from . import settings as redis_admin_settings
 from .families import Family, find_family, iter_keys
+from .families import _decode as _decode_value  # noqa: PLC2701 - shared helper
 
 _UNSET: Any = object()
+
+
+def _ordering_key(obj: Any, attr: str) -> tuple:
+    """Sort key tolerant of `None` on mixed-type columns.
+
+    `list_display` columns like `report_type` are nullable strings:
+    rows from the `uploads` family populate them with `"coverage"` /
+    `"test_results"` while `ta_flake_key` rows leave them as `None`.
+    Python 3 won't compare `str` and `int`, so the previous
+    `getattr(obj, attr) or 0` sort key crashed with `TypeError` as
+    soon as one row's column was `None` and another's was a string
+    (Bugbot review on PR #887).
+
+    Returning a 2-tuple `(is_none, value_or_blank)` keeps `None` rows
+    grouped together (sorted last), and the inner `value_or_blank` is
+    only ever compared between two non-None values of the same
+    underlying field — so the comparison stays type-consistent.
+    """
+
+    value = getattr(obj, attr, None)
+    if value is None:
+        return (1, "")
+    return (0, value)
 
 
 def _build_redis_queue(model, key: str, family: Family, redis) -> Any:
@@ -64,13 +88,21 @@ def _build_redis_queue(model, key: str, family: Family, redis) -> Any:
 
 # Filter kwargs `RedisQueueQuerySet.filter()` understands; everything else
 # raises NotImplementedError so missing functionality is loud, not silent.
+#
+# Note on commitid: bare `commitid=` and `commitid__startswith=` map to
+# `commitid_prefix`, while `commitid__exact=` maps to its own
+# `commitid_exact` bucket. Both still pushdown the supplied value into
+# the SCAN MATCH (an exact value is a valid prefix), but the post-scan
+# predicate enforces equality vs. prefix so `__exact` keeps its Django
+# semantics — see Bugbot review on PR #887, where `__exact` was silently
+# behaving as a prefix match.
 _QUEUE_FILTER_KEYS: dict[str, str] = {
     "family": "family",
     "family__exact": "family",
     "repoid": "repoid",
     "repoid__exact": "repoid",
     "commitid": "commitid_prefix",
-    "commitid__exact": "commitid_prefix",
+    "commitid__exact": "commitid_exact",
     "commitid__startswith": "commitid_prefix",
     "report_type": "report_type",
     "report_type__exact": "report_type",
@@ -264,6 +296,12 @@ class RedisQueueQuerySet:
         commitid_prefix = f.get("commitid_prefix")
         if commitid_prefix and not (obj.commitid or "").startswith(commitid_prefix):
             return False
+        # `commitid__exact` shares the SCAN pushdown with `__startswith`
+        # (an exact value is a valid prefix), but enforces equality
+        # post-scan so its Django semantics are preserved.
+        commitid_exact = f.get("commitid_exact")
+        if commitid_exact and (obj.commitid or "") != commitid_exact:
+            return False
         # Families without a repoid in their key shape (e.g. intermediate-
         # report) opt out of repoid SCAN pushdown by returning None from
         # `pattern_for`, but a defensive post-scan check guards future
@@ -322,12 +360,20 @@ class RedisQueueQuerySet:
             # Don't pass an explicit redis to iter_keys here so it routes
             # SCAN / EXISTS against the connection each family owns. The
             # builder picks the matching client per yielded family.
+            #
+            # `commitid__exact` value is a valid prefix for SCAN MATCH
+            # purposes (an exact 40-char SHA tightens the pattern even
+            # more than a prefix); the post-scan predicate is what
+            # actually enforces the exact-vs-prefix semantic split.
+            scan_commitid = self._filters.get("commitid_prefix") or self._filters.get(
+                "commitid_exact"
+            )
             items = [
                 _build_redis_queue(self.model, key, family, _client_for(family))
                 for key, family in iter_keys(
                     family=self._filters.get("family"),
                     repoid=self._filters.get("repoid"),
-                    commitid_prefix=self._filters.get("commitid_prefix"),
+                    commitid_prefix=scan_commitid,
                     category=self._category,
                 )
             ]
@@ -338,7 +384,7 @@ class RedisQueueQuerySet:
             reverse = field.startswith("-")
             attr = field.lstrip("-")
             items.sort(
-                key=lambda obj, attr=attr: getattr(obj, attr) or 0, reverse=reverse
+                key=lambda obj, attr=attr: _ordering_key(obj, attr), reverse=reverse
             )
 
         self._result_cache = items
@@ -391,15 +437,6 @@ class RedisQueueQuerySet:
     @property
     def db(self) -> str:
         return "default"
-
-
-def _decode_value(value: bytes | str) -> str:
-    if isinstance(value, bytes):
-        try:
-            return value.decode("utf-8")
-        except UnicodeDecodeError:
-            return value.decode("utf-8", errors="replace")
-    return value
 
 
 def _truncate_for_display(value: str, *, cap: int | None = None) -> str:

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -440,7 +440,37 @@ class RedisQueueAdminChangePageTest(TestCase):
             in body
         )
         # And the footer link points at the full items changelist.
-        assert "queue_name__exact=uploads/123/abc123" in body
+        # The queue name is `urlencode`'d so `/` round-trips as `%2F`,
+        # matching the `items_link` column on the changelist (and the
+        # behaviour of every other URL-building admin helper).
+        assert "queue_name__exact=uploads%2F123%2Fabc123" in body
+
+    def test_inline_items_preview_url_encodes_special_chars_in_queue_name(self):
+        """Regression for the Bugbot review on PR #888: `_render_items_inline`
+        embedded `obj.name` directly into a query string via `format_html`,
+        which only HTML-escapes — keys containing `&` or `#` would split the
+        query parameter and silently land the operator on the wrong items
+        view. The footer link must round-trip the full key via `urlencode`.
+        """
+
+        # `&` would otherwise terminate the `queue_name__exact` value.
+        weird_key = "uploads/1/sha&extra#frag"
+        self.redis.rpush(weird_key, "payload")
+
+        # The change-form URL still uses Django admin's `quote` (`/` →
+        # `_2F`, `&` → `_26`, `#` → `_23`) for the path component.
+        encoded_pk = "uploads_2F1_2Fsha_26extra_23frag"
+        response = self.client.get(
+            f"/admin/redis_admin/redisqueue/{encoded_pk}/change/"
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # The footer "view all items →" link percent-encodes each
+        # special character. The naked key would surface as a substring
+        # of the bare anchor href — and would split the query string in
+        # browsers — so insist on the encoded form.
+        assert "queue_name__exact=uploads%2F1%2Fsha%26extra%23frag" in body
 
     def test_change_page_renders_inline_items_preview_for_string_key(self):
         # `latest_upload/<repoid>/<sha>` is a STRING; the held value

--- a/apps/codecov-api/redis_admin/tests/test_queryset.py
+++ b/apps/codecov-api/redis_admin/tests/test_queryset.py
@@ -178,6 +178,65 @@ def test_queryset_populates_repoid_commitid_report_type(patched_redis):
     assert flake_row.commitid is None
 
 
+def test_queryset_filter_by_commitid_exact_does_not_match_prefix(patched_redis):
+    """`commitid__exact` must do exact matching, not prefix matching.
+
+    Regression for the Bugbot review on PR #887: `commitid__exact` was
+    silently mapped onto the `commitid_prefix` post-scan predicate, so
+    `filter(commitid__exact="abc")` matched `"abcdef"` too. Operators
+    drilling in via the admin's `?commitid__exact=…` URL parameter
+    expected Django's standard `__exact` semantics.
+    """
+
+    patched_redis.rpush("uploads/1/abc", "x")
+    patched_redis.rpush("uploads/1/abcdef", "x")
+    patched_redis.rpush("uploads/1/abczzz", "x")
+
+    rows = list(RedisQueue.objects.filter(commitid__exact="abc"))
+    assert {r.name for r in rows} == {"uploads/1/abc"}
+
+
+def test_queryset_commitid_exact_and_startswith_have_distinct_semantics(patched_redis):
+    """`commitid__exact` and `commitid__startswith` must not alias."""
+
+    patched_redis.rpush("uploads/1/abc", "x")
+    patched_redis.rpush("uploads/1/abcdef", "x")
+
+    exact = {r.name for r in RedisQueue.objects.filter(commitid__exact="abc")}
+    starts = {r.name for r in RedisQueue.objects.filter(commitid__startswith="abc")}
+
+    assert exact == {"uploads/1/abc"}
+    assert starts == {"uploads/1/abc", "uploads/1/abcdef"}
+
+
+def test_queryset_sort_by_nullable_string_field_does_not_crash(patched_redis):
+    """Sorting a column that mixes string and `None` values must not crash.
+
+    Regression for the Bugbot review on PR #887: the previous
+    `getattr(obj, attr) or 0` sort key produced `int(0)` for `None`
+    rows and a `str` for populated ones, raising `TypeError` from
+    Python 3's `<` between `int` and `str` as soon as both row shapes
+    coexisted (e.g. an `uploads` row with `report_type="coverage"` and
+    a `ta_flake_key` row with `report_type=None`).
+    """
+
+    patched_redis.rpush("uploads/1/sha/coverage", "x")
+    patched_redis.rpush("uploads/1/sha/test_results", "x")
+    patched_redis.rpush("ta_flake_key:1", "x")
+
+    rows = list(RedisQueue.objects.all().order_by("report_type"))
+    names = [r.name for r in rows]
+
+    assert set(names) == {
+        "uploads/1/sha/coverage",
+        "uploads/1/sha/test_results",
+        "ta_flake_key:1",
+    }
+    # `None` rows sort last, so the populated rows come first in
+    # whatever order their string values dictate.
+    assert names[-1] == "ta_flake_key:1"
+
+
 def test_max_scan_keys_limits_result_set(patched_redis, settings, monkeypatch):
     settings.REDIS_ADMIN_MAX_SCAN_KEYS = 3
     # `families.iter_keys` reads MAX_SCAN_KEYS off the redis_admin settings


### PR DESCRIPTION
## Summary

Sweeps up Bugbot review comments that landed on the `redis_admin` milestone PRs (#885, #887, #888, #889, #890) but didn't make it into the original commits before they merged.

### Bug fixes

- **`commitid__exact` now actually does an exact match** (review on #887). The filter map pointed both `commitid__exact` and `commitid__startswith` at the same `commitid_prefix` bucket, so `?commitid__exact=abc` would silently surface every commit whose SHA *starts with* `abc`. The new `commitid_exact` bucket keeps the SCAN MATCH pushdown (an exact value is still a valid prefix) but enforces equality in the post-scan predicate.
- **Sorting on nullable string columns no longer crashes with `TypeError`** (review on #887). The previous sort key (`getattr(obj, attr) or 0`) returned the int `0` for `None` rows, which Python 3 refuses to compare against actual strings like `"coverage"` / `"test_results"`. The new `_ordering_key` helper returns a `(is_none, value_or_blank)` tuple so `None` rows group together and same-typed values do the actual comparison.
- **Inline items preview URL-encodes the queue name** (review on #888). The "view all items →" footer link previously embedded `obj.name` via `format_html`, which only HTML-escapes — keys containing `&`, `#`, or `?` would split the query string and land the operator on the wrong items view. Now mirrors the `items_link` helper, which already used `urlencode`.

### Cleanup

- **Dedupes `_decode_value`** (review on #887). The queryset module had a byte-for-byte copy of `families._decode`; it now imports the canonical helper.
- **Dedupes `ConnectionKind`** (review on #890). The literal `Literal[\"default\", \"broker\"]` was defined identically in both `conn.py` and `families.py`; either one could drift. `families.py` now re-exports the canonical `conn.ConnectionKind` so existing `from .families import ConnectionKind` call sites keep working.

## Test plan

- [x] `pytest redis_admin/tests/` — 160 passed, including the four new regressions:
  - `test_queryset_filter_by_commitid_exact_does_not_match_prefix`
  - `test_queryset_commitid_exact_and_startswith_have_distinct_semantics`
  - `test_queryset_sort_by_nullable_string_field_does_not_crash`
  - `test_inline_items_preview_url_encodes_special_chars_in_queue_name`
- [x] `ruff check` / `ruff format --check` clean on `apps/codecov-api/redis_admin/`.
- [ ] Smoke test in staging admin: filter by `?commitid__exact=<full-sha>` (exact match), sort the changelist by a nullable column without 500ing, click "view all items →" on a queue whose name contains `&` / `#`.

## Related

- #885, #887, #888, #889, #890

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin/queryset logic used for operational Redis inspection and deletion workflows; changes are localized but affect filtering semantics and link generation, so regressions could mislead operators or break admin pages.
> 
> **Overview**
> Fixes `redis_admin` admin/queryset correctness issues discovered in follow-up reviews: `commitid__exact` now enforces true exact-match semantics (while still using SCAN prefix pushdown), and changelist ordering no longer crashes when sorting nullable string columns.
> 
> Hardens the queue change-page inline items preview by percent-encoding `queue_name__exact` in the “view all items” footer link so keys containing special query characters round-trip safely.
> 
> Includes small cleanup to avoid drift by re-exporting `ConnectionKind` from `conn.py` and reusing the canonical `_decode` helper, plus adds regression tests covering these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41688844636312aef2efb8a48d54727fe8f26ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->