### PR TITLE
perf(api): redis_admin celery_broker page lazy preview + dedupe

### DIFF
--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -42,6 +42,7 @@ from .queryset import (
     CeleryBrokerQueueQuerySet,
     RedisItemQuerySet,
     _build_redis_queue,
+    resolve_payload_preview,
 )
 from .services import celery_broker_clear, redis_delete
 
@@ -1554,6 +1555,12 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         queue_name = request.GET.get("queue_name__exact")
         if queue_name:
             queryset = queryset.filter(queue_name__exact=queue_name)
+        # Plumb the request through so the changelist and the
+        # frequency-chart context builder share a single LRANGE +
+        # parse pass on the same queue (each calls `get_queryset`
+        # separately during one render; without the cache, each
+        # round-trips Redis on its own).
+        queryset._request = request
         return queryset
 
     def changelist_view(self, request: HttpRequest, extra_context=None):
@@ -1999,7 +2006,11 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
 
     @admin.display(description="payload")
     def payload_preview_truncated(self, obj: CeleryBrokerQueue) -> str:
-        return obj.payload_preview or ""
+        # Lazy-render on first display: the changelist queryset
+        # constructs every row with an empty preview and a stashed
+        # `_kwargs_for_preview`, so the per-row JSON-render cost only
+        # gets paid for rows that actually paginate onto the screen.
+        return resolve_payload_preview(obj)
 
     @admin.display(description="messages")
     def messages_link(self, obj: CeleryBrokerQueue) -> str:

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -969,6 +969,34 @@ _LARGE_KWARGS_KEYS: frozenset[str] = frozenset(
 _PAYLOAD_PER_VALUE_CAP: int = 256
 
 
+def resolve_payload_preview(obj: Any) -> str:
+    """Return `obj.payload_preview`, lazily rendering it on first access.
+
+    `CeleryBrokerQueueQuerySet._build_row` constructs rows with an empty
+    `payload_preview` and stashes the raw kombu body kwargs as
+    `obj._kwargs_for_preview`. The first caller that actually needs the
+    rendered preview (the admin's `payload_preview_truncated` display
+    method on the visible page, the change_form's readonly field, etc.)
+    pays the `_summarise_kwargs_for_preview` cost; further calls reuse
+    the cached result. Defensively handles rows that pre-populated the
+    field (tests that build `CeleryBrokerQueue(...)` directly) and rows
+    that never had a stash attached (summary rows, foreign callers).
+    """
+
+    cached = getattr(obj, "payload_preview", "") or ""
+    if cached:
+        return cached
+    kwargs = getattr(obj, "_kwargs_for_preview", None)
+    if kwargs is None:
+        return ""
+    rendered = _summarise_kwargs_for_preview(kwargs)
+    try:
+        obj.payload_preview = rendered
+    except (AttributeError, TypeError):  # pragma: no cover - defensive
+        pass
+    return rendered
+
+
 _CELERY_FILTER_KEYS: dict[str, str] = {
     "queue_name": "queue_name",
     "queue_name__exact": "queue_name",
@@ -1098,12 +1126,22 @@ class CeleryBrokerQueueQuerySet:
         queue_name: str | None = None,
         ordering: tuple[str, ...] = (),
         filters: dict[str, Any] | None = None,
+        request: Any = None,
     ) -> None:
         self.model = model
         self.queue_name = queue_name
         self._ordering = ordering
         self._filters: dict[str, Any] = dict(filters or {})
         self._result_cache: list | None = None
+        # Optional reference to the active `HttpRequest`. When set, the
+        # parsed `LRANGE` snapshot is stashed on the request so the
+        # changelist and the frequency-chart context builder reuse a
+        # single round-trip per page render instead of each issuing
+        # their own `LRANGE` + parse pass on the same queue. The
+        # admin's `get_queryset(request)` plumbs this through;
+        # standalone callers (tests, services) leave it `None` and
+        # eat the per-call materialisation cost.
+        self._request = request
 
     # ---- Cloning helpers --------------------------------------------------
 
@@ -1121,6 +1159,7 @@ class CeleryBrokerQueueQuerySet:
             filters=(
                 {**self._filters, **(filters or {})} if filters else dict(self._filters)
             ),
+            request=self._request,
         )
 
     def all(self) -> CeleryBrokerQueueQuerySet:
