### PR TITLE
redis_admin: enumerate operator-configured Celery queues

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -151,6 +151,23 @@ All configurable via `REDIS_ADMIN_*` Django settings; defaults shown.
 | `REDIS_ADMIN_MAX_DECODE_BYTES` | `4_096` | Per-value display truncation. |
 | `REDIS_ADMIN_DELETE_BATCH_SIZE` | `500` | Pipeline batch size for `DEL` / `LREM` / `SREM` / `HDEL`. |
 | `REDIS_ADMIN_CONNECTION_FACTORY` | unset | Dotted path to a callable returning a `redis.Redis`. Defaults to `shared.helpers.redis.get_redis_connection`. |
+| `REDIS_ADMIN_BROKER_CONNECTION_FACTORY` | unset | Dotted path for the Celery broker connection. Defaults to building a client from `services.celery_broker` (falls back to `services.redis_url` for single-Redis dev/enterprise). |
+
+The `celery_broker` family also reads one shared-config knob (not a
+Django setting) to learn which Celery queue names to enumerate
+beyond the `BaseCeleryConfig` defaults:
+
+| Config key | Form | Purpose |
+|---|---|---|
+| `setup.redis_admin.celery_queues` | comma-separated string or list | Operator-supplied list of broker queue names (e.g. `uploads,notify,sync,...`). Reads via `shared.config.get_config("setup", "redis_admin", "celery_queues")`, so an env var like `SETUP__REDIS_ADMIN__CELERY_QUEUES=...` works on the API pod. The actual production list lives in private deployment config (it varies per environment), so this isn't shipped with defaults. Each name is `EXISTS`-checked before being yielded — listing a queue that doesn't exist is harmless. |
+
+Without this set the admin's `celery_broker` family only sees
+`celery`, `healthcheck`, and whatever the `enterprise_*` SCAN
+matches; queues like `uploads` / `notify` / `sync` stay invisible
+even when the broker has them, because the API pod doesn't carry
+the worker-side `setup.tasks.*.queue` env vars and so
+`BaseCeleryConfig.task_routes` resolves every route to
+`task_default_queue`.
 
 ## Adding a new family
 

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -19,11 +19,13 @@ import base64
 import fnmatch
 import json
 import logging
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import sentry_sdk
+
+from shared.config import get_config
 
 from . import conn as _conn
 from . import settings as redis_admin_settings
@@ -174,25 +176,80 @@ def _parse_celery_broker_key(_: str) -> ParsedKey:
     return ParsedKey(family="celery_broker")
 
 
+def _operator_configured_celery_queues() -> tuple[str, ...]:
+    """Read the deployment's declared list of Celery queue names.
+
+    The actual production queue topology lives in private deployment
+    config (`setup.tasks.*.queue` env vars on worker pods). The API
+    pod doesn't get those, so `BaseCeleryConfig.task_routes` inside
+    the API process resolves every route to `task_default_queue`
+    (`"celery"`) and the admin can't see queues like `uploads`,
+    `notify`, `sync`, etc. — even though they exist on the broker.
+
+    Operators close that gap by setting
+
+        SETUP__REDIS_ADMIN__CELERY_QUEUES="uploads,notify,sync,..."
+
+    on the API pod (or the equivalent in `codecov.yaml`). The names
+    are deployment-specific and intentionally not committed to this
+    OSS repo. `iter_keys` runs `EXISTS` against every entry, so
+    listing a queue that doesn't exist in Redis is harmless: it just
+    won't show up in the admin.
+    """
+
+    raw = get_config("setup", "redis_admin", "celery_queues", default=None)
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        candidates: Iterable[str] = raw.split(",")
+    elif isinstance(raw, (list, tuple, set)):
+        candidates = raw
+    else:  # pragma: no cover - defensive
+        log.warning(
+            "setup.redis_admin.celery_queues has unexpected type %s; ignoring",
+            type(raw).__name__,
+        )
+        return ()
+    cleaned = [str(name).strip() for name in candidates]
+    return tuple(name for name in cleaned if name)
+
+
 def _resolve_celery_queue_names() -> tuple[str, ...]:
     """Best-effort enumeration of the well-known Celery queue names.
 
-    Reads from the live `BaseCeleryConfig` so we pick up any queues an
-    operator configured via `setup.tasks.*.queue`. Falls back to the two
-    documented defaults if the import fails (e.g. during tests or in a
-    minimal environment).
+    Combines, in order of authority:
+
+    1. `setup.redis_admin.celery_queues` from the running config —
+       the deployment-specific list operators populate (see
+       `_operator_configured_celery_queues`). This is how a
+       production API pod learns about queues like `uploads` /
+       `notify` / `sync` that aren't reachable via
+       `BaseCeleryConfig` because the API doesn't carry the
+       worker-side `setup.tasks.*.queue` env vars.
+    2. `BaseCeleryConfig.task_routes[*]['queue']` — picks up any
+       queues *this* process has been told about via
+       `setup.tasks.*.queue` (rare in the API, normal in workers).
+    3. `task_default_queue` / `health_check_default_queue` so the
+       `celery` / `healthcheck` names are always present even on a
+       bare-bones deploy that hasn't set anything else.
+
+    Falls back to just (1) + the hardcoded `("celery",
+    "healthcheck")` defaults if `BaseCeleryConfig` can't be imported
+    (e.g. minimal-env tests).
     """
