### PR TITLE
fix(worker): cap BA retryable-error and notify lock retry countdown to visibility timeout

### DIFF
--- a/apps/worker/tasks/bundle_analysis_notify.py
+++ b/apps/worker/tasks/bundle_analysis_notify.py
@@ -84,7 +84,17 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
                     "notify_attempted": False,
                     "notify_succeeded": None,
                 }
-            self.retry(max_retries=self.max_retries, countdown=retry.countdown)
+            # Cap at 870s (30s below the 900s Redis visibility timeout) so the
+            # message is never held unacked longer than the visibility window.
+            # Without this cap, LockManager can hand back countdowns up to
+            # MAX_RETRY_COUNTDOWN_SECONDS (5 hours), and any value over 900s
+            # causes the broker to redeliver the still-unacked ETA message to
+            # additional workers - producing exponential task amplification on
+            # the bundles_analysis queue. Mirrors the cap PR #852 applied to
+            # the analogous LockRetry path in bundle_analysis_processor.py.
+            self.retry(
+                max_retries=self.max_retries, countdown=min(retry.countdown, 870)
+            )
 
     @sentry_sdk.trace
     def process_impl_within_lock(

--- a/apps/worker/tasks/bundle_analysis_processor.py
+++ b/apps/worker/tasks/bundle_analysis_processor.py
@@ -315,9 +315,17 @@ class BundleAnalysisProcessorTask(
                         "result": result.as_dict(),
                     },
                 )
+                # Cap at 870s (30s below the 900s Redis visibility timeout) so
+                # the message is never held unacked longer than the visibility
+                # window. Without this cap, retries 5+ produce countdowns >900s
+                # (e.g. 960s, 1920s, 3840s, 7680s, 15360s) which the Redis
+                # broker redelivers to additional workers, causing exponential
+                # task amplification on retryable errors like
+                # `file_not_in_storage`. Mirrors the cap applied to the
+                # LockRetry path above (PR #852).
                 self.retry(
                     max_retries=self.max_retries,
-                    countdown=30 * (2**self.request.retries),
+                    countdown=min(30 * (2**self.request.retries), 870),
                 )
             result.update_upload(carriedforward=carriedforward)
             db_session.commit()

--- a/apps/worker/tasks/tests/unit/test_bundle_analysis_notify_task.py
+++ b/apps/worker/tasks/tests/unit/test_bundle_analysis_notify_task.py
@@ -1,9 +1,14 @@
+from contextlib import contextmanager
+
+import pytest
+
 from database.tests.factories import CommitFactory
 from services.bundle_analysis.notify import BundleAnalysisNotifyReturn
 from services.bundle_analysis.notify.types import (
     NotificationSuccess,
     NotificationType,
 )
+from services.lock_manager import LockRetry
 from tasks.bundle_analysis_notify import BundleAnalysisNotifyTask
 
 
@@ -56,3 +61,66 @@ def test_bundle_analysis_notify_skips_if_all_processing_fail(dbsession):
         "notify_attempted": False,
         "notify_succeeded": NotificationSuccess.ALL_ERRORED,
     }