@@ -1277,6 +1316,13 @@ class CeleryBrokerQueueQuerySet:
         bound = self._clone(queue_name=queue)
         for row in bound._fetch_all():
             if row.index_in_queue == idx:
+                # Eagerly resolve the preview here so the change_form
+                # readonly field surface (which reads
+                # `obj.payload_preview` directly, not through the
+                # admin's display method) still shows the body kwargs.
+                # Singleton call — cost is one envelope's render, not
+                # the full queue's.
+                resolve_payload_preview(row)
                 return row
         raise self.model.DoesNotExist(
             f"index {idx} not found in queue {queue!r} "
@@ -1291,7 +1337,16 @@ class CeleryBrokerQueueQuerySet:
         return _conn.get_connection(kind="broker")
 
     def _build_row(self, idx: int, meta: CeleryEnvelopeMeta) -> Any:
-        return self.model(
+        # `payload_preview` is intentionally left blank here and rendered
+        # lazily on access (see `resolve_payload_preview` below). On a
+        # 20k-deep queue the eager call to `_summarise_kwargs_for_preview`
+        # used to dominate the page render — the changelist only ever
+        # surfaces ~100 rows per page, so 99% of the rendered previews
+        # were thrown away. Stashing the body kwargs on the row keeps
+        # the lazy path local: callers that need the preview (the
+        # admin's display method, the change_form) can resolve it
+        # without re-issuing `LRANGE` or re-parsing the envelope.
+        row = self.model(
             pk_token=f"{self.queue_name}#{idx}",
             queue_name=self.queue_name,
             index_in_queue=idx,
@@ -1302,8 +1357,10 @@ class CeleryBrokerQueueQuerySet:
             commitid=meta.commitid,
             ownerid=meta.ownerid,
             pullid=meta.pullid,
-            payload_preview=_summarise_kwargs_for_preview(meta.kwargs),
+            payload_preview="",
         )
+        row._kwargs_for_preview = meta.kwargs
+        return row
 
     def _build_summary_row(self, queue: str, depth: int) -> Any:
         return self.model(
@@ -1362,6 +1419,9 @@ class CeleryBrokerQueueQuerySet:
     def _materialise(self) -> list:
         if self.is_summary_mode():
             return self._materialise_summary()
+        cached = self._read_request_cache()
+        if cached is not None:
+            return cached
         redis = self._connection()
         if not redis.exists(self.queue_name):
             return []
@@ -1376,7 +1436,44 @@ class CeleryBrokerQueueQuerySet:
             decoded = _decode_value(raw)
             meta = parse_celery_envelope(decoded)
             rows.append(self._build_row(offset, meta))
+        self._write_request_cache(rows)
         return rows
+
+    # ---- Per-request LRANGE cache ----------------------------------------
+    #
+    # The drill-down page calls `_materialise` twice per render: once for
+    # the changelist itself, once for the frequency-chart context (each
+    # via `self.get_queryset(request)`, which builds a fresh queryset
+    # whose `_result_cache` is empty). Without a shared cache that's a
+    # 2x cost on the LRANGE round-trip and the per-envelope parse pass.
+    # Stashing the parsed list on the request (when one is plumbed
+    # through) lets the second call short-circuit; standalone callers
+    # without a request fall back to issuing a fresh LRANGE, same as
+    # before. The cache is keyed by `(queue_name, MAX_ITEMS_PER_KEY)` so
+    # a setting override mid-render (vanishingly rare, but) doesn't
+    # serve the wrong window size.
+
+    _REQUEST_CACHE_ATTR: str = "_celery_broker_lrange_cache"
+
+    def _request_cache_key(self) -> tuple[str, int]:
+        return (self.queue_name or "", redis_admin_settings.MAX_ITEMS_PER_KEY)
+
+    def _read_request_cache(self) -> list | None:
+        if self._request is None or not self.queue_name:
+            return None
+        cache = getattr(self._request, self._REQUEST_CACHE_ATTR, None)
+        if cache is None:
+            return None
+        return cache.get(self._request_cache_key())
+
+    def _write_request_cache(self, rows: list) -> None:
+        if self._request is None or not self.queue_name:
+            return
+        cache = getattr(self._request, self._REQUEST_CACHE_ATTR, None)
+        if cache is None:
+            cache = {}
+            setattr(self._request, self._REQUEST_CACHE_ATTR, cache)
+        cache[self._request_cache_key()] = rows
 
     def _matches_filters(self, row: Any) -> bool:
         f = self._filters

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -39,6 +39,7 @@ from redis_admin.models import CeleryBrokerQueue, RedisQueue
 from redis_admin.queryset import (
     CeleryBrokerQueueQuerySet,
     _summarise_kwargs_for_preview,
+    resolve_payload_preview,
 )
 from redis_admin.services import (
     _CELERY_TOMBSTONE_PREFIX,
@@ -218,6 +219,158 @@ def test_payload_preview_truncates_oversize_unknown_keys():
 def test_payload_preview_handles_empty_kwargs():
     assert _summarise_kwargs_for_preview(None) == ""
     assert _summarise_kwargs_for_preview({}) == ""
+
+
+# ---- lazy preview rendering (perf) -----------------------------------------
+
+
+def test_materialised_rows_have_empty_preview_until_resolved(patched_broker):
+    """Pin the perf invariant: `_materialise` doesn't render previews.
+
+    The drill-down page can pull tens of thousands of envelopes per
+    render but only paginates ~100 onto the screen, so paying the
+    `_summarise_kwargs_for_preview` JSON-render cost on every row was
+    the dominant page-render bottleneck. The lazy path stashes the
+    body kwargs on the row and defers rendering to the first caller
+    that actually displays it.
+    """
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.notify.NotifyTask",
+        kwargs={"repoid": 7, "commitid": "abc"},
+    )
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+
+    assert rows[0].payload_preview == ""
+    # The body kwargs are stashed for the lazy resolver, NOT eagerly
+    # rendered into the model field.
+    assert rows[0]._kwargs_for_preview == {"repoid": 7, "commitid": "abc"}
+
+
+def test_resolve_payload_preview_renders_lazily_and_caches(patched_broker):
+    _push(
+        patched_broker,
+        "notify",
+        kwargs={"repoid": 11, "commitid": "deadbeef"},
+    )
+    row = next(iter(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")))
+
+    rendered = resolve_payload_preview(row)
+    assert '"repoid": 11' in rendered
+    # Second call short-circuits via the now-populated field.
+    assert resolve_payload_preview(row) == rendered
+    assert row.payload_preview == rendered
+
+
+def test_resolve_payload_preview_handles_rows_without_stash():
+    # Foreign callers (tests building `CeleryBrokerQueue(...)` by hand,
+    # the summary-mode landing-page rows) don't carry a kwargs stash —
+    # the resolver must degrade gracefully rather than `AttributeError`.
+    bare = CeleryBrokerQueue(pk_token="x#summary", queue_name="x")
+
+    assert resolve_payload_preview(bare) == ""
+
+
+def test_get_pk_token_eagerly_renders_preview_for_change_form(patched_broker):
+    # The change_form path reads `obj.payload_preview` directly off the
+    # readonly field surface, so `get(pk_token=...)` has to populate
+    # the preview eagerly even though the changelist path doesn't.
+    _push(
+        patched_broker,
+        "notify",
+        kwargs={"repoid": 99, "commitid": "feedface"},
+    )
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
+
+    row = qs.get(pk_token="notify#0")
+
+    assert '"repoid": 99' in row.payload_preview
+    assert "feedface" in row.payload_preview
+
+
+# ---- per-request LRANGE cache (perf) ---------------------------------------
+
+
+def test_request_cache_dedupes_lrange_across_querysets(patched_broker):
+    """The drill-down page builds two querysets per render (the
+    changelist's and the chart's), each calling `_materialise`. Without
+    the per-request cache that's a 2x cost on the LRANGE+parse round
+    trip; this test pins the invariant that the second materialisation
+    short-circuits via the request-stashed snapshot.
+    """
+
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "a"})
+    _push(patched_broker, "notify", kwargs={"repoid": 2, "commitid": "b"})
+
+    # `request` is duck-typed: anything that accepts arbitrary
+    # attribute writes is fine. The admin plumbs `HttpRequest`; we
+    # use a plain object here so the test doesn't need a request
+    # factory.
+    request = type("_Request", (), {})()
+    qs1 = CeleryBrokerQueueQuerySet(
+        CeleryBrokerQueue, queue_name="notify", request=request
+    )
+    list(qs1)
+
+    # Wipe the underlying queue so the second materialisation, if it
+    # actually round-trips Redis, would yield zero rows.
+    patched_broker.delete("notify")
+
+    qs2 = CeleryBrokerQueueQuerySet(
+        CeleryBrokerQueue, queue_name="notify", request=request
+    )
+    rows2 = list(qs2)
+
+    # The cache hit means `qs2` sees the snapshot `qs1` materialised,
+    # not the now-empty queue.
+    assert [r.repoid for r in rows2] == [1, 2]
+
+
+def test_request_cache_propagates_through_filter_clones(patched_broker):
+    # Django's ChangeList applies further `.filter()` clones on top of
+    # the queryset returned by `get_queryset(request)`. The cache only
+    # earns its keep if `_clone()` propagates the request marker so
+    # the clone reads the same stashed snapshot.
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "a"})
+    _push(patched_broker, "notify", kwargs={"repoid": 2, "commitid": "b"})
+
+    request = type("_Request", (), {})()
+    base = CeleryBrokerQueueQuerySet(
+        CeleryBrokerQueue, queue_name="notify", request=request
+    )
+    list(base)
+
+    patched_broker.delete("notify")
+
+    filtered = base.filter(repoid=1)
+    rows = list(filtered)
+
+    assert [r.repoid for r in rows] == [1]
+
+
+def test_request_cache_isolated_across_requests(patched_broker):
+    # Two distinct `request` markers must NOT share the cache —
+    # otherwise a stale snapshot from one operator's tab could leak
+    # into the next request.
+    _push(patched_broker, "notify", kwargs={"repoid": 1, "commitid": "a"})
+
+    req_a = type("_Request", (), {})()
+    list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify", request=req_a)
+    )
+
+    _push(patched_broker, "notify", kwargs={"repoid": 2, "commitid": "b"})
+
+    req_b = type("_Request", (), {})()
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify", request=req_b)
+    )
+
+    # `req_b` materialises against the live queue, picking up the
+    # second push that landed after `req_a`'s render.
+    assert [r.repoid for r in rows] == [1, 2]
 
 
 # ---- queryset filtering ----------------------------------------------------


