### PR TITLE
feat(api): redis_admin CeleryBrokerQueue per-message drill-down

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -22,7 +22,8 @@ ORM-backed rows — list_display, search, filters, pagination, and
 | Model | Audience | Mutable? |
 |---|---|---|
 | `RedisQueue` | Queue families: `uploads/*`, `ta_flake_key:*`, `latest_upload/*`, `upload-processing-state/*`, `intermediate-report/*`, Celery broker queues (`celery`, `healthcheck`, `enterprise_*`, `task_routes` values) | Yes (superuser only) |
-| `RedisQueueItem` | Items inside a single queue (LIST entries / SET members / HASH fields / STRING value) | Yes (superuser only) |
+| `RedisQueueItem` | Items inside a single queue (LIST entries / SET members / HASH fields / STRING value). Used for non-celery families. | Yes (superuser only) |
+| `CeleryBrokerQueue` | One row per celery message inside one `celery_broker` queue, with the kombu envelope already parsed into `task_name` / `repoid` / `commitid` / `task_id` / `ownerid` / `pullid` columns. The default click-through from a `celery_broker` `RedisQueue` row lands here. | Yes (superuser only) |
 | `RedisLock` | Lock families: `*_lock_*`, `upload_finisher_gate_*`, `ta_flake_lock:*`, `lock_attempts:*`, `ta_notifier_fence:*`, `coordination_lock:*` | Read-only (always) |
 
 Lock families are flagged `is_deletable=False` in the registry and
@@ -35,8 +36,9 @@ accidentally surfaces them under `RedisQueue`.
 |---|---|
 | `/admin/redis_admin/redisqueue/` | Browse Redis queue keys |
 | `/admin/redis_admin/redisqueue/<key>/change/` | Inspect a single queue, with a tabular-inline preview of its items |
-| `/admin/redis_admin/redisqueueitem/?queue_name__exact=<key>` | Browse the full items of a queue |
+| `/admin/redis_admin/redisqueueitem/?queue_name__exact=<key>` | Browse the full items of a queue (non-celery families) |
 | `/admin/redis_admin/redisqueueitem/<token>/change/` | Inspect a single item |
+| `/admin/redis_admin/celerybrokerqueue/?queue_name__exact=<queue>` | Browse messages inside a celery broker queue with structured task / repoid / commitid columns and per-message clear |
 | `/admin/redis_admin/redislock/` | Browse Redis locks (read-only) |
 | `/admin/redis_admin/redisqueue/clear-by-scope/` | M6 — cross-family clear-by-scope (superuser only) |
 
@@ -168,6 +170,69 @@ even when the broker has them, because the API pod doesn't carry
 the worker-side `setup.tasks.*.queue` env vars and so
 `BaseCeleryConfig.task_routes` resolves every route to
 `task_default_queue`.
+
+## Celery broker drill-down
+
+Clicking `view items` on a `celery_broker` `RedisQueue` row lands
+on `CeleryBrokerQueueAdmin` (URL: `/admin/redis_admin/celerybrokerqueue/?queue_name__exact=<queue>`),
+which is the celery-aware drill-down: one row = one celery
+message, with the kombu envelope already parsed into structured
+columns. Other families keep using the generic `RedisQueueItem`
+inspector unchanged.
+
+| Column | Source |
+|---|---|
+| `index_in_queue` | LRANGE position |
+| `task_name` | `headers.task` (e.g. `app.tasks.bundle_analysis.BundleAnalysisProcessor`) |
+| `repoid` / `commitid` | body kwargs |
+| `ownerid` / `pullid` | body kwargs (for owner / pull-shaped tasks) |
+| `task_id` | `headers.id` (kombu UUID; useful for cross-referencing flower / Sentry) |
+| `payload_preview` | the body kwargs dict, rendered as one line. Known-large keys (`commit_yaml`, `processing_results`, `current_yaml`, `report_json`, `raw_upload`, `commit_yaml_dict`) are replaced with a `<truncated: N chars>` placeholder so a single 97 KB envelope can't blow past `MAX_DECODE_BYTES`. |
+
+Search bar tokens (in addition to bare substrings, which match
+`task_name__icontains`):
+
+- `repoid:1234` &mdash; exact repoid
+- `commit:abc` / `commitid:abc` &mdash; commit prefix (works with the 7-char abbrev or the full SHA)
+- `task:Notify` / `task_name:Notify` &mdash; task substring
+- `task_id:<uuid>` &mdash; full kombu task id
+- `ownerid:N` / `pullid:N` &mdash; for owner / pull-shaped tasks
+- `queue:notify` &mdash; switch the active queue without leaving the page
+
+Sidebar filters: queue (well-known celery queue names), celery
+task (dynamic dropdown built from the `task_name` values present
+in the currently filtered queue), repoid, commit prefix.
+
+### Per-message clear (LSET-tombstone)
+
+Item-level deletion of celery messages goes through
+`services.celery_broker_clear`, not `redis_delete`. The reason is
+that `redis_delete`'s `_classify_items` deliberately refuses
+celery_broker items because the family's `decode_value`
+transformer rewrites the raw bytes into a
+`[task=… repoid=… commit=…]` summary, and the decorated string
+won't round-trip back to `LREM` (which matches on exact bytes).
+
+`celery_broker_clear` solves this with the canonical LSET-
+tombstone idiom:
+
+1. For each selected message, `LSET <queue> <idx> <sentinel>`
+   (sentinel = `__redis_admin_celery_tombstone__:<uuid>`).
+2. Once all sentinels are written, one `LREM <queue> 0 <sentinel>`
+   sweeps them all out of the list.
+
+Per-call UUID means simultaneous clears can't step on each
+other's sentinels. Race-safe under concurrent celery consumers:
+even if a worker `BLPOP`s from the head of the list between our
+LSETs and our LREM, the popped (sentinel) message is recognised at
+task-decode time as garbage and discarded, and we still get a
+consistent count from LREM.
+
+The same dry-run + audit log apparatus as `redis_delete` is
+reused: `LogEntry.change_message` with `scope =
+"celery_broker_clear"`, count, sample, families. Superuser-only
+(`has_delete_permission`) and dry-run-required (`clear_dry_run`
+must run before the destructive `clear_selected` arms).
 
 ## Adding a new family
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -37,9 +37,13 @@ from .families import FAMILIES, iter_keys
 from .families import (
     _resolve_celery_queue_names as _celery_queue_names,  # noqa: PLC2701 - reused for filter lookups
 )
-from .models import RedisLock, RedisQueue, RedisQueueItem
-from .queryset import RedisItemQuerySet, _build_redis_queue
-from .services import redis_delete
+from .models import CeleryBrokerQueue, RedisLock, RedisQueue, RedisQueueItem
+from .queryset import (
+    CeleryBrokerQueueQuerySet,
+    RedisItemQuerySet,
+    _build_redis_queue,
+)
+from .services import celery_broker_clear, redis_delete
 
 # ---- Inline items preview (rendered on the queue change page) --------------
 #
@@ -65,7 +69,15 @@ def _render_items_inline(obj, *, max_rows: int = _ITEMS_PREVIEW_MAX_ROWS):
     a custom template. Each row links to the per-item inspector for
     drill-in; a footer link points at the full items changelist so
     paging beyond the preview is one click away.
