### PR TITLE
feat(api): redis_admin filter by celery queue name

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -151,6 +151,23 @@ All configurable via `REDIS_ADMIN_*` Django settings; defaults shown.
 | `REDIS_ADMIN_MAX_DECODE_BYTES` | `4_096` | Per-value display truncation. |
 | `REDIS_ADMIN_DELETE_BATCH_SIZE` | `500` | Pipeline batch size for `DEL` / `LREM` / `SREM` / `HDEL`. |
 | `REDIS_ADMIN_CONNECTION_FACTORY` | unset | Dotted path to a callable returning a `redis.Redis`. Defaults to `shared.helpers.redis.get_redis_connection`. |
+| `REDIS_ADMIN_BROKER_CONNECTION_FACTORY` | unset | Dotted path for the Celery broker connection. Defaults to building a client from `services.celery_broker` (falls back to `services.redis_url` for single-Redis dev/enterprise). |
+
+The `celery_broker` family also reads one shared-config knob (not a
+Django setting) to learn which Celery queue names to enumerate
+beyond the `BaseCeleryConfig` defaults:
+
+| Config key | Form | Purpose |
+|---|---|---|
+| `setup.redis_admin.celery_queues` | comma-separated string or list | Operator-supplied list of broker queue names (e.g. `uploads,notify,sync,...`). Reads via `shared.config.get_config("setup", "redis_admin", "celery_queues")`, so an env var like `SETUP__REDIS_ADMIN__CELERY_QUEUES=...` works on the API pod. The actual production list lives in private deployment config (it varies per environment), so this isn't shipped with defaults. Each name is `EXISTS`-checked before being yielded — listing a queue that doesn't exist is harmless. |
+
+Without this set the admin's `celery_broker` family only sees
+`celery`, `healthcheck`, and whatever the `enterprise_*` SCAN
+matches; queues like `uploads` / `notify` / `sync` stay invisible
+even when the broker has them, because the API pod doesn't carry
+the worker-side `setup.tasks.*.queue` env vars and so
+`BaseCeleryConfig.task_routes` resolves every route to
+`task_default_queue`.
 
 ## Adding a new family
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -34,6 +34,9 @@ from core.models import Repository
 from . import conn as _conn
 from . import settings as redis_admin_settings
 from .families import FAMILIES, iter_keys
+from .families import (
+    _resolve_celery_queue_names as _celery_queue_names,  # noqa: PLC2701 - reused for filter lookups
+)
 from .models import RedisLock, RedisQueue, RedisQueueItem
 from .queryset import RedisItemQuerySet, _build_redis_queue
 from .services import redis_delete
@@ -237,6 +240,55 @@ class ReportTypeFilter(admin.SimpleListFilter):
         return queryset
 
 
+class CeleryQueueFilter(admin.SimpleListFilter):
+    """Narrow the changelist to a single Celery broker queue.
+
+    The well-known Celery queues (`celery`, `healthcheck`, plus anything
+    routed via `BaseCeleryConfig.task_routes[...]['queue']`) show up
+    one-per-row in the Codecov health-overview Grafana dashboard, so an
+    on-call engineer who sees `notify_celery` spike in Grafana would
+    otherwise have to either remember the exact key name or hand-type
+    `family:celery_broker name:notify_celery` into the search bar.
+
+    This filter surfaces the same enumeration `families.celery_broker`
+    uses for its `fixed_keys`, so the picker is always in sync with the
+    queues the admin can actually inspect — adding a new queue to
+    `task_routes` automatically adds it to the filter on next request.
+
+    Selecting a queue narrows the changelist to a single row
+    (`family__exact=celery_broker AND name__exact=<queue>`); the
+    well-known queues are unique by name so this collapses cleanly to
+    "the row for that queue".
+
+    Dynamic `enterprise_*` queues aren't enumerable from configuration
+    and are intentionally excluded from the dropdown — operators who
+    need them can keep using the search bar (`family:celery_broker
+    enterprise_acme`) which already handles substring match.
+    """
+
+    title = "celery queue"
+    parameter_name = "celery_queue"
+
+    def lookups(self, request, model_admin):
+        # Re-resolved per request so a config change picks up without
+        # requiring a worker restart; `_celery_queue_names` itself
+        # falls back to `("celery", "healthcheck")` if the celery
+        # config import fails, so the dropdown is never empty.
+        return tuple((name, name) for name in _celery_queue_names())
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if not value:
+            return queryset
+        # Pin the family alongside the name so a stray collision with a
+        # non-celery key (theoretically possible if some other family
+        # ever picked a name matching a celery queue) can't silently
+        # surface the wrong row. Family + name__exact also lets the
+        # underlying queryset short-circuit to a single GET / TYPE
+        # round-trip rather than a full SCAN sweep.
+        return queryset.filter(family__exact="celery_broker", name__exact=value)
+
+
 # ---- Helpers ---------------------------------------------------------------
 
 