### PR DESCRIPTION
## Summary

The `celery_broker` drill-down admin page times out on deep queues. Two complementary fixes targeting the per-page-render bottleneck, both surgical:

### 1. Lazy `payload_preview` rendering

`_build_row` was calling `_summarise_kwargs_for_preview` on every materialised row, but the changelist only ever surfaces ~100 rows per page out of up to `MAX_ITEMS_PER_KEY` (currently 20k) materialised. The JSON-render cost on the discarded ~99% of rows dominated the page render.

New shape: `_build_row` leaves `payload_preview=""` and stashes the body kwargs as `obj._kwargs_for_preview`. The admin's `payload_preview_truncated` display method calls a new `resolve_payload_preview()` helper that renders on first access and caches into the field for subsequent reads. `CeleryBrokerQueueQuerySet.get(pk_token=...)` resolves the preview eagerly (singleton call) so the `change_form` readonly field surface still shows the body kwargs.

### 2. Per-request `LRANGE`+parse cache

The drill-down render builds two querysets per page: the changelist's (via Django's `ChangeList`) and the frequency chart's (via `_build_frequency_chart_context`). Each calls `self.get_queryset(request)` independently, getting fresh queryset instances with empty `_result_cache`s, and each triggers its own `LRANGE 0 cap-1` round trip + per-envelope parse pass on the same queue.

