### PR TITLE
fix(redis_admin): move chart-fragment loader to external JS for CSP

### DIFF
--- a/apps/codecov-api/redis_admin/static/redis_admin/js/celery_chart_fragment.js
+++ b/apps/codecov-api/redis_admin/static/redis_admin/js/celery_chart_fragment.js
@@ -1,0 +1,38 @@
+// Lazy-fetches the celery_broker frequency chart fragment for the
+// current drill-down queue. Triggered by the placeholder div
+// injected by templates/admin/redis_admin/celerybrokerqueue/change_list.html.
+//
+// Loaded as an external file (not inline) so the strict CSP on
+// production admin (api-admin.codecov.io) — which only allows
+// `'self'` and one fixed sha256 hash for scripts — does not block
+// it. See settings_base.py CSP_DEFAULT_SRC.
+(function () {
+  function loadChart() {
+    var el = document.getElementById('celery-chart-fragment');
+    if (!el) return;
+    var url = el.dataset.fragmentUrl;
+    if (!url) return;
+    fetch(url, { credentials: 'same-origin' })
+      .then(function (r) {
+        if (r.status === 204) {
+          el.innerHTML = '';
+          return;
+        }
+        if (!r.ok) {
+          el.innerHTML = '<p class="errornote">Could not load frequency chart (HTTP ' + r.status + ').</p>';
+          return;
+        }
+        return r.text().then(function (html) {
+          el.innerHTML = html;
+        });
+      })
+      .catch(function () {
+        el.innerHTML = '<p class="errornote">Could not load frequency chart.</p>';
+      });
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadChart);
+  } else {
+    loadChart();
+  }
+})();

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/change_list.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/change_list.html
@@ -1,11 +1,17 @@
 {% extends "admin/change_list.html" %}
 {% load admin_urls %}
+{% load static %}
 
 {% comment %}
 On the per-message drill-down page (queue_name is set), inject a lazy
 frequency chart above the result list. The chart is fetched
 asynchronously from `chart_fragment_view` so the changelist renders
 immediately regardless of queue depth (200–500k messages).
+
+The fetch helper lives in an external static file rather than an
+inline <script> so it survives the strict CSP on production
+(api-admin.codecov.io), which only allows `'self'` and one fixed
+sha256 for inline scripts. See settings_base.py CSP_DEFAULT_SRC.
 
 In summary mode (queue_name is absent) the block renders nothing extra.
 {% endcomment %}
@@ -15,31 +21,7 @@ In summary mode (queue_name is absent) the block renders nothing extra.
          data-fragment-url="{% url 'admin:celerybrokerqueue-chart-fragment' queue_name=queue_name %}">
       <p class="help">Loading frequency chart&hellip;</p>
     </div>
-    <script>
-      (function () {
-        var el = document.getElementById('celery-chart-fragment');
-        if (!el) return;
-        var url = el.dataset.fragmentUrl;
-        if (!url) return;
-        fetch(url, { credentials: 'same-origin' })
-          .then(function (r) {
-            if (r.status === 204) {
-              el.innerHTML = '';
-              return;
-            }
-            if (!r.ok) {
-              el.innerHTML = '<p class="errornote">Could not load frequency chart (HTTP ' + r.status + ').</p>';
-              return;
-            }
-            return r.text().then(function (html) {
-              el.innerHTML = html;
-            });
-          })
-          .catch(function () {
-            el.innerHTML = '<p class="errornote">Could not load frequency chart.</p>';
-          });
-      })();
-    </script>
+    <script src="{% static 'redis_admin/js/celery_chart_fragment.js' %}" defer></script>
   {% endif %}
   {{ block.super }}
 {% endblock %}

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -985,6 +985,12 @@ class CeleryFrequencyChartTest(TestCase):
         # Changelist renders the lazy-load placeholder, not the chart itself.
         assert 'id="celery-chart-fragment"' in body
         assert "data-fragment-url=" in body
+        # The loader is shipped as an EXTERNAL static file (not inline)
+        # so the strict CSP on api-admin.codecov.io — which only allows
+        # `'self'` and one fixed sha256 for inline scripts — does not
+        # block it. See settings_base.py CSP_DEFAULT_SRC.
+        assert "celery_chart_fragment.js" in body
+        assert 'src="' in body  # confirms external script form, not inline
 
         # Fetch the chart fragment directly (as the browser's JS would).
         fragment_response = self.client.get(


### PR DESCRIPTION
## Summary

The lazy-loaded Celery broker frequency chart shipped in #899 used an inline `<script>` to fetch the chart-fragment endpoint. Production (`api-admin.codecov.io`) enforces a strict CSP via `csp.middleware.CSPMiddleware` with `CSP_DEFAULT_SRC = ['self', ...]` plus one fixed sha256 (the GraphQL Playground bootstrap). The inline script body doesn't match that hash, so the browser silently blocks it — the placeholder *"Loading frequency chart…"* renders but no fetch ever fires.

Local dev doesn't catch this because `settings_dev.py` removes `CSPMiddleware` entirely.

This PR moves the loader to a static file under `redis_admin/static/redis_admin/js/celery_chart_fragment.js` and references it with `<script src="{% static ... %}" defer>`. External scripts from `'self'` are already permitted by the existing CSP, so no policy changes are needed.

Followup to #899.

## Test plan

- [x] Existing `CeleryFrequencyChartTest` assertions for the placeholder div still pass.
- [x] Added assertion that the external `celery_chart_fragment.js` script src is rendered.
- [ ] Manually verify in api-admin.codecov.io after deploy that the chart loads on a drill-down URL like `/redis_admin/celerybrokerqueue/?queue_name__exact=<queue>`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: moves existing inline fetch logic into a static file and updates a template/test; behavior should be unchanged aside from unblocking chart loading under strict CSP.
> 
> **Overview**
> Fixes the Redis admin celery broker drill-down frequency chart loader being blocked by production CSP by moving the inline `fetch` script into an external static file (`celery_chart_fragment.js`) and loading it via `{% static %}` with `defer`.
> 
> Updates the admin changelist template to reference the external script and extends the smoke test to assert the external `script src` is rendered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466c561de3a33535f261cfe79a29cf13115e907b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->