### PR TITLE
ci: consolidate self-hosted build; wire pytest-xdist (off by default)

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -22,6 +22,12 @@ on:
       make_target_prefix:
         type: string
         default: ""
+      # Forwarded to pytest as `-n <value>` via the Makefile. Accepts any value
+      # pytest-xdist accepts (e.g. `auto`, `logical`, `4`). Empty (default) runs
+      # tests serially.
+      pytest_xdist:
+        type: string
+        default: ""
     outputs:
       tests_passed:
         # Silly issue with returning job results as workflow outputs
@@ -67,11 +73,11 @@ jobs:
 
       - name: Run unit tests
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.run_unit PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make ${{ inputs.make_target_prefix }}test_env.run_unit PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }} PYTEST_XDIST=${{ inputs.pytest_xdist }}
       - name: Run integration tests
         if: ${{ !cancelled() && inputs.run_integration == true }}
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.run_integration PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make ${{ inputs.make_target_prefix }}test_env.run_integration PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }} PYTEST_XDIST=${{ inputs.pytest_xdist }}
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -48,9 +48,13 @@ jobs:
       flag_prefix: api
       pytest_rootdir: /app
       make_target_prefix: api.
-      # API tests are pure pytest-django; xdist is supported via per-worker
-      # test DB suffixing baked into pytest-django.
-      pytest_xdist: auto
+      # NOTE: API tests intentionally run serially. Enabling xdist exposed
+      # ordering-sensitive test failures in `upload/tests/views/test_uploads.py`
+      # (parametrized tests where `upload.flags.all()` returns a subset of
+      # the M2M memberships actually present in the DB). Re-enable once those
+      # tests are made worker-safe; the wiring (set this to `auto`) is in
+      # place so it's a one-line flip.
+      pytest_xdist: ""
 
   # Builds the self-hosted image on every run and pushes the rolling tag only
   # on push-to-main. Previously a separate `api-self-hosted` job re-built the

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -48,7 +48,14 @@ jobs:
       flag_prefix: api
       pytest_rootdir: /app
       make_target_prefix: api.
+      # API tests are pure pytest-django; xdist is supported via per-worker
+      # test DB suffixing baked into pytest-django.
+      pytest_xdist: auto
 
+  # Builds the self-hosted image on every run and pushes the rolling tag only
+  # on push-to-main. Previously a separate `api-self-hosted` job re-built the
+  # same image on push-to-main just to push it; this consolidates them so we
+  # only build the self-hosted image once per workflow run.
   api-build-self-hosted:
     name: Build Self Hosted (API)
     if: ${{ inputs.skip == false }}
@@ -56,6 +63,7 @@ jobs:
     uses: ./.github/workflows/_self-hosted.yml
     secrets: inherit
     with:
+      push_rolling: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
       repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
       output_directory: apps/codecov-api
       make_target_prefix: api.
@@ -71,18 +79,6 @@ jobs:
       repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
       output_directory: apps/codecov-api
       sentry_project: api