+
+    For `celery_broker` queues we route into `CeleryBrokerQueueAdmin`
+    instead — its inline preview is structured (task / repoid /
+    commit columns rather than raw kombu envelopes), and the bulk
+    "view all items →" link goes to the celery-aware changelist.
     """
+
+    if getattr(obj, "family", None) == "celery_broker":
+        return _render_celery_items_inline(obj, max_rows=max_rows)
 
     items_qs = RedisItemQuerySet(RedisQueueItem, queue_name=obj.name)
     snapshot = list(items_qs[:max_rows])
@@ -134,6 +146,99 @@ def _render_items_inline(obj, *, max_rows: int = _ITEMS_PREVIEW_MAX_ROWS):
 
     footer = format_html(
         '<p class="paginator">showing first {} item(s); {}</p>',
+        len(snapshot),
+        full_link,
+    )
+
+    return format_html(
+        '<div class="js-inline-admin-formset inline-group">'
+        '<div class="tabular inline-related last-related">'
+        '<fieldset class="module">{}{}{}</fieldset>'
+        "</div></div>",
+        heading,
+        table,
+        footer,
+    )
+
+
+def _render_celery_items_inline(obj, *, max_rows: int = _ITEMS_PREVIEW_MAX_ROWS):
+    """Tabular-inline preview specialised for `celery_broker` queues.
+
+    Mirrors `_render_items_inline` for non-celery families but pulls
+    rows from `CeleryBrokerQueueQuerySet` so the inline columns are
+    `idx | task | repoid | commit` instead of the raw kombu envelope
+    that `RedisQueueItem` would surface. The "view all items →"
+    footer points at the celery-aware changelist
+    (`CeleryBrokerQueueAdmin`) rather than the generic items view.
+    """
+
+    items_qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name=obj.name)
+    snapshot = list(items_qs[:max_rows])
+
+    full_url = reverse("admin:redis_admin_celerybrokerqueue_changelist")
+    full_link_query = urlencode({"queue_name__exact": obj.name})
+    full_link = format_html(
+        '<a href="{}?{}">view all items \u2192</a>',
+        full_url,
+        full_link_query,
+    )
+
+    heading = format_html("<h2>{}</h2>", "Celery messages")
+
+    if not snapshot:
+        body = format_html(
+            '<p class="paginator">{} <em>(empty / nothing to preview)</em></p>',
+            full_link,
+        )
+        return format_html(
+            '<div class="js-inline-admin-formset inline-group">'
+            '<div class="tabular inline-related last-related">'
+            '<fieldset class="module">{}{}</fieldset>'
+            "</div></div>",
+            heading,
+            body,
+        )
+
+    item_change_url = "admin:redis_admin_celerybrokerqueue_change"
+    rows = format_html_join(
+        "",
+        '<tr class="form-row has_original">'
+        '<td class="original">'
+        '<p><a href="{}" class="inlineviewlink">View</a></p>'
+        "</td>"
+        '<td class="field-index_in_queue"><p>{}</p></td>'
+        '<td class="field-task_name"><p>{}</p></td>'
+        '<td class="field-repoid"><p>{}</p></td>'
+        '<td class="field-commitid"><p>{}</p></td>'
+        "</tr>",
+        (
+            (
+                reverse(item_change_url, args=[quote(item.pk_token)]),
+                item.index_in_queue,
+                item.task_name or "—",
+                item.repoid if item.repoid is not None else "—",
+                (item.commitid[:7] if item.commitid else "—"),
+            )
+            for item in snapshot
+        ),
+    )
+
+    table = format_html(
+        "<table>"
+        "<thead><tr>"
+        '<th class="original"></th>'
+        '<th class="column-index_in_queue">Idx</th>'
+        '<th class="column-task_name">Task</th>'
+        '<th class="column-repoid">Repo</th>'
+        '<th class="column-commitid">Commit</th>'
+        "</tr></thead>"
+        "<tbody>{}</tbody>"
+        "</table>",
+        rows,
+    )
+
+    footer = format_html(
+        '<p class="paginator">showing first {} message(s); {}</p>',
         len(snapshot),
         full_link,
     )
@@ -869,7 +974,15 @@ class RedisQueueAdmin(admin.ModelAdmin):
 
     @admin.display(description="items")
     def items_link(self, obj: RedisQueue) -> str:
-        url = reverse("admin:redis_admin_redisqueueitem_changelist")
+        # Celery broker queues land on the celery-aware admin
+        # (`CeleryBrokerQueueAdmin`) which decodes each kombu envelope
+        # into structured columns and offers per-message clear with
+        # the LSET-tombstone path. Other families keep using the
+        # generic items view.
+        if obj.family == "celery_broker":
+            url = reverse("admin:redis_admin_celerybrokerqueue_changelist")
+        else:
+            url = reverse("admin:redis_admin_redisqueueitem_changelist")
         query = urlencode({"queue_name__exact": obj.name})
         return format_html('<a href="{}?{}">view items</a>', url, query)
 
@@ -1113,3 +1226,408 @@ class RedisQueueItemAdmin(admin.ModelAdmin):
         # Truncation already applied at queryset materialization time using
         # MAX_DECODE_BYTES, so this column just renders what's there.
         return obj.raw_value or ""
+
+
+# ---- Celery broker per-message changelist (M6) -----------------------------
+
+
+def _parse_celery_search_term(term: str) -> dict[str, str]:
+    """Pull `key:value` tokens out of the celery changelist search bar.
+
+    Recognised keys: `repoid`, `commit` / `commitid`, `task` /
+    `task_name`, `task_id`, `ownerid`, `pullid`, `queue` /
+    `queue_name`. Bare tokens become a `task_name__icontains` so a
+    user can paste a task class name (`BundleAnalysisProcessor`)
+    without remembering the prefix.
+    """
+
+    bare: list[str] = []
+    out: dict[str, str] = {}
+    for tok in term.split():
+        if ":" in tok:
+            key, _, value = tok.partition(":")
+            key = key.strip().lower()
+            value = value.strip()
+            if not value:
+                continue
+            if key == "repoid":
+                out["repoid__exact"] = value
+            elif key in ("commit", "commitid"):
+                out["commitid__startswith"] = value
+            elif key in ("task", "task_name"):
+                out["task_name__icontains"] = value
+            elif key == "task_id":
+                out["task_id__exact"] = value
+            elif key == "ownerid":
+                out["ownerid__exact"] = value
+            elif key == "pullid":
+                out["pullid__exact"] = value
+            elif key in ("queue", "queue_name"):
+                out["queue_name__exact"] = value
+            else:
+                bare.append(tok)
+        else:
+            bare.append(tok)
+    if bare:
+        out["task_name__icontains"] = " ".join(bare)
+    return out
+
+
+class CeleryBrokerTaskFilter(admin.SimpleListFilter):
+    """Sidebar dropdown of `task_name` values present in the queue.
+
+    Built dynamically off the currently-filtered queue so the picker
+    only shows tasks the operator can actually drill into.
+    `lookups()` returns an empty tuple when no `queue_name__exact`
+    is set — the admin renders the filter as "All" only.
+    """
+
+    title = "celery task"
+    parameter_name = "celery_task"
+
+    def lookups(self, request, model_admin):
+        queue = request.GET.get("queue_name__exact")
+        if not queue:
+            return ()
+        try:
+            qs = CeleryBrokerQueueQuerySet(
+                CeleryBrokerQueue, queue_name=queue
+            )._fetch_all()
+        except Exception:  # pragma: no cover - defensive
+            return ()
+        seen: list[tuple[str, str]] = []
+        seen_set: set[str] = set()
+        for row in qs:
+            name = row.task_name
+            if name and name not in seen_set:
+                seen_set.add(name)
+                seen.append((name, name))
+        seen.sort()
+        return tuple(seen)
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(task_name__exact=value)
+        return queryset
+
+
+class CeleryBrokerRepoidFilter(admin.SimpleListFilter):
+    """Free-text `repoid` filter, rendered as a sidebar input.
+
+    Django doesn't ship a stock text-input list filter, but
+    `SimpleListFilter` with empty `lookups()` plus a `?repoid=`
+    query string is enough to honour the URL parameter; the admin
+    template surfaces it via `lookup_allowed`. Operators paste a
+    repoid into the URL or the search bar (`repoid:1234`); this
+    filter just makes the URL parameter participate in the
+    queryset filter pipeline.
+    """
+
+    title = "repoid"
+    parameter_name = "repoid"
+
+    def lookups(self, request, model_admin):
+        return ()
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(repoid__exact=value)
+        return queryset
+
+    def has_output(self) -> bool:  # pragma: no cover - admin convention
+        return False
+
+
+class CeleryBrokerCommitFilter(admin.SimpleListFilter):
+    """Same shape as `CeleryBrokerRepoidFilter` but matches by commit prefix.
+
+    `commitid__startswith` so pasting either the 7-char abbrev
+    (rendered next to each row) or the full SHA both narrow
+    correctly.
+    """
+
+    title = "commit"
+    parameter_name = "commitid"
+
+    def lookups(self, request, model_admin):
+        return ()
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(commitid__startswith=value)
+        return queryset
+
+    def has_output(self) -> bool:  # pragma: no cover - admin convention
+        return False
+
+
+@admin.register(CeleryBrokerQueue)
+class CeleryBrokerQueueAdmin(admin.ModelAdmin):
+    """Per-message admin for `celery_broker` queues.
+
+    Mirrors `RedisQueueAdmin`'s "view + dry-run + clear" flow, but
+    one row = one celery message, with the kombu envelope already
+    decoded into `task_name` / `repoid` / `commitid` columns so an
+    operator can filter by repo or commit and clear stuck messages
+    without DEL-ing the whole queue. Required pre-filter is
+    `queue_name__exact` — without it the changelist short-circuits
+    to empty + an info nudge. Per-message delete uses the canonical
+    LSET-tombstone path (`services.celery_broker_clear`) so it's
+    race-safe under concurrent celery consumers.
+    """
+
+    list_display = (
+        "index_in_queue",
+        "task_name",
+        "repoid_link",
+        "commitid_link",
+        "ownerid",
+        "pullid",
+        "task_id_short",
+        "payload_preview_truncated",
+    )
+    list_filter = (
+        CeleryQueueFilter,
+        CeleryBrokerTaskFilter,
+        CeleryBrokerRepoidFilter,
+        CeleryBrokerCommitFilter,
+    )
+    list_per_page = redis_admin_settings.ITEM_PAGE_SIZE
+    show_full_result_count = False
+    ordering = ("index_in_queue",)
+    search_fields = ("task_name",)
+    search_help_text = (
+        "search by 'repoid:1234', 'commit:abc', 'task:BundleAnalysisProcessor', "
+        "'task_id:<uuid>', 'ownerid:N', 'pullid:N', or 'queue:notify'. "
+        "Bare tokens are matched against the task name."
+    )
+    readonly_fields = (
+        "pk_token",
+        "queue_name",
+        "index_in_queue",
+        "task_name",
+        "task_id",
+        "repoid",
+        "commitid",
+        "ownerid",
+        "pullid",
+        "payload_preview",
+    )
+    actions = ("clear_dry_run", "clear_selected")
+
+    # ---- Permissions / read-only safety -----------------------------------
+
+    def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
+        return bool(request.user and request.user.is_staff)
+
+    def has_view_permission(self, request: HttpRequest, obj=None) -> bool:
+        return bool(request.user and request.user.is_staff)
+
+    def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
+        # Mirrors `RedisQueueAdmin`: dry-run is staff-allowed via the
+        # `permissions=("delete",)` action gate, but the destructive
+        # commit is superuser-only.
+        return bool(request.user and request.user.is_superuser)
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        actions.pop("delete_selected", None)
+        return actions
+
+    def lookup_allowed(self, lookup, value) -> bool:
+        if lookup in (
+            "queue_name__exact",
+            "queue_name",
+            "repoid",
+            "repoid__exact",
+            "commitid",
+            "commitid__startswith",
+            "commitid__exact",
+            "task_name",
+            "task_name__exact",
+            "task_name__icontains",
+            "task_id",
+            "task_id__exact",
+            "ownerid",
+            "ownerid__exact",
+            "pullid",
+            "pullid__exact",
+        ):
+            return True
+        return super().lookup_allowed(lookup, value)
+
+    def get_queryset(self, request: HttpRequest):
+        # Bypass ChangeList's `.filter(**lookup_params)` plumbing so the
+        # required `queue_name__exact` survives untouched even when no
+        # list_filter is declared on the URL.
+        queryset = self.model._default_manager.all()
+        queue_name = request.GET.get("queue_name__exact")
+        if queue_name:
+            queryset = queryset.filter(queue_name__exact=queue_name)
+        return queryset
+
+    def changelist_view(self, request: HttpRequest, extra_context=None):
+        if not request.GET.get("queue_name__exact"):
+            messages.info(
+                request,
+                "Pick a celery_broker queue from the Redis queues list "
+                "(the 'view items' link) to see its messages.",
+            )
+        return super().changelist_view(request, extra_context)
+
+    def get_search_results(self, request, queryset, search_term):
+        if not search_term:
+            return queryset, False
+        kwargs = _parse_celery_search_term(search_term)
+        if not kwargs:
+            return queryset, False
+        try:
+            return queryset.filter(**kwargs), False
+        except NotImplementedError:
+            return queryset.none(), False
+
+    # ---- Change form (per-message inspector) -----------------------------
+
+    def get_fieldsets(self, request, obj=None):
+        return ((None, {"fields": list(self.readonly_fields)}),)
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        ctx = {
+            "show_save": False,
+            "show_save_and_continue": False,
+            "show_save_and_add_another": False,
+            "show_save_as_new": False,
+        }
+        if extra_context:
+            ctx.update(extra_context)
+        return super().changeform_view(request, object_id, form_url, ctx)
+
+    def save_model(self, request, obj, form, change):
+        raise RuntimeError("CeleryBrokerQueue rows are read-only.")
+
+    # ---- Bulk clear (dry-run + confirm) ----------------------------------
+
+    @admin.action(
+        description="Dry-run: count what 'clear selected' would clear",
+        permissions=("delete",),
+    )
+    def clear_dry_run(self, request: HttpRequest, queryset) -> None:
+        result = celery_broker_clear(list(queryset), user=request.user, dry_run=True)
+        self.message_user(
+            request,
+            (
+                f"Dry-run: would clear {result.count} celery message(s); "
+                f"sample={list(result.sample[:5])}"
+            ),
+            level=messages.INFO,
+        )
+
+    @admin.action(
+        description="Clear selected (dry-run preview, then confirm)",
+        permissions=("delete",),
+    )
+    def clear_selected(self, request: HttpRequest, queryset):
+        """Two-stage clear; LSET-tombstone path on commit."""
+
+        selected = list(queryset)
+        selected_pks = request.POST.getlist("_selected_action") or [
+            obj.pk for obj in selected
+        ]
+
+        if request.POST.get("confirm") == "yes":
+            result = celery_broker_clear(selected, user=request.user, dry_run=False)
+            self.message_user(
+                request,
+                (
+                    f"Cleared {result.count} celery message(s) "
+                    f"across {len({obj.queue_name for obj in selected})} queue(s)."
+                ),
+                level=messages.SUCCESS,
+            )
+            return None
+
+        dry_run_result = celery_broker_clear(selected, user=request.user, dry_run=True)
+        opts = self.model._meta
+        ctx = {
+            **self.admin_site.each_context(request),
+            "title": "Confirm clear of selected celery messages",
+            "opts": opts,
+            "action_name": "clear_selected",
+            "selected": selected,
+            "selected_pks": selected_pks,
+            "dry_run_result": dry_run_result,
+            "media": self.media,
+        }
+        return render(
+            request, "admin/redis_admin/clear_selected_confirmation.html", ctx
+        )
+
+    def delete_queryset(self, request: HttpRequest, queryset) -> None:
+        """Defensive: stripped from `get_actions` but route through the
+        audited celery clear if anything reintroduces it.
+        """
+
+        result = celery_broker_clear(list(queryset), user=request.user, dry_run=False)
+        self.message_user(
+            request,
+            f"Cleared {result.count} celery message(s).",
+            level=messages.SUCCESS,
+        )
+
+    def delete_model(self, request: HttpRequest, obj: CeleryBrokerQueue) -> None:
+        """Single-message delete from the change page."""
+
+        result = celery_broker_clear([obj], user=request.user, dry_run=False)
+        self.message_user(
+            request,
+            (
+                f"Cleared celery message {obj.queue_name}[{obj.index_in_queue}] "
+                f"({result.count} removed)."
+            ),
+            level=messages.SUCCESS,
+        )
+
+    # ---- Display helpers --------------------------------------------------
+
+    @admin.display(description="repo")
+    def repoid_link(self, obj: CeleryBrokerQueue) -> str:
+        if obj.repoid is None:
+            return "—"
+        try:
+            url = reverse("admin:core_repository_change", args=[obj.repoid])
+        except NoReverseMatch:
+            return str(obj.repoid)
+        return format_html('<a href="{}">{}</a>', url, obj.repoid)
+
+    @admin.display(description="commit")
+    def commitid_link(self, obj: CeleryBrokerQueue) -> str:
+        if not obj.commitid:
+            return "—"
+        try:
+            base = reverse("admin:core_commit_changelist")
+        except NoReverseMatch:
+            return obj.commitid[:7]
+        url = f"{base}?{urlencode({'q': obj.commitid})}"
+        return format_html(
+            '<a href="{}" title="{}">{}</a>', url, obj.commitid, obj.commitid[:7]
+        )
+
+    @admin.display(description="task id")
+    def task_id_short(self, obj: CeleryBrokerQueue) -> str:
+        if not obj.task_id:
+            return "—"
+        # Task IDs are kombu UUIDs; the first 8 chars uniquely identify
+        # them in nearly every realistic queue size and keep the column
+        # narrow.
+        short = obj.task_id[:8]
+        return format_html('<span title="{}">{}</span>', obj.task_id, short)
+
+    @admin.display(description="payload")
+    def payload_preview_truncated(self, obj: CeleryBrokerQueue) -> str:
+        return obj.payload_preview or ""

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -265,27 +265,82 @@ def _resolve_celery_queue_names() -> tuple[str, ...]:
     return tuple(sorted(names))
 
 
-def _peek_celery_envelope(decoded: str) -> tuple[str | None, int | None, str | None]:
-    """Pull `(task, repoid, commitid)` from a kombu JSON envelope.
+@dataclass(frozen=True)
+class CeleryEnvelopeMeta:
+    """Structured view of a kombu broker envelope.
 
-    Returns `(None, None, None)` for anything we can't parse so the
-    fallback is "show the raw payload" rather than "crash the admin".
+    The admin's `CeleryBrokerQueue` model surfaces these fields as
+    columns and accepts them as filters, so they're typed and
+    optional — a malformed or unrecognised envelope yields an
+    instance with everything set to `None`.
+
+    `kwargs` carries the raw decoded keyword-args dict (the second
+    element of the kombu body list) when present, so the admin can
+    render a `payload_preview` without re-parsing the envelope.
+    """
+
+    task: str | None = None
+    task_id: str | None = None
+    repoid: int | None = None
+    commitid: str | None = None
+    ownerid: int | None = None
+    pullid: int | None = None
+    kwargs: dict[str, Any] | None = None
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Best-effort int coercion that survives JSON's int/str ambiguity."""
+
+    if isinstance(value, bool):  # `bool` subclasses `int`; reject.
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
+    """Parse a kombu broker envelope into structured metadata.
+
+    Returns an empty `CeleryEnvelopeMeta()` for anything we can't
+    parse so the fallback is "show the raw payload" rather than
+    "crash the admin".
+
+    Kombu envelopes shape:
+        {"body": "<base64 JSON>", "headers": {"task": "...", "id": "..."}, ...}
+
+    Inside the decoded body, index `[1]` is the task's keyword-args
+    dict — `repoid`, `commitid`, `ownerid`, `pullid` are read from
+    there. Different worker tasks carry different subsets (notify
+    has repoid+commitid, sync_pull has repoid+pullid, sync_repos
+    has ownerid only) so callers should treat every field as
+    independently optional.
     """
 
     try:
         envelope = json.loads(decoded)
     except (ValueError, TypeError):