+
+
+@pytest.mark.parametrize(
+    "lock_countdown, expected_countdown",
+    [
+        # Below the cap: pass through unchanged.
+        (60, 60),
+        (300, 300),
+        (869, 869),
+        # At and above the cap: pinned at 870.
+        (870, 870),
+        (900, 870),
+        (1800, 870),
+        # LockManager.MAX_RETRY_COUNTDOWN_SECONDS upper bound (5 hours).
+        (18000, 870),
+    ],
+)
+def test_bundle_analysis_notify_task_lock_retry_countdown_capped(
+    mocker,
+    dbsession,
+    lock_countdown,
+    expected_countdown,
+):
+    """The LockRetry retry path must cap its countdown below the 900s Redis
+    visibility timeout so the broker never redelivers the still-unacked ETA
+    message to additional workers (which would amplify notify-side tasks the
+    same way file_not_in_storage amplified processor-side tasks)."""
+    commit = CommitFactory.create()
+    dbsession.add(commit)
+    dbsession.flush()
+
+    @contextmanager
+    def _raise_lock_retry(*args, **kwargs):
+        raise LockRetry(
+            countdown=lock_countdown,
+            max_retries_exceeded=False,
+            retry_num=1,
+            max_retries=10,
+            lock_name="bundle_analysis_notify",
+            repoid=commit.repoid,
+            commitid=commit.commitid,
+        )
+        yield  # pragma: no cover
+
+    mocker.patch(
+        "tasks.bundle_analysis_notify.get_bundle_analysis_lock_manager",
+        return_value=mocker.MagicMock(locked=_raise_lock_retry),
+    )
+
+    task = BundleAnalysisNotifyTask()
+    retry_call = mocker.patch.object(task, "retry")
+
+    task.run_impl(
+        dbsession,
+        [{"error": None}],
+        repoid=commit.repoid,
+        commitid=commit.commitid,
+        commit_yaml={},
+    )
+
+    retry_call.assert_called_once()
+    assert retry_call.call_args.kwargs["countdown"] == expected_countdown
+    assert retry_call.call_args.kwargs["countdown"] < 900

