### PR TITLE
feat(api): redis_admin sample window 100_000 -> 20_000

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -151,7 +151,7 @@ All configurable via `REDIS_ADMIN_*` Django settings; defaults shown.
 | `REDIS_ADMIN_MAX_SCAN_KEYS` | `10_000` | Hard cap on keys visited per `iter_keys()` sweep. |
 | `REDIS_ADMIN_SCAN_COUNT` | `500` | `COUNT` hint for each `SCAN` / `SSCAN` / `HSCAN`. |
 | `REDIS_ADMIN_ITEM_PAGE_SIZE` | `100` | Page size for the items-in-a-queue view. |
-| `REDIS_ADMIN_MAX_ITEMS_PER_KEY` | `100_000` | Hard cap on members materialised from a single SET/HASH/LIST for browsing (drives the celery_broker chart's sample window via `LRANGE 0 cap-1`). |
+| `REDIS_ADMIN_MAX_ITEMS_PER_KEY` | `20_000` | Hard cap on members materialised from a single SET/HASH/LIST for browsing (drives the celery_broker chart's sample window via `LRANGE 0 cap-1`). |
 | `REDIS_ADMIN_MAX_DECODE_BYTES` | `4_096` | Per-value display truncation. |
 | `REDIS_ADMIN_DELETE_BATCH_SIZE` | `500` | Pipeline batch size for `DEL` / `LREM` / `SREM` / `HDEL`. |
 | `REDIS_ADMIN_CONNECTION_FACTORY` | unset | Dotted path to a callable returning a `redis.Redis`. Defaults to `shared.helpers.redis.get_redis_connection`. |

--- a/apps/codecov-api/redis_admin/settings.py
+++ b/apps/codecov-api/redis_admin/settings.py
@@ -27,7 +27,7 @@ MAX_DECODE_BYTES: int = getattr(settings, "REDIS_ADMIN_MAX_DECODE_BYTES", 4_096)
 # admin browsing (M4). LIST keys use bounded LRANGE windows so they aren't
 # constrained here. SCAN-based readers stop streaming once they reach this cap
 # so a runaway 10M-element SET can't OOM the api process.
-MAX_ITEMS_PER_KEY: int = getattr(settings, "REDIS_ADMIN_MAX_ITEMS_PER_KEY", 100_000)
+MAX_ITEMS_PER_KEY: int = getattr(settings, "REDIS_ADMIN_MAX_ITEMS_PER_KEY", 20_000)
 
 # Pipeline batch size for delete operations (M5). Keeps a single delete action
 # from blocking Redis with a single oversized MULTI when an operator clears


### PR DESCRIPTION
## Summary

Pulls back the `REDIS_ADMIN_MAX_ITEMS_PER_KEY` default landed in #896 from `100_000` to `20_000`. 100k was generous for the workload it actually serves — production `celery_broker` queues are O(5k–15k) deep when wedged, and 20k preserves a comfortable 4–8x buffer on top of that without committing the api process to materialising up to 100k LRANGE rows per admin page render.

## Why tighten

The same cap bounds both:

- `_materialize_set` / `_materialize_hash` (`redis_admin/queryset.py`) — bounded SSCAN/HSCAN that streams members until the cap, sorts in Python, paginates.
- `CeleryBrokerQueueQuerySet._materialise` (`redis_admin/queryset.py`) — `LRANGE 0 cap-1` parses up to `cap` kombu envelopes per request, feeds the in-memory `Counter` aggregation behind the frequency chart.

The items-in-a-key admin page still paginates client-side at `ITEM_PAGE_SIZE=100`, so the upper bound on **visible** data is unchanged; only the worst-case materialisation cost goes down. The frequency chart's "showing top N of M sampled messages" banner now fires at 20k+ instead of 100k+, which matches the size of the queues we actually want it to flag.

## Test plan

- [x] `pytest redis_admin/tests/test_item_queryset.py` — passes (the only test that monkeypatches this setting; uses `5` as the cap, not bound to the default).
- [x] `ruff check redis_admin/settings.py` clean.
- [x] `ruff format --check redis_admin/settings.py` clean.
- [ ] Verify on staging that a celery_broker queue admin page still renders the chart end-to-end against the 20k window.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the default sampling/materialization cap for Redis admin browsing and celery broker charting, reducing worst-case CPU/memory usage without altering deletion or core Redis logic.
> 
> **Overview**
> Reduces the default `REDIS_ADMIN_MAX_ITEMS_PER_KEY` cap from `100_000` to `20_000`, limiting how many elements the `redis_admin` UI will materialize/sample from a single Redis key (including the `celery_broker` drill-down chart window).
> 
> Updates both the runtime default in `redis_admin/settings.py` and the documented default in `redis_admin/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c04bbec951876750ab004cd40a12f164bd84894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->