-        return (None, None, None)
+        return CeleryEnvelopeMeta()
     if not isinstance(envelope, dict):
-        return (None, None, None)
+        return CeleryEnvelopeMeta()
 
     headers = envelope.get("headers") or {}
-    task = headers.get("task") if isinstance(headers, dict) else None
-    if not isinstance(task, str):
-        task = None
+    task: str | None = None
+    task_id: str | None = None
+    if isinstance(headers, dict):
+        raw_task = headers.get("task")
+        if isinstance(raw_task, str):
+            task = raw_task
+        raw_task_id = headers.get("id")
+        if isinstance(raw_task_id, str) and raw_task_id:
+            task_id = raw_task_id
 
     repoid: int | None = None
     commitid: str | None = None
+    ownerid: int | None = None
+    pullid: int | None = None
+    kwargs: dict[str, Any] | None = None
     body_b64 = envelope.get("body")
     if isinstance(body_b64, str) and body_b64:
         try:
@@ -295,15 +350,34 @@ def _peek_celery_envelope(decoded: str) -> tuple[str | None, int | None, str | N
             body = None
         if isinstance(body, list) and len(body) >= 2 and isinstance(body[1], dict):
             kwargs = body[1]
-            rid = kwargs.get("repoid")
-            if isinstance(rid, int):
-                repoid = rid
-            elif isinstance(rid, str) and rid.isdigit():
-                repoid = int(rid)
+            repoid = _coerce_int(kwargs.get("repoid"))
             cid = kwargs.get("commitid")
             if isinstance(cid, str) and cid:
                 commitid = cid
-    return (task, repoid, commitid)
+            ownerid = _coerce_int(kwargs.get("ownerid"))
+            pullid = _coerce_int(kwargs.get("pullid"))
+    return CeleryEnvelopeMeta(
+        task=task,
+        task_id=task_id,
+        repoid=repoid,
+        commitid=commitid,
+        ownerid=ownerid,
+        pullid=pullid,
+        kwargs=kwargs,
+    )
+
+
+def _peek_celery_envelope(decoded: str) -> tuple[str | None, int | None, str | None]:
+    """Backwards-compatible 3-tuple shim around `parse_celery_envelope`.
+
+    Kept for the existing `_celery_decode_value` summary line and any
+    downstream import that used the M4 signature; new callers should
+    prefer `parse_celery_envelope` to reach the additional fields
+    (`task_id`, `ownerid`, `pullid`, `kwargs`).
+    """
+
+    meta = parse_celery_envelope(decoded)
+    return (meta.task, meta.repoid, meta.commitid)
 
 
 def _celery_decode_value(raw_decoded: str) -> str:

--- a/apps/codecov-api/redis_admin/models.py
+++ b/apps/codecov-api/redis_admin/models.py
@@ -9,7 +9,11 @@ Redis SCAN results and are never saved.
 
 from django.db import models
 
-from .queryset import RedisItemQuerySet, RedisQueueQuerySet
+from .queryset import (
+    CeleryBrokerQueueQuerySet,
+    RedisItemQuerySet,
+    RedisQueueQuerySet,
+)
 
 
 class RedisQueueManager(models.Manager):
@@ -97,6 +101,76 @@ class RedisLock(models.Model):
         raise RuntimeError(
             "RedisLock entries are immutable from the admin; coordination "
             "locks must be released by their owning task, not by an operator."
+        )
+
+
+class CeleryBrokerQueueManager(models.Manager):
+    def get_queryset(self) -> CeleryBrokerQueueQuerySet:  # type: ignore[override]
+        return CeleryBrokerQueueQuerySet(self.model)
+
+
+class CeleryBrokerQueue(models.Model):
+    """A single celery message inside a `celery_broker` Redis list.
+
+    Mirrors `RedisQueue`'s "fake managed=False model that the admin
+    renders directly off Redis" pattern, but specialised for the
+    celery broker: each row is one task in flight, with the kombu
+    envelope already parsed into structured columns
+    (`task_name`, `repoid`, `commitid`, etc.) so an on-call operator
+    can filter and selectively clear stuck messages without DEL-ing
+    the whole queue.
+
+    The model lives in its own admin (`CeleryBrokerQueueAdmin`)
+    rather than re-using `RedisQueueItem`: the celery body is a
+    base64-wrapped kombu envelope that's noisy in the generic items
+    view, and per-item delete needs the LSET-tombstone path
+    (`services.celery_broker_clear`) which is unsafe for other
+    families.
+
+    `pk_token` shape: `<queue_name>#<index>` — same convention as
+    `RedisQueueItem` so the admin's `change_view` URL construction
+    works without customisation. `default_permissions` includes
+    `delete` because superusers can clear individual messages from
+    the changelist; a non-superuser sees the read-only inspector
+    only.
+    """
+
+    pk_token = models.CharField(primary_key=True, max_length=600)
+    queue_name = models.CharField(max_length=512)
+    index_in_queue = models.IntegerField(default=0)
+    task_name = models.CharField(max_length=256, null=True, blank=True)
+    task_id = models.CharField(max_length=128, null=True, blank=True)
+    repoid = models.IntegerField(null=True, blank=True)
+    commitid = models.CharField(max_length=64, null=True, blank=True)
+    ownerid = models.IntegerField(null=True, blank=True)
+    pullid = models.IntegerField(null=True, blank=True)
+    payload_preview = models.TextField(blank=True)
+
+    objects = CeleryBrokerQueueManager()
+
+    class Meta:
+        managed = False
+        app_label = "redis_admin"
+        verbose_name = "Celery broker queue message"
+        verbose_name_plural = "Celery broker queue messages"
+        default_permissions = ("view", "delete")
+
+    def __str__(self) -> str:
+        if self.task_name:
+            return f"{self.queue_name}[{self.index_in_queue}] {self.task_name}"
+        return f"{self.queue_name}[{self.index_in_queue}]"
+
+    def save(self, *args, **kwargs):  # pragma: no cover - safety net
+        raise RuntimeError("CeleryBrokerQueue is read-only; saves are not supported.")
+
+    def delete(self, *args, **kwargs):  # pragma: no cover - routed via service
+        # Real deletion goes through `services.celery_broker_clear` so
+        # the LSET-tombstone path runs and the audit log captures it;
+        # bypassing that here would leave stale list entries.
+        raise NotImplementedError(
+            "CeleryBrokerQueue.delete is not supported on individual "
+            "instances; use redis_admin.services.celery_broker_clear "
+            "(which the admin's clear flow already invokes)."
         )
 
 

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -14,6 +14,7 @@ hood so the models need no real database table.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
 from typing import Any
 
@@ -21,7 +22,13 @@ import sentry_sdk
 
 from . import conn as _conn
 from . import settings as redis_admin_settings
-from .families import Family, find_family, iter_keys
+from .families import (
+    CeleryEnvelopeMeta,
+    Family,
+    find_family,
+    iter_keys,
+    parse_celery_envelope,
+)
 from .families import _decode as _decode_value  # noqa: PLC2701 - shared helper
 
 _UNSET: Any = object()
@@ -853,6 +860,443 @@ class RedisItemQuerySet:
 
     def delete(self):
         raise NotImplementedError("RedisItemQuerySet.delete is added in milestone 5")
+
+    # ---- Admin compatibility shims ---------------------------------------
+
+    @property
+    def query(self):
+        ordering = self._ordering
+
+        class _Query:
+            order_by = ordering
+            select_related = False
+            distinct = False
+
+        return _Query()
+
+    @property
+    def ordered(self) -> bool:
+        return bool(self._ordering)
+
+    @property
+    def db(self) -> str:
+        return "default"
+
+
+# ---- Celery broker per-message queryset (M6) -------------------------------
+#
+# Backs `CeleryBrokerQueue`, the celery-broker-specific drill-down: one
+# row per message inside one celery queue, with the kombu envelope
+# already parsed into structured columns. Deliberately not a subclass of
+# `RedisItemQuerySet` because field shape, pk conventions, and
+# connection routing all differ — `RedisItemQuerySet` stays the
+# generic-Redis-types fallback for non-celery families.
+
+# Names of body kwargs that are routinely huge (megabytes of base64 YAML)
+# and would blow past `MAX_DECODE_BYTES` if rendered verbatim in
+# `payload_preview`. We replace them with a `<truncated: N chars>`
+# placeholder so the preview stays scannable; operators who genuinely
+# need the raw envelope can fall through to the existing `RedisQueueItem`
+# admin.
+_LARGE_KWARGS_KEYS: frozenset[str] = frozenset(
+    {
+        "commit_yaml",
+        "commit_yaml_dict",
+        "current_yaml",
+        "processing_results",
+        "report_json",
+        "raw_upload",
+    }
+)
+
+# Per-value cap inside `payload_preview` so a single oversized kwarg
+# can't monopolise the line even when it isn't on the known-large list.
+_PAYLOAD_PER_VALUE_CAP: int = 256
+
+
+_CELERY_FILTER_KEYS: dict[str, str] = {
+    "queue_name": "queue_name",
+    "queue_name__exact": "queue_name",
+    "repoid": "repoid",
+    "repoid__exact": "repoid",
+    "commitid": "commitid_prefix",
+    "commitid__exact": "commitid_exact",
+    "commitid__startswith": "commitid_prefix",
+    "task_name": "task_name_exact",
+    "task_name__exact": "task_name_exact",
+    "task_name__icontains": "task_name_substring",
+    "task_id": "task_id_exact",
+    "task_id__exact": "task_id_exact",
+    "ownerid": "ownerid",
+    "ownerid__exact": "ownerid",
+    "pullid": "pullid",
+    "pullid__exact": "pullid",
+    # Admin bulk-action `filter(pk__in=[...])` shortcut so
+    # `clear_selected` confirmation pages can re-resolve rows by
+    # pk_token. Each pk_token is `<queue>#<idx>`, so we cross-check
+    # below that every selected pk shares the same queue.
+    "pk__in": "pk_in",
+}
+
+
+def _summarise_kwargs_for_preview(
+    kwargs: dict[str, Any] | None,
+    *,
+    cap: int | None = None,
+) -> str:
+    """Render kombu body kwargs as a one-line preview string.
+
+    Known-large keys (`commit_yaml`, `processing_results`, …) are
+    swapped for a `<truncated: N chars>` placeholder so the preview
+    stays under the global `MAX_DECODE_BYTES` cap; everything else is
+    JSON-serialised, with each value individually truncated so one
+    oversized field can't monopolise the line.
+    """
+
+    if not kwargs:
+        return ""
+    summarised: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if key in _LARGE_KWARGS_KEYS:
+            try:
+                marshalled = json.dumps(value, default=str)
+            except (TypeError, ValueError):
+                marshalled = str(value)
+            summarised[key] = f"<truncated: {len(marshalled)} chars>"
+            continue
+        try:
+            marshalled = json.dumps(value, default=str)
+        except (TypeError, ValueError):
+            marshalled = str(value)
+        if len(marshalled) > _PAYLOAD_PER_VALUE_CAP:
+            summarised[key] = (
+                f"{marshalled[:_PAYLOAD_PER_VALUE_CAP]}\u2026 "
+                f"(+{len(marshalled) - _PAYLOAD_PER_VALUE_CAP} chars)"
+            )
+        else:
+            summarised[key] = value
+    try:
+        rendered = json.dumps(summarised, default=str)
+    except (TypeError, ValueError):
+        rendered = str(summarised)
+    return _truncate_for_display(rendered, cap=cap)
+
+
+class CeleryBrokerQueueQuerySet:
+    """Fake QuerySet over messages inside one celery_broker queue.
+
+    Required pre-filter: `queue_name__exact=<queue>`. Without it the
+    queryset short-circuits to empty and the admin renders an info
+    message — the alternative would be fanning out across every
+    well-known celery queue, which is unbounded by design.
+
+    Materialisation is `LRANGE 0 MAX_ITEMS_PER_KEY-1` once, parse
+    each element via `parse_celery_envelope`, then apply Python-side
+    filters and ordering. The result snapshot is cached on the
+    queryset instance so repeated `count()` / `__getitem__` /
+    `__iter__` calls during a single admin request reuse it.
+
+    Connection routing is hard-coded to `kind="broker"` since this
+    queryset is celery-only; no `find_family` round-trip needed.
+    """
+
+    def __init__(
+        self,
+        model,
+        *,
+        queue_name: str | None = None,
+        ordering: tuple[str, ...] = (),
+        filters: dict[str, Any] | None = None,
+    ) -> None:
+        self.model = model
+        self.queue_name = queue_name
+        self._ordering = ordering
+        self._filters: dict[str, Any] = dict(filters or {})
+        self._result_cache: list | None = None
+
+    # ---- Cloning helpers --------------------------------------------------
+
+    def _clone(
+        self,
+        *,
+        queue_name: Any = _UNSET,
+        ordering: tuple[str, ...] | None = None,
+        filters: dict[str, Any] | None = None,
+    ) -> CeleryBrokerQueueQuerySet:
+        return CeleryBrokerQueueQuerySet(
+            self.model,
+            queue_name=self.queue_name if queue_name is _UNSET else queue_name,
+            ordering=self._ordering if ordering is None else ordering,
+            filters=(
+                {**self._filters, **(filters or {})} if filters else dict(self._filters)
+            ),
+        )
+
+    def all(self) -> CeleryBrokerQueueQuerySet:
+        return self._clone()
+
+    def none(self) -> CeleryBrokerQueueQuerySet:
+        empty = self._clone(queue_name=None)
+        empty._result_cache = []
+        return empty
+
+    def using(self, alias) -> CeleryBrokerQueueQuerySet:
+        return self
+
+    # ---- Compatibility shims for django.contrib.admin.utils ---------------
+
+    @property
+    def verbose_name(self):
+        return self.model._meta.verbose_name
+
+    @property
+    def verbose_name_plural(self):
+        return self.model._meta.verbose_name_plural
+
+    # ---- Filtering -------------------------------------------------------
+
+    def _interpret_filter_kwargs(
+        self, kwargs: dict[str, Any]
+    ) -> tuple[Any, dict[str, Any]]:
+        """Translate Django-style lookups into our internal filter buckets.
+
+        `new_queue_name` stays `_UNSET` when no `queue_name`-shaped
+        lookup was supplied so `_clone` can preserve the existing one.
+        """
+
+        new_queue_name: Any = _UNSET
+        new_filters: dict[str, Any] = {}
+        for key, value in kwargs.items():
+            target = _CELERY_FILTER_KEYS.get(key)
+            if target is None:
+                raise NotImplementedError(
+                    "CeleryBrokerQueueQuerySet.filter only supports "
+                    f"{sorted(_CELERY_FILTER_KEYS)}; got {key!r}"
+                )
+            if target == "queue_name":
+                new_queue_name = None if value is None or value == "" else str(value)
+                continue
+            if value is None or value == "":
+                continue
+            if target in ("repoid", "ownerid", "pullid"):
+                try:
+                    new_filters[target] = int(value)
+                except (TypeError, ValueError):
+                    new_filters["__empty__"] = True
+            elif target in ("commitid_prefix", "commitid_exact"):
+                new_filters[target] = str(value)
+            elif target in ("task_name_exact", "task_id_exact"):
+                new_filters[target] = str(value)
+            elif target == "task_name_substring":
+                new_filters[target] = str(value).lower()
+            elif target == "pk_in":
+                indexes: set[int] = set()
+                queue_names: set[str] = set()
+                bad = False
+                for raw in value or ():
+                    raw_str = str(raw)
+                    queue, sep, idx = raw_str.rpartition("#")
+                    if not sep or not queue or not idx:
+                        bad = True
+                        break
+                    try:
+                        indexes.add(int(idx))
+                    except ValueError:
+                        bad = True
+                        break
+                    queue_names.add(queue)
+                if bad or len(queue_names) > 1:
+                    # `pk__in` spanning multiple queues would force a
+                    # cross-queue fan-out and break the
+                    # `queue_name`-required invariant.
+                    new_filters["__empty__"] = True
+                elif queue_names:
+                    new_queue_name = next(iter(queue_names))
+                    new_filters["pk_in_indexes"] = indexes
+        return new_queue_name, new_filters
+
+    def filter(self, *args, **kwargs) -> CeleryBrokerQueueQuerySet:
+        if args:
+            raise NotImplementedError(
+                "CeleryBrokerQueueQuerySet.filter does not accept positional Q objects"
+            )
+        new_queue_name, new_filters = self._interpret_filter_kwargs(kwargs)
+        return self._clone(queue_name=new_queue_name, filters=new_filters)
+
+    def exclude(self, *args, **kwargs) -> CeleryBrokerQueueQuerySet:
+        if not args and not kwargs:
+            return self._clone()
+        raise NotImplementedError(
+            "CeleryBrokerQueueQuerySet.exclude is not implemented"
+        )
+
+    def order_by(self, *fields: str) -> CeleryBrokerQueueQuerySet:
+        return self._clone(ordering=tuple(fields))
+
+    def get(self, *args, **kwargs):
+        """Resolve a single message by `pk_token = '<queue>#<index>'`."""
+
+        if args:
+            raise self.model.DoesNotExist(
+                f"{self.model.__name__} positional get() is not supported"
+            )
+        pk = (
+            kwargs.pop("pk", None)
+            or kwargs.pop("pk__exact", None)
+            or kwargs.pop("pk_token", None)
+            or kwargs.pop("pk_token__exact", None)
+        )
+        if kwargs:
+            raise NotImplementedError(
+                "CeleryBrokerQueueQuerySet.get only supports pk/pk_token; "
+                f"got extra {list(kwargs)!r}"
+            )
+        if pk is None:
+            raise self.model.DoesNotExist(
+                f"{self.model.__name__} matching no kwargs does not exist"
+            )
+        pk_str = str(pk)
+        queue, sep, idx_str = pk_str.rpartition("#")
+        if not sep or not queue or not idx_str:
+            raise self.model.DoesNotExist(
+                f"pk_token must look like 'queue#<index>'; got {pk_str!r}"
+            )
+        try:
+            idx = int(idx_str)
+        except ValueError as exc:
+            raise self.model.DoesNotExist(
+                f"pk_token index must be int; got {idx_str!r}"
+            ) from exc
+        bound = self._clone(queue_name=queue)
+        for row in bound._fetch_all():
+            if row.index_in_queue == idx:
+                return row
+        raise self.model.DoesNotExist(
+            f"index {idx} not found in queue {queue!r} "
+            f"(may exceed MAX_ITEMS_PER_KEY or have been consumed)"
+        )
+
+    # ---- Materialisation -------------------------------------------------
+
+    def _connection(self) -> Any:
+        # Celery broker queues always live on the broker Redis; the
+        # family registry routes `celery_broker` here too.
+        return _conn.get_connection(kind="broker")
+
+    def _build_row(self, idx: int, meta: CeleryEnvelopeMeta) -> Any:
+        return self.model(
+            pk_token=f"{self.queue_name}#{idx}",
+            queue_name=self.queue_name,
+            index_in_queue=idx,
+            task_name=meta.task,
+            task_id=meta.task_id,
+            repoid=meta.repoid,
+            commitid=meta.commitid,
+            ownerid=meta.ownerid,
+            pullid=meta.pullid,
+            payload_preview=_summarise_kwargs_for_preview(meta.kwargs),
+        )
+
+    @sentry_sdk.trace
+    def _materialise(self) -> list:
+        if not self.queue_name:
+            return []
+        redis = self._connection()
+        if not redis.exists(self.queue_name):
+            return []
+        cap = redis_admin_settings.MAX_ITEMS_PER_KEY
+        # `LRANGE 0 cap-1` rather than streaming because celery queues
+        # are bounded in practice and a single round-trip beats paging
+        # for the typical "operator filtered to one repoid" case where
+        # filtering happens client-side anyway.
+        raw_values = redis.lrange(self.queue_name, 0, cap - 1)
+        rows: list = []
+        for offset, raw in enumerate(raw_values):
+            decoded = _decode_value(raw)
+            meta = parse_celery_envelope(decoded)
+            rows.append(self._build_row(offset, meta))
+        return rows
+
+    def _matches_filters(self, row: Any) -> bool:
+        f = self._filters
+        if f.get("__empty__"):
+            return False
+        repoid = f.get("repoid")
+        if repoid is not None and row.repoid != repoid:
+            return False
+        ownerid = f.get("ownerid")
+        if ownerid is not None and row.ownerid != ownerid:
+            return False
+        pullid = f.get("pullid")
+        if pullid is not None and row.pullid != pullid:
+            return False
+        commit_exact = f.get("commitid_exact")
+        if commit_exact and (row.commitid or "") != commit_exact:
+            return False
+        commit_prefix = f.get("commitid_prefix")
+        if commit_prefix and not (row.commitid or "").startswith(commit_prefix):
+            return False
+        task_exact = f.get("task_name_exact")
+        if task_exact and (row.task_name or "") != task_exact:
+            return False
+        task_substring = f.get("task_name_substring")
+        if task_substring and task_substring not in (row.task_name or "").lower():
+            return False
+        task_id_exact = f.get("task_id_exact")
+        if task_id_exact and (row.task_id or "") != task_id_exact:
+            return False
+        pk_in_indexes = f.get("pk_in_indexes")
+        if pk_in_indexes is not None and row.index_in_queue not in pk_in_indexes:
+            return False
+        return True
+
+    def _fetch_all(self) -> list:
+        if self._result_cache is not None:
+            return self._result_cache
+        if not self.queue_name:
+            self._result_cache = []
+            return []
+        if self._filters.get("__empty__"):
+            self._result_cache = []
+            return []
+        rows = self._materialise()
+        rows = [r for r in rows if self._matches_filters(r)]
+        for field in reversed(self._ordering):
+            reverse = field.startswith("-")
+            attr = field.lstrip("-")
+            rows.sort(
+                key=lambda obj, attr=attr: _ordering_key(obj, attr), reverse=reverse
+            )
+        self._result_cache = rows
+        return rows
+
+    def __iter__(self) -> Iterator:
+        return iter(self._fetch_all())
+
+    def iterator(self, chunk_size: int | None = None) -> Iterator:
+        return iter(self._fetch_all())
+
+    def __len__(self) -> int:
+        return len(self._fetch_all())
+
+    def count(self) -> int:
+        return len(self._fetch_all())
+
+    def __getitem__(self, item):
+        return self._fetch_all()[item]
+
+    def __bool__(self) -> bool:
+        return bool(self._fetch_all())
+
+    def delete(self):
+        # Real deletion goes through `services.celery_broker_clear`
+        # so the LSET-tombstone path runs and audit logs capture the
+        # operation. The admin's `clear_selected` action calls that
+        # service directly.
+        raise NotImplementedError(
+            "CeleryBrokerQueueQuerySet.delete is not supported; use "
+            "redis_admin.services.celery_broker_clear"
+        )
 
     # ---- Admin compatibility shims ---------------------------------------
 

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -34,7 +35,7 @@ from django.contrib.contenttypes.models import ContentType
 from . import conn as _conn
 from . import settings as redis_admin_settings
 from .families import ConnectionKind, find_family
-from .models import RedisLock, RedisQueue, RedisQueueItem
+from .models import CeleryBrokerQueue, RedisLock, RedisQueue, RedisQueueItem
 
 log = logging.getLogger(__name__)
 
@@ -381,6 +382,187 @@ def _redis_delete(
         span.set_data("redis_admin.count", result.count)
         span.set_data("redis_admin.refused_count", len(refused))
         span.set_data("redis_admin.families", list(families))
+    except AttributeError:  # pragma: no cover - older sdks
+        pass
+    return result
+
+
+# ---- Celery broker per-message clear (M6) ----------------------------------
+#
+# `redis_delete()`'s `_classify_items` deliberately refuses item-level
+# deletes for `celery_broker` because the family's `decode_value`
+# transformer prepends a `[task=… repoid=… commit=…]` summary and the
+# decorated string can't round-trip back to LREM (LREM matches on
+# exact bytes). The new `CeleryBrokerQueueAdmin` solves this with the
+# canonical LSET-tombstone idiom: replace each target index with a
+# unique sentinel value, then LREM the sentinel in one pass. Race-safe
+# under concurrent celery consumers since the sentinel only matches
+# the slot we replaced — even if a worker BLPOPs from the head between
+# our LSET and LREM, the popped (sentinel) message is recognised at
+# task-decode time as garbage and we still end up with a consistent
+# delete count.
+
+# Tombstone prefix is intentionally distinctive so a stray LREM
+# attempt on the wrong queue couldn't accidentally match a real
+# message. Each call appends a fresh UUID so simultaneous clears
+# don't step on each other.
+_CELERY_TOMBSTONE_PREFIX = "__redis_admin_celery_tombstone__"
+
+
+def _celery_clear_tombstone() -> str:
+    return f"{_CELERY_TOMBSTONE_PREFIX}:{uuid.uuid4().hex}"
+
+
+def _execute_celery_clear(
+    redis,
+    queue_name: str,
+    indexes: Sequence[int],
+    *,
+    tombstone: str,
+) -> int:
+    """LSET-then-LREM the given indexes inside `queue_name`.
+
+    Returns the number of list elements actually removed (the LREM
+    reply); we don't double-count duplicates because LSET writes the
+    same sentinel for every selected idx and LREM count=0 wipes them
+    all in a single sweep.
+    """
+
+    if not indexes:
+        return 0
+    pipe = redis.pipeline(transaction=False)
+    for idx in indexes:
+        # `LSET` raises if the index is out of range; the admin
+        # already materialised these from `LRANGE`, so the only way
+        # we'd see that here is if a celery consumer drained the queue
+        # between the operator clicking "Clear" and us reaching this
+        # line. Don't crash the whole pipeline in that case — the
+        # subsequent LREM for the sentinel will simply remove zero
+        # entries. We tolerate per-op failures by reading replies
+        # rather than raising.
+        try:
+            pipe.lset(queue_name, idx, tombstone)
+        except Exception:  # pragma: no cover - defensive
+            log.exception(
+                "redis_admin.celery_broker_clear: failed to enqueue LSET for %s[%s]",
+                queue_name,
+                idx,
+            )
+    try:
+        replies = pipe.execute(raise_on_error=False)
+    except TypeError:  # pragma: no cover - some clients don't accept the kwarg
+        replies = pipe.execute()
+    failures = sum(1 for reply in replies if isinstance(reply, Exception))
+    if failures:
+        log.warning(
+            "redis_admin.celery_broker_clear: %s LSET op(s) failed on %s "
+            "(likely consumer drained the slot mid-clear); proceeding to LREM",
+            failures,
+            queue_name,
+        )
+
+    deleted = redis.lrem(queue_name, 0, tombstone)
+    try:
+        return int(deleted or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def celery_broker_clear(
+    targets: Iterable[CeleryBrokerQueue],
+    *,
+    user,
+    dry_run: bool = False,
+) -> DeleteResult:
+    """Clear the given celery broker messages with the LSET-tombstone path.
+
+    Parallels `redis_delete()` for the `RedisQueue` / `RedisQueueItem`
+    surfaces but is celery-broker-specific: targets must already be
+    `CeleryBrokerQueue` rows materialised from
+    `CeleryBrokerQueueQuerySet`, which carry the per-queue index we
+    need for LSET. Wraps in a sentry span and writes a `LogEntry`
+    audit row with `scope="celery_broker_clear"` so the existing
+    operator audit trail keeps capturing celery clears alongside
+    family-level deletes.
+    """
+
+    span_name = "celery_broker_dry_run" if dry_run else "celery_broker_execute"
+    with sentry_sdk.start_span(op="redis.admin.delete", name=span_name) as span:
+        try:
+            span.set_tag("redis_admin.dry_run", dry_run)
+            span.set_tag("redis_admin.scope", "celery_broker_clear")
+        except AttributeError:  # pragma: no cover - older sdks
+            pass
+        return _celery_broker_clear(targets, user=user, dry_run=dry_run, span=span)
+
+
+def _celery_broker_clear(
+    targets: Iterable[CeleryBrokerQueue],
+    *,
+    user,
+    dry_run: bool,
+    span,
+) -> DeleteResult:
+    by_queue: dict[str, list[int]] = {}
+    sample_source: list[str] = []
+    for target in targets:
+        if not isinstance(target, CeleryBrokerQueue):
+            log.warning(
+                "redis_admin.celery_broker_clear: ignoring non-celery target %r",
+                type(target),
+            )
+            continue
+        if not target.queue_name:
+            continue
+        by_queue.setdefault(target.queue_name, []).append(target.index_in_queue)
+        sample_source.append(f"{target.queue_name}#{target.index_in_queue}")
+
+    sample = tuple(sample_source[:_AUDIT_SAMPLE_SIZE])
+    families = ("celery_broker",) if by_queue else ()
+    pending_count = sum(len(v) for v in by_queue.values())
+
+    if dry_run or not by_queue:
+        result = DeleteResult(
+            count=pending_count,
+            sample=sample,
+            families=families,
+            dry_run=dry_run,
+            refused=(),
+        )
+    else:
+        redis = _conn.get_connection(kind="broker")
+        deleted = 0
+        for queue_name, indexes in by_queue.items():
+            tombstone = _celery_clear_tombstone()
+            # Sort descending so if two pipelines race against the same
+            # queue, the higher-index LSETs land before lower-index
+            # ones — keeps the failure mode "the slot we missed has
+            # been consumed" instead of "we wrote a tombstone over a
+            # message we hadn't intended to".
+            indexes_sorted = sorted(set(indexes), reverse=True)
+            deleted += _execute_celery_clear(
+                redis, queue_name, indexes_sorted, tombstone=tombstone
+            )
+        result = DeleteResult(
+            count=deleted,
+            sample=sample,
+            families=families,
+            dry_run=False,
+            refused=(),
+        )
+
+    _record_audit(
+        user=user,
+        scope="celery_broker_clear",
+        count=result.count,
+        refused=(),
+        sample=sample,
+        families=families,
+        dry_run=dry_run,
+    )
+    try:
+        span.set_data("redis_admin.count", result.count)
+        span.set_data("redis_admin.queues", sorted(by_queue))
     except AttributeError:  # pragma: no cover - older sdks
         pass
     return result

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -1,0 +1,683 @@
+"""End-to-end coverage for the M6 `CeleryBrokerQueue` drill-down.
+
+Covers the four moving pieces:
+
+* envelope parser (`parse_celery_envelope`) — pulls structured fields
+  out of a kombu broker payload, including the `task_id` / `ownerid`
+  / `pullid` extensions added in M6 on top of the existing
+  `(task, repoid, commitid)` shape.
+* `_summarise_kwargs_for_preview` — keeps the per-message preview
+  under `MAX_DECODE_BYTES` even when a kwarg like `commit_yaml`
+  ships a multi-megabyte payload.
+* `CeleryBrokerQueueQuerySet` — filtering by repoid / commitid /
+  task / etc.
+* `services.celery_broker_clear` — LSET-tombstone clear path,
+  including a concurrent-consumer race simulation and the audit
+  log.
+
+Plus an admin smoke test that the changelist refuses to fan out
+without a `queue_name__exact` and that the celery_broker `view
+items` link routes here instead of the generic `RedisQueueItem`.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import fakeredis
+import pytest
+from django.contrib.admin.models import LogEntry
+from django.test import TestCase
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin import services as redis_admin_services
+from redis_admin.families import parse_celery_envelope
+from redis_admin.models import CeleryBrokerQueue, RedisQueue
+from redis_admin.queryset import (
+    CeleryBrokerQueueQuerySet,
+    _summarise_kwargs_for_preview,
+)
+from redis_admin.services import (
+    _CELERY_TOMBSTONE_PREFIX,
+    celery_broker_clear,
+)
+from shared.django_apps.codecov_auth.tests.factories import UserFactory
+from utils.test_utils import Client
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _build_envelope(
+    *,
+    task: str | None = "app.tasks.notify.NotifyTask",
+    task_id: str | None = "task-uuid-1",
+    args: list | None = None,
+    kwargs: dict[str, Any] | None = None,
+) -> str:
+    """Build a kombu broker envelope JSON string suitable for LRANGE."""
+
+    body = json.dumps([args or [], kwargs or {}, {}])
+    body_b64 = base64.b64encode(body.encode("utf-8")).decode("ascii")
+    headers: dict[str, Any] = {}
+    if task is not None:
+        headers["task"] = task
+    if task_id is not None:
+        headers["id"] = task_id
+    return json.dumps({"body": body_b64, "headers": headers})
+
+
+@pytest.fixture
+def patched_broker(monkeypatch) -> fakeredis.FakeStrictRedis:
+    """Route both the cache and broker get_connection to one fakeredis."""
+
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(
+        redis_admin_conn, "get_connection", lambda kind="default": server
+    )
+    return server
+
+
+# ---- envelope parser -------------------------------------------------------
+
+
+def test_parse_envelope_extracts_task_repoid_commit_from_kwargs():
+    envelope = _build_envelope(
+        task="app.tasks.notify.NotifyTask",
+        task_id="abc-uuid",
+        kwargs={
+            "repoid": 21222368,
+            "commitid": "0832c110a744ddb8185bfdf0524aad41d3c3d21a",
+        },
+    )
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.task == "app.tasks.notify.NotifyTask"
+    assert meta.task_id == "abc-uuid"
+    assert meta.repoid == 21222368
+    assert meta.commitid == "0832c110a744ddb8185bfdf0524aad41d3c3d21a"
+    assert meta.ownerid is None
+    assert meta.pullid is None
+    assert meta.kwargs == {
+        "repoid": 21222368,
+        "commitid": "0832c110a744ddb8185bfdf0524aad41d3c3d21a",
+    }
+
+
+def test_parse_envelope_extracts_ownerid_and_pullid():
+    envelope = _build_envelope(
+        task="app.tasks.sync_pull.PullSyncTask",
+        kwargs={"repoid": 7, "pullid": 42},
+    )
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.task == "app.tasks.sync_pull.PullSyncTask"
+    assert meta.repoid == 7
+    assert meta.pullid == 42
+    assert meta.commitid is None
+    assert meta.ownerid is None
+
+
+def test_parse_envelope_owner_only_task():
+    envelope = _build_envelope(
+        task="app.tasks.sync_repos.SyncRepos",
+        kwargs={"ownerid": 99, "username": "octocat"},
+    )
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.ownerid == 99
+    assert meta.repoid is None
+    assert meta.pullid is None
+
+
+def test_parse_envelope_handles_string_int_repoid():
+    """JSON ints from celery sometimes round-trip as strings."""
+
+    envelope = _build_envelope(kwargs={"repoid": "1234", "commitid": "abc"})
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.repoid == 1234
+
+
+def test_parse_envelope_rejects_bool_in_int_fields():
+    """`bool` subclasses `int`; refuse to coerce True/False to 1/0."""
+
+    envelope = _build_envelope(kwargs={"repoid": True})
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.repoid is None
+
+
+def test_parse_envelope_returns_empty_for_garbled_json():
+    meta = parse_celery_envelope("not-json {")
+
+    assert meta.task is None
+    assert meta.repoid is None
+    assert meta.commitid is None
+    assert meta.kwargs is None
+
+
+def test_parse_envelope_returns_empty_for_missing_headers():
+    envelope = json.dumps({"body": ""})
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.task is None
+    assert meta.repoid is None
+
+
+def test_parse_envelope_ignores_non_dict_kwargs():
+    """Some tasks pass positional-only args; `body[1]` is a list."""
+
+    body = json.dumps([[1, 2, 3], [], {}])
+    body_b64 = base64.b64encode(body.encode("utf-8")).decode("ascii")
+    envelope = json.dumps({"body": body_b64, "headers": {"task": "t"}})
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.task == "t"
+    assert meta.repoid is None
+    assert meta.kwargs is None
+
+
+# ---- payload preview -------------------------------------------------------
+
+
+def test_payload_preview_truncates_known_large_keys():
+    big_yaml = {"codecov": {"foo": "x" * 5000}}
+    preview = _summarise_kwargs_for_preview({"repoid": 1, "commit_yaml": big_yaml})
+
+    assert "<truncated:" in preview
+    assert "5000" not in preview or "<truncated:" in preview
+    assert '"repoid": 1' in preview
+    # Even with a 5KB kwarg, the rendered preview stays bounded.
+    assert len(preview) < 1000
+
+
+def test_payload_preview_truncates_oversize_unknown_keys():
+    """Unknown kwargs above the per-value cap fall back to a `… (+N chars)` marker."""
+
+    long_value = "x" * 1024
+    preview = _summarise_kwargs_for_preview({"weird_blob": long_value})
+
+    # JSON-rendered, the ellipsis is escaped as `\u2026` rather than
+    # the literal codepoint, so check for the pattern that follows it.
+    assert "(+" in preview
+    assert "chars)" in preview
+    assert "weird_blob" in preview
+
+
+def test_payload_preview_handles_empty_kwargs():
+    assert _summarise_kwargs_for_preview(None) == ""
+    assert _summarise_kwargs_for_preview({}) == ""
+
+
+# ---- queryset filtering ----------------------------------------------------
+
+
+def _push(redis, queue, **kwargs):
+    """Push one envelope into `queue` and return the raw value."""
+
+    raw = _build_envelope(**kwargs)
+    redis.rpush(queue, raw)
+    return raw
+
+
+def test_queryset_requires_queue_name_to_yield_rows(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue)
+
+    assert list(qs) == []
+    assert qs.count() == 0
+
+
+def test_queryset_yields_one_row_per_message(patched_broker):
+    _push(patched_broker, "notify", task="t1", kwargs={"repoid": 1, "commitid": "a"})
+    _push(patched_broker, "notify", task="t2", kwargs={"repoid": 2, "commitid": "b"})
+
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+
+    assert [r.index_in_queue for r in rows] == [0, 1]
+    assert [r.task_name for r in rows] == ["t1", "t2"]
+    assert [r.repoid for r in rows] == [1, 2]
+    assert [r.pk_token for r in rows] == ["notify#0", "notify#1"]
+
+
+def test_queryset_filter_by_repoid(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "a"})
+    _push(patched_broker, "notify", kwargs={"repoid": 2, "commitid": "b"})
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "c"})
+
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+        repoid__exact=1
+    )
+
+    rows = list(qs)
+    assert {r.commitid for r in rows} == {"a", "c"}
+    assert all(r.repoid == 1 for r in rows)
+
+
+def test_queryset_filter_by_commitid_startswith_matches_short_or_full_sha(
+    patched_broker,
+):
+    _push(
+        patched_broker,
+        "notify",
+        kwargs={"repoid": 1, "commitid": "0832c110a744ddb8185bfdf0524aad41d3c3d21a"},
+    )
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "deadbeef0"})
+
+    short_hits = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+            commitid__startswith="0832c11"
+        )
+    )
+    full_hits = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+            commitid__startswith="0832c110a744ddb8185bfdf0524aad41d3c3d21a"
+        )
+    )
+
+    assert len(short_hits) == 1
+    assert len(full_hits) == 1
+    assert short_hits[0].commitid == full_hits[0].commitid
+
+
+def test_queryset_commitid_exact_does_not_match_prefix(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "abcdef0"})
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "abc"})
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+            commitid__exact="abc"
+        )
+    )
+
+    assert {r.commitid for r in rows} == {"abc"}
+
+
+def test_queryset_filter_by_task_name_icontains(patched_broker):
+    _push(patched_broker, "bundle_analysis", task="app.tasks.bundle_analysis.A")
+    _push(patched_broker, "bundle_analysis", task="app.tasks.notify.B")
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(
+            CeleryBrokerQueue, queue_name="bundle_analysis"
+        ).filter(task_name__icontains="bundle")
+    )
+
+    assert {r.task_name for r in rows} == {"app.tasks.bundle_analysis.A"}
+
+
+def test_queryset_filter_by_task_id_exact(patched_broker):
+    _push(patched_broker, "notify", task_id="aaaa")
+    _push(patched_broker, "notify", task_id="bbbb")
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+            task_id__exact="bbbb"
+        )
+    )
+
+    assert [r.task_id for r in rows] == ["bbbb"]
+
+
+def test_queryset_combined_filters(patched_broker):
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.notify.NotifyTask",
+        kwargs={"repoid": 1, "commitid": "abc"},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.upload.UploadTask",
+        kwargs={"repoid": 1, "commitid": "abc"},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.notify.NotifyTask",
+        kwargs={"repoid": 2, "commitid": "abc"},
+    )
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+            repoid=1, task_name__icontains="notify"
+        )
+    )
+
+    assert len(rows) == 1
+    assert rows[0].repoid == 1
+    assert "Notify" in (rows[0].task_name or "")
+
+
+def test_queryset_filter_pk_in_resolves_indexes(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+    _push(patched_broker, "notify", kwargs={"repoid": 2})
+    _push(patched_broker, "notify", kwargs={"repoid": 3})
+
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue).filter(
+        pk__in=["notify#0", "notify#2"]
+    )
+    rows = list(qs)
+
+    assert {r.index_in_queue for r in rows} == {0, 2}
+
+
+def test_queryset_filter_pk_in_refuses_cross_queue_selection(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+    _push(patched_broker, "uploads", kwargs={"repoid": 1})
+
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue).filter(
+        pk__in=["notify#0", "uploads#0"]
+    )
+
+    assert list(qs) == []
+
+
+def test_queryset_filter_unknown_kwarg_raises(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
+
+    with pytest.raises(NotImplementedError):
+        qs.filter(some_random_field="x")
+
+
+def test_queryset_get_by_pk_token(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "first"})
+    _push(patched_broker, "notify", kwargs={"repoid": 2, "commitid": "second"})
+
+    row = CeleryBrokerQueueQuerySet(CeleryBrokerQueue).get(pk="notify#1")
+
+    assert row.commitid == "second"
+    assert row.index_in_queue == 1
+
+
+def test_queryset_get_raises_for_missing_index(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+
+    with pytest.raises(CeleryBrokerQueue.DoesNotExist):
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue).get(pk="notify#99")
+
+
+def test_queryset_ordering_by_repoid(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 3})
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+    _push(patched_broker, "notify", kwargs={"repoid": 2})
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").order_by(
+            "repoid"
+        )
+    )
+
+    assert [r.repoid for r in rows] == [1, 2, 3]
+
+
+# ---- service: celery_broker_clear ------------------------------------------
+
+
+@pytest.mark.django_db
+def test_celery_broker_clear_dry_run_does_not_mutate(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+    _push(patched_broker, "notify", kwargs={"repoid": 2})
+    user = UserFactory()
+
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+        repoid=1
+    )
+
+    result = celery_broker_clear(list(qs), user=user, dry_run=True)
+
+    assert result.dry_run is True
+    assert result.count == 1
+    assert patched_broker.llen("notify") == 2
+
+
+@pytest.mark.django_db
+def test_celery_broker_clear_removes_only_matching_messages(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "a"})
+    _push(patched_broker, "notify", kwargs={"repoid": 2, "commitid": "b"})
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "c"})
+    user = UserFactory()
+
+    targets = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+            repoid=1
+        )
+    )
+
+    result = celery_broker_clear(targets, user=user, dry_run=False)
+
+    assert result.count == 2
+    assert patched_broker.llen("notify") == 1
+    survivor = json.loads(patched_broker.lrange("notify", 0, -1)[0].decode("utf-8"))
+    body_decoded = json.loads(base64.b64decode(survivor["body"]).decode("utf-8"))
+    assert body_decoded[1]["repoid"] == 2
+
+
+@pytest.mark.django_db
+def test_celery_broker_clear_writes_audit_log_entry(patched_broker):
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+    user = UserFactory()
+
+    targets = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+
+    celery_broker_clear(targets, user=user, dry_run=False)
+
+    entries = list(LogEntry.objects.filter(user_id=user.id))
+    assert len(entries) == 1
+    payload = json.loads(entries[0].change_message)
+    assert payload["scope"] == "celery_broker_clear"
+    assert payload["count"] == 1
+    assert payload["dry_run"] is False
+    assert payload["families"] == ["celery_broker"]
+
+
+@pytest.mark.django_db
+def test_celery_broker_clear_handles_concurrent_consumer_pop(
+    patched_broker, monkeypatch
+):
+    """Simulate a celery worker BLPOPing a message between LSET and LREM.
+
+    The LSET-tombstone path must still:
+      1. produce a consistent delete count (LREM reply),
+      2. never resurrect the popped message,
+      3. never accidentally delete other unrelated rows.
+    """
+
+    _push(patched_broker, "notify", task="t0", kwargs={"repoid": 0})
+    _push(patched_broker, "notify", task="t1", kwargs={"repoid": 1})
+    _push(patched_broker, "notify", task="t2", kwargs={"repoid": 2})
+    user = UserFactory()
+
+    targets = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+            repoid=2
+        )
+    )
+    assert len(targets) == 1
+
+    real_execute_celery_clear = redis_admin_services._execute_celery_clear
+
+    def racing_execute_celery_clear(redis, queue_name, indexes, *, tombstone):
+        # Consumer drains the head right before we'd LSET. The
+        # surviving list reads `[t1-msg, t2-msg]`, so what was
+        # `targets[0].index_in_queue == 2` no longer points at the
+        # t2 message — it now points past the end. The tombstone
+        # write fails (LSET rejects out-of-range), and the LREM is
+        # a no-op. The cleared count must be 0, not 1, and the
+        # surviving list must not have lost t1.
+        redis.lpop(queue_name)
+        return real_execute_celery_clear(
+            redis, queue_name, indexes, tombstone=tombstone
+        )
+
+    monkeypatch.setattr(
+        redis_admin_services,
+        "_execute_celery_clear",
+        racing_execute_celery_clear,
+    )
+
+    result = celery_broker_clear(targets, user=user, dry_run=False)
+
+    surviving_raw = patched_broker.lrange("notify", 0, -1)
+    surviving_tasks = []
+    for raw in surviving_raw:
+        envelope = json.loads(raw.decode("utf-8"))
+        surviving_tasks.append(envelope["headers"]["task"])
+
+    # Consumer popped t0 (the head); we never touched t1 or t2.
+    assert "t1" in surviving_tasks
+    assert "t2" in surviving_tasks
+    # No tombstone leaked into the surviving list.
+    for raw in surviving_raw:
+        assert _CELERY_TOMBSTONE_PREFIX.encode() not in raw
+    # LREM on a missing tombstone returns 0; the result count
+    # reflects what actually got removed in Redis.
+    assert result.count == 0
+
+
+@pytest.mark.django_db
+def test_celery_broker_clear_uses_unique_tombstone_per_call(patched_broker):
+    """Two simultaneous `celery_broker_clear` calls must not share a
+    tombstone — otherwise one's LREM would wipe the other's pending
+    LSETs.
+    """
+
+    user = UserFactory()
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+
+    # Track every tombstone the service writes by intercepting LREM.
+    tombstones: list[str] = []
+    real_lrem = patched_broker.lrem
+
+    def spying_lrem(name, count, value):
+        tombstones.append(value.decode() if isinstance(value, bytes) else str(value))
+        return real_lrem(name, count, value)
+
+    patched_broker.lrem = spying_lrem  # type: ignore[assignment]
+
+    celery_broker_clear(rows, user=user, dry_run=False)
+    _push(patched_broker, "notify", kwargs={"repoid": 1})
+    rows2 = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+    celery_broker_clear(rows2, user=user, dry_run=False)
+
+    assert len(tombstones) == 2
+    assert tombstones[0] != tombstones[1]
+    assert all(t.startswith(_CELERY_TOMBSTONE_PREFIX) for t in tombstones)
+
+
+@pytest.mark.django_db
+def test_celery_broker_clear_ignores_non_celery_targets(patched_broker):
+    user = UserFactory()
+    not_celery = RedisQueue(
+        name="uploads/1/abc", family="uploads", redis_type="list", depth=1
+    )
+
+    result = celery_broker_clear([not_celery], user=user, dry_run=False)
+
+    assert result.count == 0
+    assert result.families == ()
+
+
+# ---- admin smoke tests -----------------------------------------------------
+
+
+class CeleryBrokerQueueAdminSmokeTest(TestCase):
+    """Click-through coverage for the `CeleryBrokerQueueAdmin` changelist."""
+
+    def setUp(self):
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
+        self.user = UserFactory(is_staff=True, is_superuser=True)
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def _push(self, queue, **kwargs):
+        self.redis.rpush(queue, _build_envelope(**kwargs))
+
+    def test_changelist_requires_queue_name_filter(self):
+        self._push("notify", kwargs={"repoid": 1})
+
+        response = self.client.get("/admin/redis_admin/celerybrokerqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        # Without the queue filter we render the info nudge and zero rows.
+        assert "Pick a celery_broker queue" in body
+
+    def test_changelist_shows_messages_for_selected_queue(self):
+        self._push(
+            "notify",
+            task="app.tasks.notify.NotifyTask",
+            kwargs={"repoid": 1, "commitid": "abcdef0123"},
+        )
+
+        response = self.client.get(
+            "/admin/redis_admin/celerybrokerqueue/?queue_name__exact=notify"
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        assert "app.tasks.notify.NotifyTask" in body
+        assert "abcdef0" in body  # short commit rendered in the changelist
+
+    def test_changelist_renders_task_and_repoid_columns(self):
+        self._push(
+            "notify",
+            task="app.tasks.bundle_analysis.BundleAnalysisProcessor",
+            kwargs={"repoid": 21222368, "commitid": "0832c110a744ddb"},
+        )
+
+        response = self.client.get(
+            "/admin/redis_admin/celerybrokerqueue/?queue_name__exact=notify"
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        assert "BundleAnalysisProcessor" in body
+        assert "21222368" in body
+        # 7-char commit prefix appears in the rendered changelist column.
+        assert "0832c11" in body
+
+    def test_redisqueue_items_link_routes_celery_to_celery_admin(self):
+        # The `celery_broker` family enumerates `_resolve_celery_queue_names()`
+        # for its `fixed_keys`; in a minimal test env those resolve to
+        # `("celery", "healthcheck")`, so push to one of those to be sure
+        # the queue surfaces on the changelist.
+        self.redis.rpush("celery", _build_envelope(kwargs={"repoid": 1}))
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        assert "celerybrokerqueue/" in body
+        assert "queue_name__exact=celery" in body
+
+
+@pytest.mark.django_db
+def test_non_staff_user_cannot_view_celery_broker_admin():
+    user = UserFactory(is_staff=False)
+    client = Client()
+    client.force_login(user)
+
+    response = client.get("/admin/redis_admin/celerybrokerqueue/")
+
+    assert response.status_code in (302, 403)

--- a/apps/codecov-api/redis_admin/tests/test_services.py
+++ b/apps/codecov-api/redis_admin/tests/test_services.py
@@ -254,7 +254,7 @@ class TestRedisDeleteService(TestCase):
 
         original = redis_admin_conn.get_connection
         redis_admin_conn.get_connection = (  # type: ignore[assignment]
-            lambda kind="default": (broker_server if kind == "broker" else cache_server)
+            lambda kind="default": broker_server if kind == "broker" else cache_server
         )
         try:
             result = redis_delete(


### PR DESCRIPTION
## Summary

Adds a celery-broker-specific drill-down mirror of the `RedisQueue` admin: clicking `view items` on a `celery_broker` row now lands on `CeleryBrokerQueueAdmin` (one row = one celery message) with the kombu envelope already parsed into structured columns and a race-safe LSET-tombstone clear flow. On-call operators who see a queue spike on the [Codecov health-overview Grafana dashboard](https://grafana-prod.codecov.dev/d/w8C_Pnw4k/codecov-health-overview-beta?orgId=1&from=now-6h&to=now) can drill into `notify`, filter to `repoid=42 commit=abc`, and clear just the matching messages without DEL-ing the whole queue.

Continues the lineage of #890 → #891 → #892. The plan: see [`CeleryBrokerQueue drill-down model`](https://github.com/codecov/umbrella/blob/tomhu/redis-admin-celery-broker-queue/apps/codecov-api/redis_admin/README.md#celery-broker-drill-down).

### Pieces

- **`families.parse_celery_envelope`** extends the existing kombu parser with `task_id` / `ownerid` / `pullid` / raw `kwargs` dict; `_peek_celery_envelope` is preserved as a 3-tuple shim for the existing `_celery_decode_value` summary line.
- **`CeleryBrokerQueue`** unmanaged model with `task_name` / `task_id` / `repoid` / `commitid` / `ownerid` / `pullid` / `payload_preview` columns. `default_permissions` includes `delete` so superusers get a per-message clear button.
- **`CeleryBrokerQueueQuerySet`** materialises by `LRANGE 0 MAX_ITEMS_PER_KEY-1` and applies Python-side filtering. Connection hard-coded to `kind=\"broker\"`. Required pre-filter is `queue_name__exact` — without it the changelist short-circuits to empty + info nudge, mirroring `RedisQueueItemAdmin`.
- **`payload_preview`** shows the body kwargs dict, with known-large keys (`commit_yaml`, `processing_results`, `current_yaml`, `report_json`, `raw_upload`, `commit_yaml_dict`) replaced with `<truncated: N chars>` placeholder so a single 97 KB envelope can't blow past `MAX_DECODE_BYTES`.
- **`services.celery_broker_clear`** uses the canonical LSET-tombstone idiom: `LSET <queue> <idx> <sentinel>` per target index, then one `LREM <queue> 0 <sentinel>`. Per-call UUID tombstone so simultaneous clears can't step on each other. Race-safe under concurrent celery consumers (LREM count stays consistent even if a worker BLPOPs the head between LSET and LREM).
- **`CeleryBrokerQueueAdmin`** mirrors the `RedisQueueAdmin` clear pattern: dry-run + confirm two-stage `clear_selected`, superuser-gated commit, audit log via `_record_audit` with `scope=\"celery_broker_clear\"`. Reuses `clear_selected_confirmation.html`.
- **Wiring**: `RedisQueueAdmin._render_items_inline` + `items_link` reroute celery_broker rows to the new admin. Other families keep using `RedisQueueItem` unchanged.
- **Search bar**: `repoid:N`, `commit:abc`, `task:Notify`, `task_id:<uuid>`, `ownerid:N`, `pullid:N`, `queue:notify`. Bare tokens match `task_name__icontains`.

### Tests (36 new)

- envelope parser: `repoid` / `commitid` / `ownerid` / `pullid` extraction; rejects `bool` in int slots; tolerates garbled JSON / missing `headers.task` / non-dict body.
- `_summarise_kwargs_for_preview`: known-large keys → placeholder; unknown oversized → per-value cap; empty kwargs handled.
- queryset: `repoid` filter, `commitid__exact` vs `__startswith` (short + full SHA), `task_name__icontains`, `task_id`, combined; `pk__in` shortcut + cross-queue refusal; ordering; get-by-pk_token.
- `celery_broker_clear`: dry-run is no-op; commit removes only matches; LogEntry written; concurrent-pop preserves consistency; per-call UUID tombstones unique; non-celery targets ignored.
- admin smoke: changelist requires `queue_name__exact`; click-through routes to new admin; columns render; non-staff redirected.

### Deploy implications

**None.** Same broker connection, no new env vars, no schema changes, no new k8s config. The `setup.redis_admin.celery_queues` env var that #892 added is still the only deploy-time knob, and it's only needed to enumerate non-default queues on the API pod (out of scope for this PR).

### Out of scope

- No SET/HASH equivalent (celery_broker is always LIST).
- Other families (uploads/*, intermediate-report/*) keep using `RedisQueueItem` unchanged.
- No celery message replay / requeue button — just inspect + delete.
- No streaming-clear for queues > `MAX_ITEMS_PER_KEY`.

## Test plan

- [x] `pytest redis_admin -q` &mdash; 203 passed (167 pre-existing + 36 new)
- [x] `ruff check redis_admin/` &mdash; clean
- [x] `ruff format --check redis_admin/` &mdash; clean
- [ ] Smoke-test on staging: load `/admin/redis_admin/redisqueue/?family=celery_broker`, click `view items` on `celery`, confirm structured columns + dry-run path
- [ ] Verify a `celery_broker_clear` audit log row lands in `/admin/admin/logentry/`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new admin surfaces that can delete individual Celery broker messages in Redis; while superuser-gated and audited, mistakes or edge cases could impact queue processing behavior.
> 
> **Overview**
> Adds a new `CeleryBrokerQueue` drill-down for `celery_broker` Redis queues so operators can browse one row per Celery message with parsed `task_name`/`repoid`/`commitid`/`task_id` (plus `ownerid`/`pullid`) and filter/search on those fields.
> 
> `RedisQueueAdmin` now routes `celery_broker` “view items” (and inline previews) to this new admin instead of the generic `RedisQueueItem` view, and introduces an audited, superuser-only per-message clear flow (`services.celery_broker_clear`) using an LSET-tombstone + LREM pattern to avoid raw-bytes roundtrips.
> 
> Extends the kombu envelope parsing (`parse_celery_envelope`) and adds a celery-specific queryset with payload preview truncation, plus a comprehensive new test suite covering parsing, filtering, admin routing, and clear race-safety/audit logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f27690145cbc4a088c051d5b9ff75621e1d12eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->