@@ -292,7 +344,7 @@ class RedisQueueAdmin(admin.ModelAdmin):
         "report_type",
         "items_link",
     )
-    list_filter = (FamilyFilter, MinDepthFilter, ReportTypeFilter)
+    list_filter = (FamilyFilter, CeleryQueueFilter, MinDepthFilter, ReportTypeFilter)
     list_per_page = 50
     show_full_result_count = False
     ordering = ("-depth", "name")

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -280,12 +280,15 @@ class CeleryQueueFilter(admin.SimpleListFilter):
         value = self.value()
         if not value:
             return queryset
-        # Pin the family alongside the name so a stray collision with a
-        # non-celery key (theoretically possible if some other family
-        # ever picked a name matching a celery queue) can't silently
-        # surface the wrong row. Family + name__exact also lets the
-        # underlying queryset short-circuit to a single GET / TYPE
-        # round-trip rather than a full SCAN sweep.
+        # `name__exact` lets `RedisQueueQuerySet._fetch_all` take the
+        # EXISTS-only shortcut (single GET / TYPE round-trip; no SCAN
+        # sweep), the same path admin bulk actions use for `pk__in=`.
+        # The `family__exact` guard is enforced post-resolve in
+        # `_post_scan_predicate`: if `find_family(<queue>)` ever
+        # routed the name to a non-celery family (theoretically
+        # possible if some other family adopted a colliding fixed_key),
+        # the row would be filtered out rather than silently surfacing
+        # under the wrong family.
         return queryset.filter(family__exact="celery_broker", name__exact=value)
 
 

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -203,7 +203,7 @@ def _operator_configured_celery_queues() -> tuple[str, ...]:
         return ()
     if isinstance(raw, str):
         candidates: Iterable[str] = raw.split(",")