+
+    names: set[str] = set(_operator_configured_celery_queues())
 
     try:
         from shared.celery_config import BaseCeleryConfig  # noqa: PLC0415
     except Exception:  # pragma: no cover - defensive: any import error
         log.warning(
             "redis_admin: could not import BaseCeleryConfig; "
-            "using ('celery', 'healthcheck') only"
+            "falling back to operator-configured queues plus defaults"
         )
-        return ("celery", "healthcheck")
+        names.update(("celery", "healthcheck"))
+        return tuple(sorted(names))
 
-    names: set[str] = set()
     names.add(getattr(BaseCeleryConfig, "task_default_queue", "celery") or "celery")
     names.add(
         getattr(BaseCeleryConfig, "health_check_default_queue", "healthcheck")

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -231,6 +231,74 @@ def test_celery_broker_family_resolves_known_queue_names():
     assert "healthcheck" in family.fixed_keys
 
 
+def test_resolve_celery_queue_names_includes_operator_configured_queues(monkeypatch):
+    """Real production queues (`uploads`, `notify`, `sync`, ...) live in
+    private deployment config, not in the OSS `BaseCeleryConfig`. The
+    API pod surfaces them via `setup.redis_admin.celery_queues`. Without
+    this we silently miss every non-default queue on the broker — the
+    exact regression that motivated this change.
+    """
+
+    from redis_admin import families as families_mod  # noqa: PLC0415
+
+    config_overrides = {
+        ("setup", "redis_admin", "celery_queues"): "uploads, notify ,sync,",
+    }
+
+    def fake_get_config(*keys, default=None):
+        return config_overrides.get(tuple(keys), default)
+
+    monkeypatch.setattr(families_mod, "get_config", fake_get_config)
+
+    names = families_mod._resolve_celery_queue_names()
+    assert "uploads" in names
+    assert "notify" in names
+    assert "sync" in names
+    assert "celery" in names
+    assert "healthcheck" in names
+    assert "" not in names
+
+
+def test_resolve_celery_queue_names_accepts_list_form(monkeypatch):
+    """`get_config` returns a list when the value is set via
+    JSON/YAML rather than a comma-separated env var; we treat both
+    shapes identically so operators don't have to care which knob
+    they used.
+    """
+
+    from redis_admin import families as families_mod  # noqa: PLC0415
+
+    config_overrides = {
+        ("setup", "redis_admin", "celery_queues"): ["uploads", "  notify  ", ""],
+    }
+
+    def fake_get_config(*keys, default=None):
+        return config_overrides.get(tuple(keys), default)
+
+    monkeypatch.setattr(families_mod, "get_config", fake_get_config)
+
+    names = families_mod._resolve_celery_queue_names()
+    assert "uploads" in names
+    assert "notify" in names
+    assert "" not in names
+
+
+def test_resolve_celery_queue_names_unset_keeps_defaults(monkeypatch):
+    """When the operator hasn't configured anything we still get the
+    `task_default_queue` / `health_check_default_queue` baseline so a
+    bare-bones deploy (dev, enterprise) keeps working unchanged.
+    """
+
+    from redis_admin import families as families_mod  # noqa: PLC0415
+
+    monkeypatch.setattr(
+        families_mod, "get_config", lambda *_args, default=None: default
+    )
+    names = families_mod._resolve_celery_queue_names()
+    assert "celery" in names
+    assert "healthcheck" in names
+
+
 def test_iter_keys_yields_celery_queues_via_fixed_keys(patched_redis):
     patched_redis.rpush("celery", '{"task": "x"}')
     patched_redis.rpush("healthcheck", '{"task": "y"}')


### PR DESCRIPTION
## Summary

Fixes the case where the admin's `?family=celery_broker` view shows fewer
queues than expected
— even after PR #890 routed the family to the broker Redis.

## Root cause

`_resolve_celery_queue_names()` reads `BaseCeleryConfig.task_routes[*]['queue']`,
where each route's queue resolves via
`get_config(\"setup\", \"tasks\", <group>, \"queue\", default=task_default_queue)`.
The API pod doesn't set `SETUP__TASKS__<group>__QUEUE` env vars (only
worker pods do), so every route resolved to `task_default_queue`
(`\"celery\"`). The admin's `celery_broker` family only saw `celery`,
`healthcheck`, and whatever the `enterprise_*` SCAN matched — so
queues like `uploads`, `notify`, `sync`, `bundles_analysis`,
`upload_finisher`, `timeseries`, etc. were silently invisible even
when the broker had them.