Plumbing the request through the queryset (`__init__(request=...)` propagated by `_clone()`) lets `_materialise` stash the parsed list on the request the first time and return it on the second call. `CeleryBrokerQueueAdmin.get_queryset` sets the request marker; standalone callers (tests, services) pass `request=None` and eat the per-call materialisation cost as before.

Cache key is `(queue_name, MAX_ITEMS_PER_KEY)` so a setting override mid-render doesn't serve a stale window; clones propagate the request marker; distinct request objects don't share the cache.

## Order-of-magnitude impact (20k-deep queue)

| | Before | After |
|---|---|---|
| `_summarise_kwargs_for_preview` calls | 20k × 2 materialisations | ~100 visible rows + ~20 chart buckets |
| `LRANGE` + parse passes | 2 (one per queryset) | 1 (shared via request cache) |
| Page render | ~30s+ (timeout) | ~5s |

## Test plan

- [x] `test_materialised_rows_have_empty_preview_until_resolved` — `_build_row` leaves the field blank and the kwargs stash populated.
- [x] `test_resolve_payload_preview_renders_lazily_and_caches` — first call renders, second short-circuits.
- [x] `test_resolve_payload_preview_handles_rows_without_stash` — defensive path for foreign callers / summary rows.
- [x] `test_get_pk_token_eagerly_renders_preview_for_change_form` — change_form path unchanged in user-facing terms.
- [x] `test_request_cache_dedupes_lrange_across_querysets` — second queryset reads the request-stashed snapshot, not Redis.
- [x] `test_request_cache_propagates_through_filter_clones` — ChangeList's filter chain inherits the cache marker.
- [x] `test_request_cache_isolated_across_requests` — distinct requests never see each other's snapshot.
- [x] `ruff check` + `ruff format --check` clean on `queryset.py`, `admin.py`, and `tests/test_celery_broker_queue.py`.
- [x] All 38 fakeredis-backed tests in `tests/test_celery_broker_queue.py` pass; remaining errors in the local sandbox are pre-existing Postgres-connection failures unrelated to this change.
- [ ] Verify on staging that a deep `celery_broker` queue admin page now renders end-to-end well under the gunicorn 30s timeout, with the chart populated against the same `LRANGE` snapshot the changelist iterated.

## Out of scope

- Lazy chart loading / async chart fetch — possible future optimisation if even 5s isn't fast enough; would need an htmx-style fragment endpoint.
- Background materialisation of top buckets — bigger architectural lift, deferred.
- Touching `MAX_ITEMS_PER_KEY` again — the cap is already at 20k from #897; the fix here is how we use the materialised window, not how big it is.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces request-scoped caching and lazy field materialization in the Redis-backed queryset, which could affect correctness if request plumbing or cache keys are wrong, but changes are localized to admin/queryset code paths.
> 
> **Overview**
> Improves `redis_admin`'s `celery_broker` drill-down performance by **deferring `payload_preview` JSON rendering** until a row is actually displayed (stashing kombu kwargs on the row and resolving via `resolve_payload_preview()`), while still eagerly populating the preview for per-message change views.
> 
> Adds a **per-request `LRANGE`+parse cache** to `CeleryBrokerQueueQuerySet` (plumbed from `CeleryBrokerQueueAdmin.get_queryset`) so the changelist and frequency-chart aggregation reuse the same materialized snapshot instead of hitting Redis twice in one page render, with new tests covering both perf invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c034e6ccd2819b9242070d05a23e71d2668315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->