--- a/apps/worker/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/apps/worker/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -2117,3 +2117,97 @@ def test_bundle_analysis_processor_task_cleanup_with_none_result(
 
     assert result == previous_result
     assert upload.state == "error"
+
+
+@pytest.mark.parametrize(
+    "request_retries, expected_countdown",
+    [
+        (0, 30),
+        (1, 60),
+        (2, 120),
+        (3, 240),
+        (4, 480),
+        # retries 5+ would naturally produce countdowns >= 960s, which exceeds
+        # the 900s Redis visibility timeout and causes message redelivery /
+        # exponential task amplification. The cap pins them at 870s.
+        (5, 870),
+        (6, 870),
+        (7, 870),
+        (8, 870),
+        (9, 870),
+    ],
+)
+def test_bundle_analysis_processor_task_retryable_error_countdown_capped(
+    mocker,
+    dbsession,
+    mock_storage,
+    request_retries,
+    expected_countdown,
+):
+    """The retryable-error retry path must cap its countdown below the 900s
+    Redis visibility timeout so the broker never redelivers the still-unacked
+    ETA message to additional workers (which produced exponential task
+    amplification on the bundles_analysis queue, e.g. for repeated
+    `file_not_in_storage` errors).
+    """
+    storage_path = (
+        "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite"
+    )
+    mock_storage.write_file(get_bucket_name(), storage_path, "test-content")
+
+    mocker.patch.object(
+        BundleAnalysisProcessorTask,
+        "app",
+        tasks={
+            bundle_analysis_save_measurements_task_name: mocker.MagicMock(),
+        },
+    )
+
+    commit = CommitFactory.create(state="pending")
+    dbsession.add(commit)
+    dbsession.flush()
+
+    commit_report = CommitReport(commit_id=commit.id_)
+    dbsession.add(commit_report)
+    dbsession.flush()
+
+    upload = UploadFactory.create(storage_path=storage_path, report=commit_report)
+    dbsession.add(upload)
+    dbsession.flush()
+
+    retryable_error = ProcessingError(
+        code="file_not_in_storage",
+        params={"location": storage_path},
+        is_retryable=True,
+    )
+    processing_result = ProcessingResult(
+        upload=upload,
+        commit=commit,
+        error=retryable_error,
+    )
+    mocker.patch(
+        "services.bundle_analysis.report.BundleAnalysisReportService.process_upload",
+        return_value=processing_result,
+    )
+
+    task = BundleAnalysisProcessorTask()
+    task.request.retries = request_retries
+    # Pin the attempts header to 1 for every case so we always take the retry
+    # branch (not the max-retries-exceeded early return). In production these
+    # two counters can drift apart anyway: visibility-timeout redeliveries
+    # increment `attempts` while keeping `request.retries` low.
+    task.request.headers = {"attempts": 1}
+    retry_call = mocker.patch.object(task, "retry")
+
+    task.run_impl(
+        dbsession,
+        [],
+        repoid=commit.repoid,
+        commitid=commit.commitid,
+        commit_yaml={},
+        params={"upload_id": upload.id_, "commit": commit.commitid},
+    )
+
+    retry_call.assert_called_once()
+    assert retry_call.call_args.kwargs["countdown"] == expected_countdown
+    assert retry_call.call_args.kwargs["countdown"] < 900


### PR DESCRIPTION
## Summary

Closes the two remaining uncapped `self.retry(countdown=...)` sites in the bundle analysis pipeline. PR #852 already capped the `LockRetry` path in `bundle_analysis_processor.py` at 870s (30s below the 900s Redis visibility timeout); this PR applies the same `min(..., 870)` cap to:

1. **`bundle_analysis_processor.py`** - the `is_retryable` `ProcessingError` branch (e.g. `FileNotInStorageError`, `PutRequestRateLimitError`). The hand-rolled `30 * (2**self.request.retries)` formula crosses 900s at retry 5 (960s) and reaches 15360s by retry 9.

2. **`bundle_analysis_notify.py`** - the `LockRetry` branch passed `retry.countdown` straight through, even though `LockManager` returns values up to `MAX_RETRY_COUNTDOWN_SECONDS = 5 hours`.

## Why this matters

Any `countdown` above the 900s Redis visibility timeout causes the broker to redeliver the still-unacked ETA message to additional workers. Each redelivered copy executes the same task body, hits the same retryable error, and emits another retry message:

```
retry  countdown   redeliveries   copies executing
-----  ---------   ------------   ----------------
  0       30s          0                 1
  1       60s          0                 1
  2      120s          0                 1
  3      240s          0                 1
  4      480s          0                 1
  5      960s          1                 2
  6     1920s          2                 6
  7     3840s          4                30
  8     7680s          8               270
  9    15360s         17             4,860
```

That is ~5,172 cumulative task executions per ghost upload before `max_retries=10` stops the chain. Empirical evidence from a recent NodeKit CI run showed 17 silent bundle PUT failures producing ~82,600 simultaneously queued `BundleAnalysisProcessor` tasks (17 ghosts x ~4,860 peak copies) on the `bundles_analysis` queue.

After this PR, every retry path under bundle analysis is bounded at 870s, so the broker can never redeliver an unacked retry message. Total work per retryable error is bounded at `max_retries` instead of the cascade.

## Tests

- `test_bundle_analysis_processor_task_retryable_error_countdown_capped` (10 parametrized cases over retries 0..9) - asserts `countdown == min(30*2**n, 870)` and `< 900` for every retry stage. Confirms the cap kicks in at retry 5.
- `test_bundle_analysis_notify_task_lock_retry_countdown_capped` (7 parametrized cases over `lock_countdown` 60s..18000s) - asserts pass-through below the cap and clamping at 870s above it.

All 49 tests in `test_bundle_analysis_processor_task.py` and `test_bundle_analysis_notify_task.py` pass locally.

## Out of scope (tracked separately)

- B1: short-circuit `file_not_in_storage` after 2 retries OR `Upload.created_at > 5min` (eliminates wasted retries on uploads that will demonstrably never appear).
- A3: re-introduce a `BaseCodecovTask.retry()` global clamp (PR #720 was reverted in PR #743; ship A3 once we understand the original revert reason).
- F1-F7: bundler-plugin-side changes (`failOnUploadError`, jittered backoff, cancel endpoint, summary log, provider-fallthrough warning) to stop ghost uploads at the source.

## Test plan

- [x] Local pytest of both task test files (49 tests, 0 failures).
- [ ] CI green on the PR.
- [ ] Post-deploy: watch `bundles_analysis` queue length and `worker_task_counts_retries_by_count{retry_count>=5}` to confirm no further amplification.

Refs CODECOV-59

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2174644c3e2d5a7734c03a706b3dbc3edfdab3bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->