## Fix

Read the deployment-specific queue list from a new shared-config key:

\`\`\`
setup.redis_admin.celery_queues = \"uploads,notify,sync,...\"
\`\`\`

Operators populate it on the API pod via
\`SETUP__REDIS_ADMIN__CELERY_QUEUES\` (or the equivalent in
\`codecov.yaml\`). The actual queue names are deployment-specific and
intentionally **not** committed to this OSS repo. Each name is
\`EXISTS\`-checked in \`iter_keys\` before being yielded, so listing a
queue that doesn't exist on the broker is harmless.

Without this configured, behaviour is unchanged: \`celery\`,
\`healthcheck\`, and the \`enterprise_*\` SCAN still surface as before,
so dev / enterprise single-Redis deploys keep working.

## Deploy follow-up

To make production benefit from this PR, add to the API pod's env
in the private chart (alongside the existing \`SERVICES__CELERY_BROKER\`
plumbing):

\`\`\`yaml
- name: \"SETUP__REDIS_ADMIN__CELERY_QUEUES\"
  value: \"<comma-separated list synced with k8s-v2/config/<env>.yaml>\"
\`\`\`

(Same set the workers consume via \`CODECOV_WORKER_QUEUES\`. Listing
the deployment-specific queue names lives in private deployment
config, not in this OSS PR.)

## Test plan

- [x] `pytest redis_admin` (159 passed)
- [x] `ruff check redis_admin/` (clean)
- [x] New regression tests:
  - `test_resolve_celery_queue_names_includes_operator_configured_queues` — the env-var path surfaces operator queues
  - `test_resolve_celery_queue_names_accepts_list_form` — JSON/YAML list shape works identically
  - `test_resolve_celery_queue_names_unset_keeps_defaults` — bare-bones deploy fallback locked in
- [ ] After deploy: confirm \`/admin/redis_admin/redisqueue/?family=celery_broker\` shows queue depths matching Grafana

## Context

Continues the Grafana-vs-admin discrepancy investigation
(PR #890 routed the family to the broker Redis; this PR makes the
admin actually enumerate the queues that live there).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to redis_admin queue-name enumeration for the `celery_broker` family and add tests/docs; behavior remains unchanged unless the new config key is set.
> 
> **Overview**
> The `celery_broker` family now enumerates Celery queue names from an operator-supplied shared-config key (`setup.redis_admin.celery_queues`) in addition to the existing `BaseCeleryConfig`-derived defaults, so non-default broker queues become visible in the admin.
> 
> It adds parsing/normalization for comma-separated or list forms, preserves fallback behavior when unset or when `BaseCeleryConfig` can’t be imported, and documents the new knob in `redis_admin/README.md` with regression tests covering these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839a8a1711e87386f1e1cbaf546560ff5f6d443c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->