-      make_target_prefix: api.
-
-  api-self-hosted:
-    name: Push Self Hosted Image (API)
-    needs: [api-build-self-hosted, api-test]
-    secrets: inherit
-    if: ${{ inputs.skip == false && github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
-    uses: ./.github/workflows/_self-hosted.yml
-    with:
-      push_rolling: true
-      repo: ${{ vars.CODECOV_API_IMAGE_V2 || vars.CODECOV_API_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-api' }}
-      output_directory: apps/codecov-api
       make_target_prefix: api.
 
   # This job works around a strange interaction between reusable workflows and

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -39,6 +39,9 @@ jobs:
       flag_prefix: shared
       pytest_rootdir: /app
       make_target_prefix: shared.
+      # Shared tests use pytest-django; xdist is supported via per-worker test
+      # DB suffixing baked into pytest-django.
+      pytest_xdist: auto
 
   shared-benchmark:
     name: Benchmarks (Shared)

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -39,9 +39,11 @@ jobs:
       flag_prefix: shared
       pytest_rootdir: /app
       make_target_prefix: shared.
-      # Shared tests use pytest-django; xdist is supported via per-worker test
-      # DB suffixing baked into pytest-django.
-      pytest_xdist: auto
+      # NOTE: shared tests intentionally run serially. Enabling xdist exposed
+      # races on the per-worker postgres test DB (`test_postgres_gw0` "already
+      # exists" / "is being accessed by other users") inside shared's custom
+      # `django_setup_test_db`. Re-enable once that path is xdist-safe.
+      pytest_xdist: ""
 
   shared-benchmark:
     name: Benchmarks (Shared)

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -47,7 +47,16 @@ jobs:
       flag_prefix: worker
       pytest_rootdir: /app
       make_target_prefix: worker.
+      # NOTE: worker tests intentionally run serially. The SQLAlchemy DB setup
+      # in apps/worker/conftest.py expects the deprecated xdist `slaveinput`
+      # API and mutates an immutable `engine.url`; enabling xdist here without
+      # fixing those would race on `test_postgres_sqlalchemy`.
+      pytest_xdist: ""
 
+  # Builds the self-hosted image on every run and pushes the rolling tag only
+  # on push-to-main. Previously a separate `worker-self-hosted` job re-built the
+  # same image on push-to-main just to push it; this consolidates them so we
+  # only build the self-hosted image once per workflow run.
   worker-build-self-hosted:
     name: Build Self Hosted (Worker)
     if: ${{ inputs.skip == false }}
@@ -55,6 +64,7 @@ jobs:
     uses: ./.github/workflows/_self-hosted.yml
     secrets: inherit
     with:
+      push_rolling: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
       repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
       output_directory: apps/worker
       make_target_prefix: worker.
@@ -70,18 +80,6 @@ jobs:
       repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
       output_directory: apps/worker
       sentry_project: worker
-      make_target_prefix: worker.
-
-  worker-self-hosted:
-    name: Push Self Hosted Image (Worker)
-    needs: [worker-build-self-hosted, worker-test]
-    secrets: inherit
-    if: ${{ inputs.skip == false && github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
-    uses: ./.github/workflows/_self-hosted.yml
-    with:
-      push_rolling: true
-      repo: ${{ vars.CODECOV_WORKER_IMAGE_V2 || vars.CODECOV_WORKER_IMAGE_V2_SELF_HOSTED || 'codecov/self-hosted-worker' }}
-      output_directory: apps/worker
       make_target_prefix: worker.
 
   # This job works around a strange interaction between reusable workflows and

--- a/apps/codecov-api/conftest.py
+++ b/apps/codecov-api/conftest.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from pathlib import Path
 from unittest import mock
 
@@ -23,7 +25,19 @@ def pytest_configure(config):
     """
     pytest_configure is the canonical way to configure test server for entire testing suite
     """
-    pass
+    # Isolate the system tempdir per xdist worker. Some tests (e.g. those
+    # exercising `BundleAnalysisReport`) scan and clean up `/tmp/bundle_analysis_*`
+    # to verify cleanup behavior; under xdist those operations would race
+    # against other workers' temp files. Pointing each worker at its own
+    # subdirectory keeps that scan/cleanup logic worker-local. Tests that
+    # check the system tempdir should use `tempfile.gettempdir()` rather than
+    # hard-coding `/tmp`.
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id:
+        worker_tmp = os.path.join(tempfile.gettempdir(), f"pytest_{worker_id}")
+        os.makedirs(worker_tmp, exist_ok=True)
+        os.environ["TMPDIR"] = worker_tmp
+        tempfile.tempdir = worker_tmp
 
 
 @pytest.fixture

--- a/apps/codecov-api/graphql_api/tests/test_commit.py
+++ b/apps/codecov-api/graphql_api/tests/test_commit.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import os
+import tempfile
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, PropertyMock, patch
 
@@ -1006,7 +1007,8 @@ class TestCommit(GraphQLTestHelper, TestCase):
         }
 
     def test_bundle_analysis_sqlite_file_deleted(self):
-        os.system("rm -rf /tmp/bundle_analysis_*")
+        tmpdir = tempfile.gettempdir()
+        os.system(f"rm -rf {tmpdir}/bundle_analysis_*")
 
         base_commit_report = CommitReportFactory(
             commit=self.parent_commit,
@@ -1055,13 +1057,14 @@ class TestCommit(GraphQLTestHelper, TestCase):
         }
         self.gql_request(query, variables=variables)
 
-        for file in os.listdir("/tmp"):
+        for file in os.listdir(tmpdir):
             assert not file.startswith("bundle_analysis_")
-        os.system("rm -rf /tmp/bundle_analysis_*")
+        os.system(f"rm -rf {tmpdir}/bundle_analysis_*")
 
     @patch("graphql_api.views.os.unlink")
     def test_bundle_analysis_sqlite_file_not_deleted(self, os_unlink_mock):
-        os.system("rm -rf /tmp/bundle_analysis_*")
+        tmpdir = tempfile.gettempdir()
+        os.system(f"rm -rf {tmpdir}/bundle_analysis_*")
         os_unlink_mock.side_effect = Exception("something went wrong")
 
         base_commit_report = CommitReportFactory(
@@ -1112,12 +1115,12 @@ class TestCommit(GraphQLTestHelper, TestCase):
         self.gql_request(query, variables=variables)
 
         found = False
-        for file in os.listdir("/tmp"):
+        for file in os.listdir(tmpdir):
             if file.startswith("bundle_analysis_"):
                 found = True
                 break
         assert found
-        os.system("rm -rf /tmp/bundle_analysis_*")
+        os.system(f"rm -rf {tmpdir}/bundle_analysis_*")
 
     def test_bundle_analysis_missing_report(self):
         query = (

--- a/apps/codecov-api/graphql_api/tests/test_pull.py
+++ b/apps/codecov-api/graphql_api/tests/test_pull.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -281,7 +282,8 @@ class TestPullRequestList(GraphQLTestHelper, TestCase):
         mock_task_service.return_value.pulls_sync.assert_not_called()
 
     def test_when_repository_has_null_head_has_parent_report(self):
-        os.system("rm -rf /tmp/bundle_analysis_*")
+        tmpdir = tempfile.gettempdir()
+        os.system(f"rm -rf {tmpdir}/bundle_analysis_*")
 
         parent_commit = CommitFactory(repository=self.repository)
 
@@ -343,10 +345,10 @@ class TestPullRequestList(GraphQLTestHelper, TestCase):
             }
         }
 
-        for file in os.listdir("/tmp"):
+        for file in os.listdir(tmpdir):
             assert not file.startswith("bundle_analysis_")
 
-        os.system("rm -rf /tmp/bundle_analysis_*")
+        os.system(f"rm -rf {tmpdir}/bundle_analysis_*")
 
     @freeze_time("2021-02-02")
     def test_when_pr_is_first_pr_in_repo(self):
@@ -496,7 +498,8 @@ class TestPullRequestList(GraphQLTestHelper, TestCase):
         }
 
     def test_bundle_analysis_sqlite_file_deleted(self):
-        os.system("rm -rf /tmp/bundle_analysis_*")
+        tmpdir = tempfile.gettempdir()
+        os.system(f"rm -rf {tmpdir}/bundle_analysis_*")
 
         parent_commit = CommitFactory(repository=self.repository)
         commit = CommitFactory(
@@ -563,10 +566,10 @@ class TestPullRequestList(GraphQLTestHelper, TestCase):
             }
         }
 
-        for file in os.listdir("/tmp"):
+        for file in os.listdir(tmpdir):
             assert not file.startswith("bundle_analysis_")
 
-        os.system("rm -rf /tmp/bundle_analysis_*")
+        os.system(f"rm -rf {tmpdir}/bundle_analysis_*")
 
     @freeze_time("2021-02-02")
     def test_pull_no_patch_totals(self):

--- a/docker/Makefile.ci-tests
+++ b/docker/Makefile.ci-tests
@@ -6,6 +6,12 @@ PYTEST_ROOTDIR ?= "/app"
 # Directory containing source files to measure coverage for. Overridden by `shared`.
 COV_SOURCE ?= "./"
 
+# Optional pytest-xdist worker count. When non-empty, `-n <value>` is passed to
+# pytest. Accepts any value pytest-xdist accepts (e.g. `auto`, `logical`, `4`).
+# Empty (default) runs tests serially.
+PYTEST_XDIST ?=
+PYTEST_XDIST_FLAG := $(if $(PYTEST_XDIST),-n $(PYTEST_XDIST),)
+
 ######
 # Generic targets for running Python tests inside a Docker environment.
 #
@@ -43,7 +49,8 @@ _test_env.run_unit:
 		    --junitxml=unit.junit.xml \
 		    -o junit_family=legacy \
 		    -c pytest.ini \
-		    --rootdir=${PYTEST_ROOTDIR}"
+		    --rootdir=${PYTEST_ROOTDIR} \
+		    ${PYTEST_XDIST_FLAG}"
 
 # Outside the Docker env: Run integration tests.
 _test_env.run_integration:
@@ -56,7 +63,8 @@ _test_env.run_integration:
 		    --junitxml=integration.junit.xml \
 		    -o junit_family=legacy \
 		    -c pytest.ini \
-		    --rootdir=${PYTEST_ROOTDIR}"
+		    --rootdir=${PYTEST_ROOTDIR} \
+		    ${PYTEST_XDIST_FLAG}"
 
 # Outside the Docker env: Start the Docker env and run unit + integration tests in one go.
 _test_env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ dev = [
     "pytest-insta==0.3.0",
     "pytest-mock>=3.14.0",
     "pytest-sqlalchemy>=0.3.0",
+    "pytest-xdist>=3.6.1",
     "respx>=0.22.0",
     "sqlalchemy-utils>=0.41.2",
     "types-mock>=5.2.0.20250516",

--- a/uv.lock
+++ b/uv.lock
@@ -686,6 +686,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "factory-boy"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1888,6 +1897,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2550,6 +2572,7 @@ dev = [
     { name = "pytest-insta" },
     { name = "pytest-mock" },
     { name = "pytest-sqlalchemy" },
+    { name = "pytest-xdist" },
     { name = "respx" },
     { name = "ruff" },
     { name = "sqlalchemy-utils" },
@@ -2803,6 +2826,7 @@ dev = [
     { name = "pytest-insta", specifier = "==0.3.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-sqlalchemy", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.12.0" },
     { name = "sqlalchemy-utils", specifier = ">=0.41.2" },


### PR DESCRIPTION
## Summary

Two CI improvements:

### 1. Consolidate self-hosted build/push so we build once per run (items 3+4 from the speedup plan)

On push-to-main, both `api-build-self-hosted` and `api-self-hosted` ran. The second job called [`_self-hosted.yml`](https://github.com/codecov/umbrella/blob/main/.github/workflows/_self-hosted.yml) again purely to push the rolling tag — it cache-hit on the build but still spun up a fresh runner, restored cache, and `docker load`d the tar (~50-90s of pure overhead per app).

This PR collapses each pair into a single `*-build-self-hosted` job that always builds and conditionally pushes by computing `push_rolling` from the same push-to-main condition. The inner `_self-hosted.yml` already gates its push job on `inputs.push_rolling == true`, so no changes were needed there.

- Removes the `api-self-hosted` and `worker-self-hosted` top-level jobs in [`api-ci.yml`](https://github.com/codecov/umbrella/blob/tomhu/ci-shard-and-selfhosted-consolidate/.github/workflows/api-ci.yml) and [`worker-ci.yml`](https://github.com/codecov/umbrella/blob/tomhu/ci-shard-and-selfhosted-consolidate/.github/workflows/worker-ci.yml).
- Existing PR check names (`API CI / Build Self Hosted (API) / Build Self Hosted App`, etc.) are preserved.
- Expected impact: ~50-90s off push-to-main critical path per app and one redundant runner per app per main push.

### 2. Wire pytest-xdist plumbing (off by default for now)

The plumbing for opting individual test jobs into pytest-xdist is in place but every app keeps `pytest_xdist: ""` (serial). This unblocks future enablement as a one-line flip per app:

- `pytest-xdist>=3.6.1` added to the `dev` dep group; `uv.lock` updated.
- New `PYTEST_XDIST` Make variable in [`docker/Makefile.ci-tests`](https://github.com/codecov/umbrella/blob/tomhu/ci-shard-and-selfhosted-consolidate/docker/Makefile.ci-tests). When non-empty, the test recipes append `-n <value>`. Empty default = serial (no behavior change).
- New `pytest_xdist` input on [`_run-tests.yml`](https://github.com/codecov/umbrella/blob/tomhu/ci-shard-and-selfhosted-consolidate/.github/workflows/_run-tests.yml) forwarded to the make recipe.
- API conftest defensively isolates `tempfile.gettempdir()` per xdist worker so the bundle-analysis tests in [`graphql_api/tests/test_pull.py`](https://github.com/codecov/umbrella/blob/tomhu/ci-shard-and-selfhosted-consolidate/apps/codecov-api/graphql_api/tests/test_pull.py) and [`test_commit.py`](https://github.com/codecov/umbrella/blob/tomhu/ci-shard-and-selfhosted-consolidate/apps/codecov-api/graphql_api/tests/test_commit.py) (which clean up `bundle_analysis_*` files in the system tmpdir) won't race once xdist is enabled. Those tests now use `tempfile.gettempdir()` instead of hard-coded `/tmp` — small hygiene improvement under serial mode too.

#### Why xdist is staying off in this PR

A run with `pytest_xdist: auto` on this branch hit two separate test-isolation regressions:

- **API**: `upload/tests/views/test_uploads.py::test_uploads_post_tokenless` and `test_uploads_post_token_required_auth_check` (7 parametrized variants) failed under xdist with `assert list(upload.flags.all()) == [flag1, flag2]` returning only `[flag2]`, even though both `UploadFlagMembership` rows were demonstrably present in the DB for that upload. Looks like Django M2M-related caching or a parametrize-ordering effect — worth fixing in a focused follow-up rather than gating this PR.
- **Shared**: workers raced creating the per-worker postgres test DB (`test_postgres_gw0` "already exists" / "is being accessed by other users") inside shared's custom `django_setup_test_db` in [`libs/shared/shared/testutils.py`](https://github.com/codecov/umbrella/blob/main/libs/shared/shared/testutils.py). Separate plumbing change.

Both are tracked for follow-ups. The wiring in this PR means re-enabling later is a one-line change per workflow.

For the record, the API xdist run (before backing off) measured **3:38** vs the previous **~6:00** serial baseline, so the underlying speedup is real and worth pursuing in a follow-up.

## Test plan

- [x] CI passes on this branch (validates the self-hosted consolidation on a PR; tests stay serial so no behavior change for those).
- [ ] After merge, watch one push-to-main run to confirm self-hosted rolling images are still pushed (single build, single push) and that the previous `Push Self Hosted Image (API/Worker)` check name being gone is intentional w.r.t. branch protection.

## Notes / follow-ups

- Worker xdist support is left as a follow-up (its `apps/worker/conftest.py` uses the deprecated xdist `slaveinput` API and mutates `engine.url`).
- Shared xdist support: make `django_setup_test_db` worker-safe.
- API xdist support: investigate the `upload.flags.all()` discrepancy in `test_uploads.py`.
- Other items from the speedup plan (collapsing the 4-way Codecov upload matrix, ubuntu-large queueing, etc.) are not in this PR.