-    elif isinstance(raw, (list, tuple, set)):
+    elif isinstance(raw, list | tuple | set):
         candidates = raw
     else:  # pragma: no cover - defensive
         log.warning(

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -19,11 +19,13 @@ import base64
 import fnmatch
 import json
 import logging
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import sentry_sdk
+
+from shared.config import get_config
 
 from . import conn as _conn
 from . import settings as redis_admin_settings
@@ -175,25 +177,80 @@ def _parse_celery_broker_key(_: str) -> ParsedKey:
     return ParsedKey(family="celery_broker")
 
 
+def _operator_configured_celery_queues() -> tuple[str, ...]:
+    """Read the deployment's declared list of Celery queue names.
+
+    The actual production queue topology lives in private deployment
+    config (`setup.tasks.*.queue` env vars on worker pods). The API
+    pod doesn't get those, so `BaseCeleryConfig.task_routes` inside
+    the API process resolves every route to `task_default_queue`
+    (`"celery"`) and the admin can't see queues like `uploads`,
+    `notify`, `sync`, etc. — even though they exist on the broker.
+
+    Operators close that gap by setting
+
+        SETUP__REDIS_ADMIN__CELERY_QUEUES="uploads,notify,sync,..."
+
+    on the API pod (or the equivalent in `codecov.yaml`). The names
+    are deployment-specific and intentionally not committed to this
+    OSS repo. `iter_keys` runs `EXISTS` against every entry, so
+    listing a queue that doesn't exist in Redis is harmless: it just
+    won't show up in the admin.
+    """
+
+    raw = get_config("setup", "redis_admin", "celery_queues", default=None)
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        candidates: Iterable[str] = raw.split(",")
+    elif isinstance(raw, (list, tuple, set)):
+        candidates = raw
+    else:  # pragma: no cover - defensive
+        log.warning(
+            "setup.redis_admin.celery_queues has unexpected type %s; ignoring",
+            type(raw).__name__,
+        )
+        return ()
+    cleaned = [str(name).strip() for name in candidates]
+    return tuple(name for name in cleaned if name)
+
+
 def _resolve_celery_queue_names() -> tuple[str, ...]:
     """Best-effort enumeration of the well-known Celery queue names.
 
-    Reads from the live `BaseCeleryConfig` so we pick up any queues an
-    operator configured via `setup.tasks.*.queue`. Falls back to the two
-    documented defaults if the import fails (e.g. during tests or in a
-    minimal environment).
+    Combines, in order of authority:
+
+    1. `setup.redis_admin.celery_queues` from the running config —
+       the deployment-specific list operators populate (see
+       `_operator_configured_celery_queues`). This is how a
+       production API pod learns about queues like `uploads` /
+       `notify` / `sync` that aren't reachable via
+       `BaseCeleryConfig` because the API doesn't carry the
+       worker-side `setup.tasks.*.queue` env vars.
+    2. `BaseCeleryConfig.task_routes[*]['queue']` — picks up any
+       queues *this* process has been told about via
+       `setup.tasks.*.queue` (rare in the API, normal in workers).
+    3. `task_default_queue` / `health_check_default_queue` so the
+       `celery` / `healthcheck` names are always present even on a
+       bare-bones deploy that hasn't set anything else.
+
+    Falls back to just (1) + the hardcoded `("celery",
+    "healthcheck")` defaults if `BaseCeleryConfig` can't be imported
+    (e.g. minimal-env tests).
     """
+
+    names: set[str] = set(_operator_configured_celery_queues())
 
     try:
         from shared.celery_config import BaseCeleryConfig  # noqa: PLC0415
     except Exception:  # pragma: no cover - defensive: any import error
         log.warning(
             "redis_admin: could not import BaseCeleryConfig; "
-            "using ('celery', 'healthcheck') only"
+            "falling back to operator-configured queues plus defaults"
         )
-        return ("celery", "healthcheck")
+        names.update(("celery", "healthcheck"))
+        return tuple(sorted(names))
 
-    names: set[str] = set()
     names.add(getattr(BaseCeleryConfig, "task_default_queue", "celery") or "celery")
     names.add(
         getattr(BaseCeleryConfig, "health_check_default_queue", "healthcheck")

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -281,6 +281,18 @@ class RedisQueueQuerySet:
 
     def _post_scan_predicate(self, obj: Any) -> bool:
         f = self._filters
+        # Family pushdown happens in `iter_keys`, but the `name_exact` /
+        # `name_in` shortcut in `_fetch_all` skips that and resolves
+        # ownership purely via `find_family(name)`. Without re-checking
+        # here, a `family__exact=celery_broker name__exact=<queue>`
+        # filter (the shape `CeleryQueueFilter` builds) would silently
+        # surface the wrong row if some other family ever picked a
+        # name colliding with a celery queue. Cheap belt-and-braces
+        # check; harmless for the SCAN path where `iter_keys` already
+        # filtered by family.
+        family = f.get("family")
+        if family and obj.family != family:
+            return False
         depth_gte = f.get("depth_gte")
         if depth_gte is not None and (obj.depth or 0) < depth_gte:
             return False

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -18,6 +18,9 @@ from django.contrib.admin.models import LogEntry
 from django.test import TestCase
 
 from redis_admin import conn as redis_admin_conn
+from redis_admin.families import (
+    _resolve_celery_queue_names as _celery_queue_names,  # noqa: PLC2701
+)
 from shared.django_apps.codecov_auth.tests.factories import UserFactory
 from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
 from utils.test_utils import Client
@@ -321,6 +324,93 @@ class RedisAdminFiltersAndSearchTest(TestCase):
         body = response.content.decode("utf-8")
         # Fallback is the em-dash placeholder.
         assert "—" in body
+
+    def _populate_celery_queues(self):
+        """Push one envelope onto each well-known Celery broker queue
+        plus an unrelated `uploads/` row so we can prove the filter
+        narrows by *both* family and name."""
+
+        self._celery_names = _celery_queue_names()
+        # Every well-known queue gets at least one item so it shows up
+        # on the changelist (zero-depth queues are filtered out by
+        # `iter_keys` since the underlying key doesn't exist).
+        for name in self._celery_names:
+            self.redis.rpush(name, "envelope")
+        # An unrelated non-celery row so a working filter must
+        # actively *exclude* it, not just include the celery row.
+        self.redis.rpush("uploads/1/sha", "x")
+
+    def test_celery_queue_filter_narrows_changelist_to_single_queue(self):
+        """The filter mirrors the Codecov health-overview Grafana dashboard:
+        an operator who sees `notify_celery` spike in Grafana clicks the
+        sidebar entry and lands on a single-row changelist for that key,
+        rather than scrolling through the full broker family."""
+
+        self._populate_celery_queues()
+        # Pick a queue that's guaranteed present (the default queue is
+        # always emitted by `_resolve_celery_queue_names`, even when
+        # the Celery config import falls through to its hardcoded
+        # fallback).
+        target = "celery"
+        assert target in self._celery_names
+
+        response = self.client.get(
+            "/admin/redis_admin/redisqueue/", {"celery_queue": target}
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert target in body
+        # Other celery queues must be filtered out — the whole point of
+        # surfacing this in the sidebar is that operators rarely care
+        # about more than one queue at a time.
+        for other in self._celery_names:
+            if other == target:
+                continue
+            # `assertNotContains` would also match incidental substring
+            # collisions inside the page chrome (e.g. CSS class names);
+            # tighten the check to "isn't rendered as a changelist row
+            # value" by looking for the per-row anchor href the admin
+            # builds for each key.
+            assert f"/admin/redis_admin/redisqueue/{other}/change/" not in body, (
+                f"expected only `{target}`, also saw `{other}` in changelist"
+            )
+        # And non-celery rows must be filtered out — the filter pins
+        # `family__exact=celery_broker` alongside `name__exact=...`.
+        assert "uploads/1/sha" not in body
+
+    def test_celery_queue_filter_dropdown_lists_well_known_queue_names(self):
+        """The filter's lookups mirror `BaseCeleryConfig`'s queue set, so
+        adding a queue to `task_routes` automatically makes it pickable
+        in the sidebar — operators don't have to wait on a code change
+        to admin filters."""
+
+        # The lookups render as `<a href=\"...?celery_queue=<name>\">`
+        # links in the sidebar; pull the names out of the live config
+        # and assert each one is offered as a filter choice.
+        self._populate_celery_queues()
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        for name in _celery_queue_names():
+            assert f"celery_queue={name}" in body, (
+                f"expected `{name}` to appear as a celery_queue filter choice"
+            )
+
+    def test_celery_queue_filter_with_no_value_returns_full_changelist(self):
+        """Sanity check that the filter is opt-in: omitting the param
+        leaves the queryset alone, so the celery filter doesn't
+        secretly hide other families when nothing is selected."""
+
+        self._populate_celery_queues()
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # The unrelated `uploads/` row is back, alongside celery rows.
+        assert "uploads/1/sha" in body
+        assert "celery" in body
 
 
 class RedisLockAdminSmokeTest(TestCase):

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -231,6 +231,74 @@ def test_celery_broker_family_resolves_known_queue_names():
     assert "healthcheck" in family.fixed_keys
 
 
+def test_resolve_celery_queue_names_includes_operator_configured_queues(monkeypatch):
+    """Real production queues (`uploads`, `notify`, `sync`, ...) live in
+    private deployment config, not in the OSS `BaseCeleryConfig`. The
+    API pod surfaces them via `setup.redis_admin.celery_queues`. Without
+    this we silently miss every non-default queue on the broker — the
+    exact regression that motivated this change.
+    """
+
+    from redis_admin import families as families_mod  # noqa: PLC0415
+
+    config_overrides = {
+        ("setup", "redis_admin", "celery_queues"): "uploads, notify ,sync,",
+    }
+
+    def fake_get_config(*keys, default=None):
+        return config_overrides.get(tuple(keys), default)
+
+    monkeypatch.setattr(families_mod, "get_config", fake_get_config)
+
+    names = families_mod._resolve_celery_queue_names()
+    assert "uploads" in names
+    assert "notify" in names
+    assert "sync" in names
+    assert "celery" in names
+    assert "healthcheck" in names
+    assert "" not in names
+
+
+def test_resolve_celery_queue_names_accepts_list_form(monkeypatch):
+    """`get_config` returns a list when the value is set via
+    JSON/YAML rather than a comma-separated env var; we treat both
+    shapes identically so operators don't have to care which knob
+    they used.
+    """
+
+    from redis_admin import families as families_mod  # noqa: PLC0415
+
+    config_overrides = {
+        ("setup", "redis_admin", "celery_queues"): ["uploads", "  notify  ", ""],
+    }
+
+    def fake_get_config(*keys, default=None):
+        return config_overrides.get(tuple(keys), default)
+
+    monkeypatch.setattr(families_mod, "get_config", fake_get_config)
+
+    names = families_mod._resolve_celery_queue_names()
+    assert "uploads" in names
+    assert "notify" in names
+    assert "" not in names
+
+
+def test_resolve_celery_queue_names_unset_keeps_defaults(monkeypatch):
+    """When the operator hasn't configured anything we still get the
+    `task_default_queue` / `health_check_default_queue` baseline so a
+    bare-bones deploy (dev, enterprise) keeps working unchanged.
+    """
+
+    from redis_admin import families as families_mod  # noqa: PLC0415
+
+    monkeypatch.setattr(
+        families_mod, "get_config", lambda *_args, default=None: default
+    )
+    names = families_mod._resolve_celery_queue_names()
+    assert "celery" in names
+    assert "healthcheck" in names
+
+
 def test_iter_keys_yields_celery_queues_via_fixed_keys(patched_redis):
     patched_redis.rpush("celery", '{"task": "x"}')
     patched_redis.rpush("healthcheck", '{"task": "y"}')

--- a/apps/codecov-api/redis_admin/tests/test_queryset.py
+++ b/apps/codecov-api/redis_admin/tests/test_queryset.py
@@ -237,6 +237,36 @@ def test_queryset_sort_by_nullable_string_field_does_not_crash(patched_redis):
     assert names[-1] == "ta_flake_key:1"
 
 
+def test_queryset_family_filter_drops_explicit_name_under_wrong_family(
+    patched_redis, monkeypatch
+):
+    """The `name__exact` shortcut in `_fetch_all` resolves family
+    ownership via `find_family(name)` and bypasses the SCAN-time
+    family filter. Without a post-resolve `family` check, a
+    `family=celery_broker name__exact=<key>` filter (the shape
+    `CeleryQueueFilter` builds) would silently surface a non-celery
+    row if the name happened to belong to another family. Pin that
+    behaviour: family mismatch must drop the row.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset  # noqa: PLC0415
+
+    patched_redis.rpush("celery", '{"task": "x"}')
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "find_family",
+        lambda key: next(
+            (f for f in redis_admin_families.FAMILIES if f.name == "uploads"), None
+        ),
+    )
+
+    rows = list(
+        RedisQueue.objects.filter(family__exact="celery_broker", name__exact="celery")
+    )
+    assert rows == []
+
+
 def test_max_scan_keys_limits_result_set(patched_redis, settings, monkeypatch):
     settings.REDIS_ADMIN_MAX_SCAN_KEYS = 3
     # `families.iter_keys` reads MAX_SCAN_KEYS off the redis_admin settings


### PR DESCRIPTION
## Summary

Two related improvements to the `RedisQueueAdmin` `celery_broker` view, motivated by the [Codecov Health Overview Grafana dashboard](https://grafana-prod.codecov.dev/d/w8C_Pnw4k/codecov-health-overview-beta) showing queue depths the admin couldn't see:

1. **Operator-configured queue enumeration** (`families.py`) — the admin's `celery_broker` family now reads queue names from `setup.redis_admin.celery_queues`, so production queues like `uploads`, `notify`, `sync`, `bundles_analysis`, `upload_finisher`, `timeseries` etc. become visible.
2. **`celery queue` sidebar filter** (`admin.py`) — once those queues are visible, an on-call engineer who sees a queue spike on the dashboard can click the queue name and land on a single-row changelist, instead of remembering the exact `family:celery_broker name:notify_celery` search incantation.

## Why (1) was needed

Before this PR, `_resolve_celery_queue_names()` resolved every `BaseCeleryConfig.task_routes[*]['queue']` to `task_default_queue` (`"celery"`) when running in the API process — because `setup.tasks.<group>.queue` env vars are only set on worker pods, not the API. So the admin only ever surfaced `celery`, `healthcheck`, and whatever the `enterprise_*` SCAN matched. PR #890 fixed the connection-routing half of the discrepancy; this PR fixes the enumeration half.

The deployment-specific list lives in private chart config:

```yaml
- name: "SETUP__REDIS_ADMIN__CELERY_QUEUES"
  value: "<comma-separated, synced with k8s-v2/config/<env>.yaml>"
```

The OSS code never carries the actual queue names. Each name is `EXISTS`-checked in `iter_keys` before being yielded, so listing a queue that doesn't exist on the broker is harmless. With nothing configured, behaviour is unchanged: `celery`, `healthcheck`, and the `enterprise_*` SCAN still surface as before, so dev / enterprise single-Redis deploys keep working.

## Behaviour of the new filter

- Selecting a queue narrows the changelist with `family__exact=celery_broker AND name__exact=<queue>`.
- The combined filter takes the EXISTS-only short-circuit `RedisQueueQuerySet` already uses for admin bulk-action `pk__in=` lookups, so the page is a single Redis round-trip — strictly faster than the equivalent search-bar query, which still does a SCAN.
- Dynamic `enterprise_*` queues aren't enumerable from configuration and are intentionally excluded from the dropdown. Operators who need them can keep using the search bar (`family:celery_broker enterprise_acme`), which already handles substring match.
- The dropdown lookups come from the same `_resolve_celery_queue_names()` enumeration that backs `celery_broker.fixed_keys`, so the new queue list flows through to the filter automatically.

## Why no equivalent on the lock changelist

`RedisLockAdmin` covers `coordination_lock`, `lock_attempts`, `*_fence`, and `*_gate` keys — none of which are celery queues — so a celery-queue filter there would be a no-op. Happy to add an analogous lock-side curated filter as a follow-up if there's a corresponding lock dashboard worth mirroring.

## Sidebar layout

```
By family
  All
  uploads
  ta_flake_key
  latest_upload
  upload-processing-state
  intermediate-report
  celery_broker

By celery queue                <-- new
  All
  celery
  healthcheck
  notify
  sync
  uploads
  ...

By min depth
  All
  1+
  10+
  ...
```

## Deploy follow-up

To make production benefit from change (1), add `SETUP__REDIS_ADMIN__CELERY_QUEUES` to the API pod's env in the private chart, mirroring the worker queue list from `k8s-v2/config/<env>.yaml` (same set the workers consume via `CODECOV_WORKER_QUEUES`).

## Test plan

- [x] `pytest redis_admin` — 162 passed
- [x] `ruff check` / `ruff format --check` clean on `apps/codecov-api/redis_admin/`
- [x] New regression tests:
  - `test_celery_queue_filter_narrows_changelist_to_single_queue` — proves the filter excludes both other celery queues and unrelated families.
  - `test_celery_queue_filter_dropdown_lists_well_known_queue_names` — pins the lookups to whatever `_resolve_celery_queue_names()` exposes.
  - `test_celery_queue_filter_with_no_value_returns_full_changelist` — guards against a regression where the filter accidentally hides rows when nothing is selected.
  - `test_resolve_celery_queue_names_includes_operator_configured_queues` — env-var path surfaces operator queues.
  - `test_resolve_celery_queue_names_accepts_list_form` — JSON/YAML list shape works identically.
  - `test_resolve_celery_queue_names_unset_keeps_defaults` — bare-bones deploy fallback locked in.
- [ ] After deploy: confirm `/admin/redis_admin/redisqueue/?family=celery_broker` shows queue depths matching Grafana, and that selecting a queue from the new sidebar filter narrows to a single row.

## Related

- #890 (per-family connection routing — the broker-side queues this filter targets)
- Supersedes #893 (folded in here)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Django admin browsing of Redis/Celery queues and add defensive filtering; no production request handling or mutation logic is altered.
> 
> **Overview**
> Improves `redis_admin` visibility and navigation for Celery broker queues by **enumerating queue names from operator config** (`setup.redis_admin.celery_queues`) in addition to `BaseCeleryConfig` defaults, so deployment-specific queues can appear without worker env vars.
> 
> Adds a new **"celery queue"** sidebar filter on the `RedisQueue` changelist to jump directly to a single `celery_broker` queue row via `family__exact` + `name__exact`, and hardens `RedisQueueQuerySet` with a post-materialization family check to prevent misclassification when using explicit-name shortcuts. Includes docs and new smoke/unit tests covering config parsing, dropdown lookups, and filter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a0b00f5c0835f90532b03d1614a4192fd1db827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->