### PR TITLE
feat(redis_admin): split celery_broker caps into display vs scan limits

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -151,7 +151,9 @@ All configurable via `REDIS_ADMIN_*` Django settings; defaults shown.
 | `REDIS_ADMIN_MAX_SCAN_KEYS` | `10_000` | Hard cap on keys visited per `iter_keys()` sweep. |
 | `REDIS_ADMIN_SCAN_COUNT` | `500` | `COUNT` hint for each `SCAN` / `SSCAN` / `HSCAN`. |
 | `REDIS_ADMIN_ITEM_PAGE_SIZE` | `100` | Page size for the items-in-a-queue view. |
-| `REDIS_ADMIN_MAX_ITEMS_PER_KEY` | `20_000` | Hard cap on members materialised from a single SET/HASH/LIST for browsing (drives the celery_broker chart's sample window via `LRANGE 0 cap-1`). |
+| `REDIS_ADMIN_MAX_ITEMS_PER_KEY` | `20_000` | Hard cap on members materialised from a single SET/HASH for admin browsing (M4). LIST keys use bounded LRANGE windows so they aren't constrained here. |
+| `REDIS_ADMIN_CELERY_BROKER_DISPLAY_LIMIT` | `2_000` | Number of per-message rows materialised on the `celery_broker` changelist drill-down. Smaller than the scan limit because each row keeps a parsed envelope in the per-request cache. |
+| `REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT` | `100_000` | Sample window used by deep scans of a `celery_broker` queue (frequency chart + streaming clear). Both walk the queue in chunks and discard payloads, so memory stays flat regardless of this cap. |
 | `REDIS_ADMIN_MAX_DECODE_BYTES` | `4_096` | Per-value display truncation. |
 | `REDIS_ADMIN_DELETE_BATCH_SIZE` | `500` | Pipeline batch size for `DEL` / `LREM` / `SREM` / `HDEL`. |
 | `REDIS_ADMIN_CONNECTION_FACTORY` | unset | Dotted path to a callable returning a `redis.Redis`. Defaults to `shared.helpers.redis.get_redis_connection`. |
@@ -258,10 +260,10 @@ Grouping by `task_name` matters on shared queues like the default
 unrelated tasks routed through the same queue.
 
 The chart's percentages are computed against the visible
-`LRANGE 0 MAX_ITEMS_PER_KEY-1` window, not against `LLEN`. When
-`LLEN > MAX_ITEMS_PER_KEY` the chart surfaces a "showing top N
-of M sampled messages (queue depth: K)" banner so operators know
-the share is over the visible window.
+`LRANGE 0 CELERY_BROKER_SCAN_LIMIT-1` window, not against `LLEN`.
+When `LLEN > CELERY_BROKER_SCAN_LIMIT` the chart surfaces a
+"showing top N of M sampled messages (queue depth: K)" banner so
+operators know the share is over the visible window.
 
 ### `clear-by-filter/` (chart-driven targeted clear)
 

--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -153,7 +153,7 @@ All configurable via `REDIS_ADMIN_*` Django settings; defaults shown.
 | `REDIS_ADMIN_ITEM_PAGE_SIZE` | `100` | Page size for the items-in-a-queue view. |
 | `REDIS_ADMIN_MAX_ITEMS_PER_KEY` | `20_000` | Hard cap on members materialised from a single SET/HASH for admin browsing (M4). LIST keys use bounded LRANGE windows so they aren't constrained here. |
 | `REDIS_ADMIN_CELERY_BROKER_DISPLAY_LIMIT` | `2_000` | Number of per-message rows materialised on the `celery_broker` changelist drill-down. Smaller than the scan limit because each row keeps a parsed envelope in the per-request cache. |
-| `REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT` | `100_000` | Sample window used by deep scans of a `celery_broker` queue (frequency chart + streaming clear). Both walk the queue in chunks and discard payloads, so memory stays flat regardless of this cap. |
+| `REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT` | `100_000` | Sample window used by the `celery_broker` frequency chart aggregator. The streaming clear (Clear queue → Clear all) intentionally is *not* bounded by this — it walks the full `LLEN(queue)` so a clear action always drains the entire queue regardless of the chart's sample size. |
 | `REDIS_ADMIN_MAX_DECODE_BYTES` | `4_096` | Per-value display truncation. |
 | `REDIS_ADMIN_DELETE_BATCH_SIZE` | `500` | Pipeline batch size for `DEL` / `LREM` / `SREM` / `HDEL`. |
 | `REDIS_ADMIN_CONNECTION_FACTORY` | unset | Dotted path to a callable returning a `redis.Redis`. Defaults to `shared.helpers.redis.get_redis_connection`. |

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -34,7 +34,7 @@ from core.models import Repository
 
 from . import conn as _conn
 from . import settings as redis_admin_settings
-from .families import FAMILIES, iter_keys
+from .families import FAMILIES, iter_families, iter_keys
 from .families import (
     _resolve_celery_queue_names as _celery_queue_names,  # noqa: PLC2701 - reused for filter lookups
 )
@@ -316,15 +316,40 @@ class FamilyFilter(admin.SimpleListFilter):
     # `RedisQueueAdmin` and `RedisLockAdmin` override this on their
     # subclass so each admin only lists families it actually surfaces.
     category: str = "queue"
+    # Families that are categorically excluded from the dropdown even
+    # though they match `category`. Subclasses use this to hide a
+    # family that has its own dedicated admin (e.g. `celery_broker`
+    # is surfaced by `CeleryBrokerQueueAdmin`; leaving it selectable
+    # on the generic queue filter would be a dead option that
+    # returns zero rows because `RedisQueueAdmin.get_queryset` runs
+    # `.family_exclude("celery_broker")`).
+    excluded_names: frozenset[str] = frozenset()
 
     def lookups(self, request, model_admin):
-        return tuple((f.name, f.name) for f in FAMILIES if f.category == self.category)
+        return tuple(
+            (f.name, f.name)
+            for f in iter_families(category=self.category, exclude=self.excluded_names)
+        )
 
     def queryset(self, request, queryset):
         value = self.value()
         if value:
             return queryset.filter(family__exact=value)
         return queryset
+
+
+class QueueFamilyFilter(FamilyFilter):
+    """`FamilyFilter` for `RedisQueueAdmin` — omits `celery_broker`.
+
+    The queue changelist hides `celery_broker` rows entirely
+    (`get_queryset` calls `.family_exclude("celery_broker")`) so
+    leaving the value in the dropdown surfaces a clickable option
+    that filters the page to zero rows. Dropping it from the
+    choice list keeps the sidebar in sync with what the admin can
+    actually display.
+    """
+
+    excluded_names = frozenset({"celery_broker"})
 
 
 class LockFamilyFilter(FamilyFilter):
@@ -488,7 +513,7 @@ class RedisQueueAdmin(admin.ModelAdmin):
     # queue list to a specific celery queue — is removed for the
     # same reason; the new admin's landing page is the discovery
     # surface for celery queues.
-    list_filter = (FamilyFilter, MinDepthFilter, ReportTypeFilter)
+    list_filter = (QueueFamilyFilter, MinDepthFilter, ReportTypeFilter)
     list_per_page = 50
     show_full_result_count = False
     ordering = ("-depth", "name")
@@ -1460,7 +1485,15 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
     )
     list_per_page = redis_admin_settings.ITEM_PAGE_SIZE
     show_full_result_count = False
+    # Default ordering for the per-message drill-down (one row per
+    # kombu envelope). `get_ordering` below flips this to
+    # `(-depth, queue_name)` in summary mode so the landing page
+    # surfaces the hottest queues first.
     ordering = ("index_in_queue",)
+    # Summary mode ordering: depth DESC, then queue_name ASC. Kept
+    # as a class attribute so tests / subclasses can pin the
+    # expected sort without reaching into `get_ordering`.
+    summary_ordering: tuple[str, ...] = ("-depth", "queue_name")
     search_fields = ("task_name",)
     search_help_text = (
         "search by 'repoid:1234', 'commit:abc', 'task:BundleAnalysisProcessor', "
@@ -1525,6 +1558,27 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         """Summary mode = no `queue_name__exact` filter on the URL."""
 
         return not request.GET.get("queue_name__exact")
+
+    def get_ordering(self, request: HttpRequest):
+        """Default sort depends on mode.
+
+        * Summary (landing page, no `queue_name__exact`): deepest
+          queues first, ties broken alphabetically by queue name —
+          an on-call engineer scanning the top of the page sees the
+          hottest queues up top.
+        * Drill-down (per-message view, `?queue_name__exact=<q>`):
+          index-order is preserved so `matches[0]` is the next
+          message a Celery consumer would pop. The clear-by-filter
+          and keep-one-survivor paths rely on that invariant.
+
+        Django's `ChangeList` still layers explicit `?o=` column-
+        header clicks on top of this default, so operators can
+        re-sort at will.
+        """
+
+        if self._is_summary_request(request):
+            return self.summary_ordering
+        return self.ordering
 
     def get_list_display(self, request: HttpRequest):
         if self._is_summary_request(request):

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -1589,6 +1589,18 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             # `chart_fragment_view` via an AJAX call, keeping the
             # changelist fast even for 500k-deep queues.
             ctx["queue_name"] = request.GET.get("queue_name__exact", "")
+            # Surface the actual `CELERY_BROKER_SCAN_LIMIT` so the
+            # loader hint reflects whatever the deployment overrode it
+            # to (50_000 / 200_000 / etc.), instead of the hardcoded
+            # default. Keeps the user-facing message honest in
+            # environments where the scan window has been tuned.
+            # Pre-formatted with thousands separators since
+            # `django.contrib.humanize` is not installed in this
+            # service's INSTALLED_APPS, so `intcomma` is unavailable
+            # in the template.
+            ctx["scan_limit_label"] = (
+                f"{redis_admin_settings.CELERY_BROKER_SCAN_LIMIT:,}"
+            )
         return super().changelist_view(request, ctx)
 
     def _build_frequency_chart_context(
@@ -1840,12 +1852,44 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             # has its own error handling.
             match_count = len(sample_targets)
             kept_index = sample_targets[0].index_in_queue if sample_targets else None
-        # Backwards-compat: existing callers below still reference
-        # `matches` for dispatching `celery_broker_clear`. The streaming
-        # clear only needs the filter tuples (which it derives from
-        # targets), not the full target list — passing the trimmed
-        # `sample_targets` is sufficient and cheap.
-        matches = sample_targets
+        # Build a single synthetic target carrying the operator's
+        # *exact* filter (queue + task_name? + repoid? + commitid?)
+        # so `_celery_broker_clear` always derives the same
+        # `frozenset({(task_name or None, repoid, commitid or None)})`
+        # that `streaming_celery_count` walked the full queue with.
+        #
+        # Without this, the clear path inferred its filter set from
+        # `sample_targets` — the materialised window capped by
+        # `CELERY_BROKER_DISPLAY_LIMIT` (default 2_000). That had two
+        # silent-no-op modes:
+        #
+        # 1. All matches sit beyond the display window (e.g. a recent
+        #    burst on a queue with `LLEN > 2_000`): `sample_targets`
+        #    is empty, `by_queue_filters` becomes `{}`, the streaming
+        #    clear loop doesn't iterate, and the queue is never
+        #    touched even though `match_count > 0` from streaming.
+        # 2. Operator filtered by `repoid` only: each `sample_target`
+        #    contributes a *specific* `(task_name, repoid, commitid)`
+        #    triple, so the filter set excludes any task name not
+        #    represented in the first 2_000 messages — those messages
+        #    survive the clear.
+        #
+        # The synthetic target restores the streaming-clear semantic
+        # of "match every envelope whose `(task, repoid, commitid)`
+        # equals the operator's input." Per-message and bulk-select
+        # paths (`delete_model`, `clear_selected`, `delete_queryset`,
+        # `clear_dry_run`) still pass real materialised rows — those
+        # are intentionally index-driven, not filter-driven, so they
+        # don't go through this code path.
+        filter_target = CeleryBrokerQueue(
+            pk_token=f"{queue_name}#{kept_index if kept_index is not None else 'filter'}",
+            queue_name=queue_name,
+            index_in_queue=kept_index,
+            task_name=task_name or None,
+            repoid=repoid,
+            commitid=commitid or None,
+        )
+        matches = [filter_target]
 
         expected_confirm = queue_name
         typed_confirm = (request.POST.get("typed_confirm") or "").strip()

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -17,6 +17,7 @@ prefix-style tokens in addition to plain substrings:
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable, Sequence
 from typing import Any
 from urllib.parse import urlencode
@@ -45,7 +46,19 @@ from .queryset import (
     _stream_frequency_aggregate,
     resolve_payload_preview,
 )
-from .services import celery_broker_clear, redis_delete
+from .services import (
+    celery_broker_clear,
+    redis_delete,
+    streaming_celery_count,
+)
+
+log = logging.getLogger(__name__)
+
+# Cap on the rows we render in the clear-by-filter preview
+# table. Decoupled from `CELERY_BROKER_DISPLAY_LIMIT` because
+# the preview page only needs a representative slice; the real
+# `match_count` comes from the streaming counter.
+_CLEAR_BY_FILTER_SAMPLE_SIZE: int = 20
 
 # ---- Inline items preview (rendered on the queue change page) --------------
 #
@@ -1795,13 +1808,44 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             queryset = queryset.filter(repoid=repoid)
         if commitid:
             queryset = queryset.filter(commitid__startswith=commitid)
-        # `_fetch_all` materialises in LRANGE order (ascending
-        # `index_in_queue`), so `matches[0]` is always the lowest-
-        # index match. We sort defensively in case a future ordering
-        # change perturbs that.
-        matches = sorted(queryset, key=lambda row: row.index_in_queue or 0)
-        match_count = len(matches)
-        kept_index: int | None = matches[0].index_in_queue if matches else None
+        # Cap-bounded sample for the preview table (cheap, in-memory).
+        # The queryset materialises the first `CELERY_BROKER_DISPLAY_LIMIT`
+        # messages, then filters; we trim further to keep the rendered
+        # table compact.
+        sample_targets = sorted(queryset, key=lambda row: row.index_in_queue or 0)[
+            :_CLEAR_BY_FILTER_SAMPLE_SIZE
+        ]
+
+        # `match_count` and `kept_index` come from a streaming pass
+        # over the full queue so the preview agrees with what the
+        # actual clear (also unbounded) would do. Going through the
+        # queryset would underreport whenever `LLEN(queue) >
+        # CELERY_BROKER_DISPLAY_LIMIT` (anything past the 2k materialise
+        # window).
+        try:
+            match_count, kept_index = streaming_celery_count(
+                queue_name,
+                task_name=task_name or None,
+                repoid=repoid,
+                commitid=commitid or None,
+            )
+        except Exception:
+            log.exception(
+                "redis_admin.clear_by_filter: streaming count failed for %r",
+                queue_name,
+            )
+            # Defensive fallback: degrade to the queryset count rather
+            # than render a 500. The operator at least sees something
+            # and can still hit "Clear all" — the streaming clear path
+            # has its own error handling.
+            match_count = len(sample_targets)
+            kept_index = sample_targets[0].index_in_queue if sample_targets else None
+        # Backwards-compat: existing callers below still reference
+        # `matches` for dispatching `celery_broker_clear`. The streaming
+        # clear only needs the filter tuples (which it derives from
+        # targets), not the full target list — passing the trimmed
+        # `sample_targets` is sufficient and cheap.
+        matches = sample_targets
 
         expected_confirm = queue_name
         typed_confirm = (request.POST.get("typed_confirm") or "").strip()
@@ -1815,7 +1859,7 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         # through to the render path without invoking the service or
         # writing a LogEntry.
         if request.method == "POST" and action in valid_actions:
-            if not matches:
+            if match_count == 0:
                 messages.info(
                     request,
                     "No messages match the filter — nothing to clear.",
@@ -1871,7 +1915,6 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
                         )
                     return HttpResponseRedirect(changelist_url)
 
-        sample_targets = matches[:25]
         ctx = {
             **self.admin_site.each_context(request),
             "title": f"Clear {queue_name} by filter",

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -823,6 +823,31 @@ def find_family(key: str) -> Family | None:
     return None
 
 
+def iter_families(
+    *,
+    category: Literal["queue", "lock"] | None = None,
+    exclude: Iterable[str] = (),
+) -> Iterator[Family]:
+    """Yield registered families, optionally narrowed by category / name.
+
+    Single entry point for admin UI surfaces (`FamilyFilter.lookups`,
+    the clear-by-scope family picker) that need to enumerate the
+    family registry with a consistent exclusion list. Keeping the
+    filtering here means a family that's served by its own dedicated
+    admin (today: `celery_broker`, surfaced by
+    `CeleryBrokerQueueAdmin`) can be dropped from generic enumerators
+    without each caller re-implementing the same skip list.
+    """
+
+    exclude_set = frozenset(exclude)
+    for family in FAMILIES:
+        if category is not None and family.category != category:
+            continue
+        if family.name in exclude_set:
+            continue
+        yield family
+
+
 def iter_keys(
     redis=None,
     *,

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -1082,8 +1082,8 @@ class FrequencyBucket:
 
     `pct` is the bucket's share of the total queue depth, computed
     against the snapshot the chart was built from (i.e. against the
-    `LRANGE 0 MAX_ITEMS_PER_KEY-1` materialisation, not against
-    `LLEN`). For queues larger than `MAX_ITEMS_PER_KEY` the chart
+    `LRANGE 0 CELERY_BROKER_SCAN_LIMIT-1` materialisation, not against
+    `LLEN`). For queues larger than `CELERY_BROKER_SCAN_LIMIT` the chart
     template surfaces a banner so operators know the percentages
     are over the visible window.
     """
@@ -1114,7 +1114,7 @@ def _stream_frequency_aggregate(
     """Streaming `(task_name, repoid, commitid)` frequency aggregator.
 
     Walks `queue_name` in `_STREAM_CHUNK`-sized LRANGE chunks up to
-    `MAX_ITEMS_PER_KEY` total messages. Each chunk is parsed and
+    `CELERY_BROKER_SCAN_LIMIT` total messages. Each chunk is parsed and
     immediately discarded — the only retained state is a rolling
     `Counter` keyed on the 3-tuple. Memory footprint is bounded by
     the number of unique `(task, repoid, commitid)` triples rather
@@ -1135,7 +1135,7 @@ def _stream_frequency_aggregate(
       in isolation without first materialising the changelist.
     """
 
-    cap = redis_admin_settings.MAX_ITEMS_PER_KEY
+    cap = redis_admin_settings.CELERY_BROKER_SCAN_LIMIT
     counter: Counter[tuple[str | None, int | None, str | None]] = Counter()
     total = 0
 
@@ -1187,7 +1187,7 @@ class CeleryBrokerQueueQuerySet:
     message — the alternative would be fanning out across every
     well-known celery queue, which is unbounded by design.
 
-    Materialisation is `LRANGE 0 MAX_ITEMS_PER_KEY-1` once, parse
+    Materialisation is `LRANGE 0 CELERY_BROKER_DISPLAY_LIMIT-1` once, parse
     each element via `parse_celery_envelope`, then apply Python-side
     filters and ordering. The result snapshot is cached on the
     queryset instance so repeated `count()` / `__getitem__` /
@@ -1404,7 +1404,7 @@ class CeleryBrokerQueueQuerySet:
                 return row
         raise self.model.DoesNotExist(
             f"index {idx} not found in queue {queue!r} "
-            f"(may exceed MAX_ITEMS_PER_KEY or have been consumed)"
+            f"(may exceed CELERY_BROKER_DISPLAY_LIMIT or have been consumed)"
         )
 
     # ---- Materialisation -------------------------------------------------
@@ -1503,7 +1503,7 @@ class CeleryBrokerQueueQuerySet:
         redis = self._connection()
         if not redis.exists(self.queue_name):
             return []
-        cap = redis_admin_settings.MAX_ITEMS_PER_KEY
+        cap = redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT
         # `LRANGE 0 cap-1` rather than streaming because celery queues
         # are bounded in practice and a single round-trip beats paging
         # for the typical "operator filtered to one repoid" case where
@@ -1527,14 +1527,17 @@ class CeleryBrokerQueueQuerySet:
     # Stashing the parsed list on the request (when one is plumbed
     # through) lets the second call short-circuit; standalone callers
     # without a request fall back to issuing a fresh LRANGE, same as
-    # before. The cache is keyed by `(queue_name, MAX_ITEMS_PER_KEY)` so
-    # a setting override mid-render (vanishingly rare, but) doesn't
+    # before. The cache is keyed by `(queue_name, CELERY_BROKER_DISPLAY_LIMIT)`
+    # so a setting override mid-render (vanishingly rare, but) doesn't
     # serve the wrong window size.
 
     _REQUEST_CACHE_ATTR: str = "_celery_broker_lrange_cache"
 
     def _request_cache_key(self) -> tuple[str, int]:
-        return (self.queue_name or "", redis_admin_settings.MAX_ITEMS_PER_KEY)
+        return (
+            self.queue_name or "",
+            redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT,
+        )
 
     def _read_request_cache(self) -> list | None:
         if self._request is None or not self.queue_name:
@@ -1650,7 +1653,7 @@ class CeleryBrokerQueueQuerySet:
         1. **Cached path**: if the per-request LRANGE snapshot is
            already populated (i.e. the changelist materialised first),
            aggregates directly over those rows. Zero extra Redis
-           round-trips; bounded by `MAX_ITEMS_PER_KEY`.
+           round-trips; bounded by `CELERY_BROKER_DISPLAY_LIMIT`.
         2. **Streaming path**: if the cache is empty (called from the
            chart-fragment endpoint before the changelist materialised,
            or in a standalone context), calls

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -414,16 +414,19 @@ def _redis_delete(
 # For 200–500k-deep queues the old eager-materialise-then-LSET path
 # had two problems:
 #
-#   1. Memory: materialising up to `CELERY_BROKER_SCAN_LIMIT` rows into
-#      Python before clearing was O(N) in memory.
+#   1. Memory: materialising the entire queue into Python before
+#      clearing was O(N) in memory.
 #   2. Race drift: the index a Celery consumer sees between our
 #      `LRANGE` snapshot and our `LSET` call can shift if another
 #      consumer BLPOPs from the head. The old code had no verify step.
 #
-# The new path (see `_streaming_celery_clear`) walks the queue in
-# 10k-row LRANGE chunks.  For each candidate position it does a
-# verify-before-LSET (LINDEX to confirm the raw bytes still match the
-# snapshot row before writing the tombstone) and a
+# The new path (see `_streaming_celery_clear`) walks the **entire**
+# queue in 10k-row LRANGE chunks every pass — the clear has no
+# artificial cap because "Clear all" needs to drain whatever depth
+# the queue happens to be at, even past the chart sampler's window
+# (`CELERY_BROKER_SCAN_LIMIT`). For each candidate position it does
+# a verify-before-LSET (LINDEX to confirm the raw bytes still match
+# the snapshot row before writing the tombstone) and a
 # repeat-until-stable loop (max 3 passes) to catch messages that
 # drifted into our filter window between passes.
 
@@ -464,9 +467,9 @@ def _streaming_celery_clear(
 ) -> _StreamingClearStats:
     """Streaming LRANGE+verify-before-LSET clear for `queue_name`.
 
-    Walks the queue in `_CELERY_CLEAR_CHUNK`-row chunks, identifies
-    messages whose parsed `(task_name, repoid, commitid)` triple
-    appears in `filter_tuples`, and for each match:
+    Walks the **entire** queue in `_CELERY_CLEAR_CHUNK`-row chunks,
+    identifies messages whose parsed `(task_name, repoid, commitid)`
+    triple appears in `filter_tuples`, and for each match:
 
     1. Issues `LINDEX key idx` to re-read the raw bytes at that
        position.
@@ -479,8 +482,9 @@ def _streaming_celery_clear(
     tombstones in one shot.
 
     The loop repeats up to `_CELERY_MAX_PASSES` times, stopping
-    early when a pass finds zero matches OR two consecutive passes
-    tombstone the same count (stable point reached).
+    early when a pass finds zero matches (queue drained of matches)
+    OR two consecutive passes tombstone the same count (stable
+    point reached — pathological persistent-drift signal).
 
     `keep_one=True` skips the first matching message encountered in
     the first pass and on all subsequent passes, implementing the
@@ -491,7 +495,6 @@ def _streaming_celery_clear(
     total_drifted = 0
     prev_lset: int | None = None
     passes_run = 0
-    cap = redis_admin_settings.CELERY_BROKER_SCAN_LIMIT
 
     # Track whether we've kept the "first" across all passes so that
     # repeat passes honour the same semantic (first by queue index).
@@ -507,8 +510,19 @@ def _streaming_celery_clear(
         # surviving message is always kept, even as the queue shifts.
         pass_first_kept = first_kept
 
+        # Walk the entire queue every pass: clearing has to traverse
+        # the full depth so a "Clear all" on a 200k+ saturated queue
+        # actually drains it. The chart's `_stream_frequency_aggregate`
+        # caps at `CELERY_BROKER_SCAN_LIMIT` because it only needs a
+        # representative sample to compute bucket proportions; the
+        # clear path has no analogous bound — capping it meant that on
+        # a queue dominated by one `(task, repoid, commitid)` triple,
+        # pass 1 cleared the first `cap` positions, pass 2 cleared
+        # another `cap` that shifted in from beyond, and the
+        # `prev_lset == matches_lset` plateau exit then declared
+        # convergence with most of the queue still in place.
         depth = int(redis.llen(queue_name) or 0)
-        for chunk_start in range(0, min(depth, cap), _CELERY_CLEAR_CHUNK):
+        for chunk_start in range(0, depth, _CELERY_CLEAR_CHUNK):
             chunk_end = chunk_start + _CELERY_CLEAR_CHUNK - 1
             raw_chunk = redis.lrange(queue_name, chunk_start, chunk_end)
             for offset, raw in enumerate(raw_chunk):

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -447,6 +447,37 @@ def _celery_clear_tombstone() -> str:
     return f"{_CELERY_TOMBSTONE_PREFIX}:{uuid.uuid4().hex}"
 
 
+def _envelope_matches_any_filter(meta, filter_tuples: frozenset) -> bool:
+    """Return True if `meta` matches any tuple in `filter_tuples`.
+
+    Each filter tuple is `(task_name, repoid, commitid)` where any
+    slot may be `None` to mean "wildcard / don't constrain on this
+    field". Mirrors the queryset's "filter by what's set" semantic
+    (`queryset.filter(repoid=repoid)` doesn't constrain `task_name`),
+    so callers like `streaming_celery_count` and the clear-by-filter
+    path can reuse the same triple-shaped frozenset they would build
+    for an exact-tuple match without silently undercounting when the
+    operator left a slot unset.
+
+    Without the wildcard semantics, a filter built from operator
+    input (e.g. `(None, 1, "abc")` for "repoid=1 AND commitid=abc",
+    no task constraint) would never match a real envelope (whose
+    `meta.task` is always populated), so both the streaming counter
+    and the streaming clear would silently report zero matches even
+    when the queryset path would have surfaced rows.
+    """
+
+    for ft_task, ft_repoid, ft_commitid in filter_tuples:
+        if ft_task is not None and ft_task != meta.task:
+            continue
+        if ft_repoid is not None and ft_repoid != meta.repoid:
+            continue
+        if ft_commitid is not None and ft_commitid != meta.commitid:
+            continue
+        return True
+    return False
+
+
 @dataclass(frozen=True)
 class _StreamingClearStats:
     """Per-run stats from `_streaming_celery_clear`."""
@@ -555,8 +586,7 @@ def _streaming_celery_clear(
                 idx = chunk_start + offset
                 decoded = _decode_value(raw)
                 meta = parse_celery_envelope(decoded)
-                key = (meta.task, meta.repoid, meta.commitid)
-                if key not in filter_tuples:
+                if not _envelope_matches_any_filter(meta, filter_tuples):
                     continue
                 matches_found += 1
                 if first_match_index is None:

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -453,6 +453,7 @@ class _StreamingClearStats:
 
     total_lset: int
     total_drifted: int
+    total_found: int
     passes_run: int
 
 
@@ -489,10 +490,22 @@ def _streaming_celery_clear(
     `keep_one=True` skips the first matching message encountered in
     the first pass and on all subsequent passes, implementing the
     "clear all but first (lowest-index match)" semantic.
+
+    On `dry_run=True` we walk the queue exactly once and accumulate
+    `total_found` without issuing any LSET/LREM. The dry-run preview
+    only needs the count, not race coverage, so multi-pass would
+    just re-scan a quiet queue for no benefit (and on a 500k-deep
+    queue that's a real cost).
+
+    Returns a `_StreamingClearStats` carrying `total_lset` (slots
+    tombstoned), `total_drifted` (slots skipped due to LRANGE/LINDEX
+    drift), `total_found` (every match observed across passes —
+    populated for the dry-run preview), and `passes_run`.
     """
 
     total_lset = 0
     total_drifted = 0
+    total_found = 0
     prev_lset: int | None = None
     passes_run = 0
 
@@ -568,7 +581,14 @@ def _streaming_celery_clear(
 
         total_lset += matches_lset
         total_drifted += matches_drifted
+        total_found += matches_found
 
+        # Dry-run only needs the count; one full scan is exact for a
+        # quiet queue and the streaming-clear semantics for the preview
+        # don't need the verify-before-LSET race coverage that justifies
+        # multi-pass on the executing path.
+        if dry_run:
+            break
         # Stability check: stop when no matches or lset count plateaued.
         if matches_found == 0:
             break
@@ -589,6 +609,7 @@ def _streaming_celery_clear(
     return _StreamingClearStats(
         total_lset=total_lset,
         total_drifted=total_drifted,
+        total_found=total_found,
         passes_run=passes_run,
     )
 
@@ -642,7 +663,6 @@ def _celery_broker_clear(
     # tokens for the audit log.
     by_queue_filters: dict[str, set] = {}
     sample_source: list[str] = []
-    pending_count = 0
 
     for target in targets:
         if not isinstance(target, CeleryBrokerQueue):
@@ -656,7 +676,6 @@ def _celery_broker_clear(
         key = (target.task_name, target.repoid, target.commitid)
         by_queue_filters.setdefault(target.queue_name, set()).add(key)
         sample_source.append(f"{target.queue_name}#{target.index_in_queue}")
-        pending_count += 1
 
     sample = tuple(sample_source[:_AUDIT_SAMPLE_SIZE])
     families = ("celery_broker",) if by_queue_filters else ()
@@ -665,8 +684,39 @@ def _celery_broker_clear(
     total_drifted = 0
     total_passes = 0
 
-    if dry_run or not by_queue_filters:
-        result_count = pending_count
+    if not by_queue_filters:
+        # No celery_broker targets at all (operator submitted an empty
+        # filter set, or all targets were the wrong polymorphic type).
+        result_count = 0
+    elif dry_run:
+        # Walk the full queue per filter triple so the preview count
+        # matches what the real clear would tombstone. Counts only —
+        # `_streaming_celery_clear(..., dry_run=True)` skips LSET/LREM.
+        # Without this, the preview was reporting `pending_count`
+        # (the materialised target list, capped by
+        # `CELERY_BROKER_DISPLAY_LIMIT`), so a 200k-deep queue with
+        # 190k matches would show ~1.9k in the preview while the
+        # actual clear then drained 190k.
+        redis = _conn.get_connection(kind="broker")
+        total_found = 0
+        for queue_name, filter_set in by_queue_filters.items():
+            tombstone = _celery_clear_tombstone()
+            stats = _streaming_celery_clear(
+                redis,
+                queue_name,
+                frozenset(filter_set),
+                tombstone,
+                keep_one=keep_one,
+                dry_run=True,
+            )
+            total_found += stats.total_found
+            total_passes += stats.passes_run
+        # `keep_one` semantics: the actual clear preserves one
+        # message per (queue, filter) tuple, so subtract one for
+        # the preview.
+        if keep_one and total_found > 0:
+            total_found = max(0, total_found - len(by_queue_filters))
+        result_count = total_found
     else:
         redis = _conn.get_connection(kind="broker")
         for queue_name, filter_set in by_queue_filters.items():

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -749,6 +749,7 @@ def _celery_broker_clear(
         # actual clear then drained 190k.
         redis = _conn.get_connection(kind="broker")
         total_found = 0
+        queues_with_matches = 0
         for queue_name, filter_set in by_queue_filters.items():
             tombstone = _celery_clear_tombstone()
             stats = _streaming_celery_clear(
@@ -760,12 +761,20 @@ def _celery_broker_clear(
                 dry_run=True,
             )
             total_found += stats.total_found
+            if stats.total_found > 0:
+                queues_with_matches += 1
             total_passes += stats.passes_run
         # `keep_one` semantics: the actual clear preserves one
-        # message per (queue, filter) tuple, so subtract one for
-        # the preview.
-        if keep_one and total_found > 0:
-            total_found = max(0, total_found - len(by_queue_filters))
+        # message per queue *that has at least one match*. Subtract
+        # only for those queues, not for every queue in the filter
+        # set -- otherwise a queue that drained to zero matches
+        # between the changelist render and this preview (e.g. a
+        # consumer popped the last match) would shave one extra
+        # off the count, underreporting what the real clear will
+        # tombstone. Aligns the preview with the actual execution
+        # path of `_streaming_celery_clear`.
+        if keep_one and queues_with_matches > 0:
+            total_found = max(0, total_found - queues_with_matches)
         result_count = total_found
     else:
         redis = _conn.get_connection(kind="broker")

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -414,7 +414,7 @@ def _redis_delete(
 # For 200–500k-deep queues the old eager-materialise-then-LSET path
 # had two problems:
 #
-#   1. Memory: materialising up to `MAX_ITEMS_PER_KEY` rows into
+#   1. Memory: materialising up to `CELERY_BROKER_SCAN_LIMIT` rows into
 #      Python before clearing was O(N) in memory.
 #   2. Race drift: the index a Celery consumer sees between our
 #      `LRANGE` snapshot and our `LSET` call can shift if another
@@ -491,7 +491,7 @@ def _streaming_celery_clear(
     total_drifted = 0
     prev_lset: int | None = None
     passes_run = 0
-    cap = redis_admin_settings.MAX_ITEMS_PER_KEY
+    cap = redis_admin_settings.CELERY_BROKER_SCAN_LIMIT
 
     # Track whether we've kept the "first" across all passes so that
     # repeat passes honour the same semantic (first by queue index).

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -454,6 +454,7 @@ class _StreamingClearStats:
     total_lset: int
     total_drifted: int
     total_found: int
+    first_match_index: int | None
     passes_run: int
 
 
@@ -506,6 +507,12 @@ def _streaming_celery_clear(
     total_lset = 0
     total_drifted = 0
     total_found = 0
+    # Tracks the lowest-index match seen across all passes. Pass 1
+    # walks the queue in ascending index order, so the first match
+    # we see IS the lowest. Used by the clear-by-filter preview to
+    # render the "Clear all but first" callout (`kept_index`)
+    # without a separate queryset materialisation.
+    first_match_index: int | None = None
     prev_lset: int | None = None
     passes_run = 0
 
@@ -552,6 +559,8 @@ def _streaming_celery_clear(
                 if key not in filter_tuples:
                     continue
                 matches_found += 1
+                if first_match_index is None:
+                    first_match_index = idx
 
                 # keep_one: skip the first match across all chunks
                 # (lowest index in current pass).
@@ -610,8 +619,49 @@ def _streaming_celery_clear(
         total_lset=total_lset,
         total_drifted=total_drifted,
         total_found=total_found,
+        first_match_index=first_match_index,
         passes_run=passes_run,
     )
+
+
+def streaming_celery_count(
+    queue_name: str,
+    *,
+    task_name: str | None = None,
+    repoid: int | None = None,
+    commitid: str | None = None,
+) -> tuple[int, int | None]:
+    """Streaming `(match_count, lowest_index_match)` for the
+    `(queue_name, task_name?, repoid?, commitid?)` filter.
+
+    Walks the full `LLEN(queue)` so the returned count agrees
+    with what `celery_broker_clear` would actually tombstone.
+    Used by `clear_by_filter_view` to render the preview page;
+    the queryset path is bounded by `CELERY_BROKER_DISPLAY_LIMIT`
+    and would underreport on deep queues.
+
+    The filter compares envelope tuples by exact equality. The
+    admin view passes `commitid` straight from the chart row
+    (full 40-char hash), so this matches the
+    `queryset.filter(commitid__startswith=...)` path the
+    changelist uses for full-length input. Partial-prefix
+    commits (rare; only reachable via manual URL editing) will
+    count as zero — that's a documented limitation; the user
+    can still browse via the changelist filters.
+    """
+
+    redis = _conn.get_connection(kind="broker")
+    filter_tuples = frozenset({(task_name or None, repoid, commitid or None)})
+    tombstone = _celery_clear_tombstone()
+    stats = _streaming_celery_clear(
+        redis,
+        queue_name,
+        filter_tuples,
+        tombstone,
+        keep_one=False,
+        dry_run=True,
+    )
+    return stats.total_found, stats.first_match_index
 
 
 def celery_broker_clear(

--- a/apps/codecov-api/redis_admin/settings.py
+++ b/apps/codecov-api/redis_admin/settings.py
@@ -38,13 +38,15 @@ CELERY_BROKER_DISPLAY_LIMIT: int = getattr(
     settings, "REDIS_ADMIN_CELERY_BROKER_DISPLAY_LIMIT", 2_000
 )
 
-# Sample window used by deep scans of a celery_broker queue: the streaming
-# frequency chart aggregator (`_stream_frequency_aggregate`) and the
-# streaming clear (`services._streaming_celery_clear`). Both walk the queue
-# in bounded chunks and discard payloads, so memory stays flat regardless
-# of this cap; raising it just trades latency for accuracy. Keeping the
-# chart and clear on the same window guarantees that anything the chart
-# surfaces is reachable by the "Clear queue" button.
+# Sample window for the streaming frequency chart aggregator
+# (`_stream_frequency_aggregate`). Walks the queue in bounded chunks and
+# discards payloads, so memory stays flat regardless of this cap; raising
+# it just trades latency for accuracy.
+#
+# The streaming clear (`services._streaming_celery_clear`) is intentionally
+# *not* bounded by this — it walks `LLEN(queue)` so a "Clear all" action
+# always drains the entire queue, even if the user is targeting matches
+# beyond the chart's sample window.
 CELERY_BROKER_SCAN_LIMIT: int = getattr(
     settings, "REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT", 100_000
 )

--- a/apps/codecov-api/redis_admin/settings.py
+++ b/apps/codecov-api/redis_admin/settings.py
@@ -29,6 +29,26 @@ MAX_DECODE_BYTES: int = getattr(settings, "REDIS_ADMIN_MAX_DECODE_BYTES", 4_096)
 # so a runaway 10M-element SET can't OOM the api process.
 MAX_ITEMS_PER_KEY: int = getattr(settings, "REDIS_ADMIN_MAX_ITEMS_PER_KEY", 20_000)
 
+# Per-message rows materialised on the celery_broker changelist drill-down.
+# Tighter than `MAX_ITEMS_PER_KEY` because each row holds a parsed envelope
+# in memory (kept in the per-request LRANGE cache) and is rendered as a
+# table cell — the operator only needs a representative slice, not the
+# entire 100k-deep queue.
+CELERY_BROKER_DISPLAY_LIMIT: int = getattr(
+    settings, "REDIS_ADMIN_CELERY_BROKER_DISPLAY_LIMIT", 2_000
+)
+
+# Sample window used by deep scans of a celery_broker queue: the streaming
+# frequency chart aggregator (`_stream_frequency_aggregate`) and the
+# streaming clear (`services._streaming_celery_clear`). Both walk the queue
+# in bounded chunks and discard payloads, so memory stays flat regardless
+# of this cap; raising it just trades latency for accuracy. Keeping the
+# chart and clear on the same window guarantees that anything the chart
+# surfaces is reachable by the "Clear queue" button.
+CELERY_BROKER_SCAN_LIMIT: int = getattr(
+    settings, "REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT", 100_000
+)
+
 # Pipeline batch size for delete operations (M5). Keeps a single delete action
 # from blocking Redis with a single oversized MULTI when an operator clears
 # thousands of keys at once.

--- a/apps/codecov-api/redis_admin/static/redis_admin/css/celery_chart_fragment.css
+++ b/apps/codecov-api/redis_admin/static/redis_admin/css/celery_chart_fragment.css
@@ -1,0 +1,69 @@
+/* Loading card shown while the celery_broker frequency chart fragment
+ * is fetched. Replaces the previous subtle "Loading…" help line so the
+ * loading state is obvious at the top of the changelist while the user
+ * waits for the fragment endpoint to materialise the chart (which can
+ * take a few seconds on deep queues — the aggregator samples up to
+ * CELERY_BROKER_SCAN_LIMIT messages).
+ *
+ * Lives in an external file so it survives the production CSP, which
+ * blocks inline <style> tags. See settings_base.py CSP_DEFAULT_SRC.
+ */
+
+.celery-chart-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 8px;
+  margin: 16px 0;
+  padding: 28px 24px;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 6px;
+  background: var(--darkened-bg, #f8f8f8);
+  color: var(--body-fg, #333);
+  min-height: 120px;
+  box-sizing: border-box;
+}
+
+.celery-chart-loader__spinner {
+  width: 36px;
+  height: 36px;
+  border: 4px solid var(--border-color, #ddd);
+  border-top-color: var(--primary, #417690);
+  border-radius: 50%;
+  animation: celery-chart-spin 0.85s linear infinite;
+}
+
+.celery-chart-loader__label {
+  margin: 6px 0 0 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+.celery-chart-loader__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--body-quiet-color, #666);
+  max-width: 480px;
+  line-height: 1.4;
+}
+
+@keyframes celery-chart-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* Respect operators who set reduced-motion in their OS — the spinner
+ * still gets a subtle pulse so the loading affordance survives. */
+@media (prefers-reduced-motion: reduce) {
+  .celery-chart-loader__spinner {
+    animation: celery-chart-pulse 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes celery-chart-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.4; }
+}

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/change_list.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/change_list.html
@@ -8,18 +8,29 @@ frequency chart above the result list. The chart is fetched
 asynchronously from `chart_fragment_view` so the changelist renders
 immediately regardless of queue depth (200–500k messages).
 
-The fetch helper lives in an external static file rather than an
-inline <script> so it survives the strict CSP on production
-(api-admin.codecov.io), which only allows `'self'` and one fixed
-sha256 for inline scripts. See settings_base.py CSP_DEFAULT_SRC.
+The fetch helper + loader styles live in external static files rather
+than inline <script>/<style> tags so they survive the strict CSP on
+production (api-admin.codecov.io), which only allows `'self'` and one
+fixed sha256 for inline scripts. See settings_base.py CSP_DEFAULT_SRC.
 
 In summary mode (queue_name is absent) the block renders nothing extra.
 {% endcomment %}
+{% block extrastyle %}
+  {{ block.super }}
+  {% if queue_name %}
+    <link rel="stylesheet" href="{% static 'redis_admin/css/celery_chart_fragment.css' %}">
+  {% endif %}
+{% endblock %}
+
 {% block content %}
   {% if queue_name %}
     <div id="celery-chart-fragment"
          data-fragment-url="{% url 'admin:celerybrokerqueue-chart-fragment' queue_name=queue_name %}">
-      <p class="help">Loading frequency chart&hellip;</p>
+      <div class="celery-chart-loader" role="status" aria-live="polite">
+        <div class="celery-chart-loader__spinner" aria-hidden="true"></div>
+        <p class="celery-chart-loader__label">Loading frequency chart&hellip;</p>
+        <p class="celery-chart-loader__hint">Sampling up to 100,000 messages from <code>{{ queue_name }}</code> &mdash; this can take a few seconds on deep queues.</p>
+      </div>
     </div>
     <script src="{% static 'redis_admin/js/celery_chart_fragment.js' %}" defer></script>
   {% endif %}

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/change_list.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/change_list.html
@@ -29,7 +29,7 @@ In summary mode (queue_name is absent) the block renders nothing extra.
       <div class="celery-chart-loader" role="status" aria-live="polite">
         <div class="celery-chart-loader__spinner" aria-hidden="true"></div>
         <p class="celery-chart-loader__label">Loading frequency chart&hellip;</p>
-        <p class="celery-chart-loader__hint">Sampling up to 100,000 messages from <code>{{ queue_name }}</code> &mdash; this can take a few seconds on deep queues.</p>
+        <p class="celery-chart-loader__hint">Sampling up to {{ scan_limit_label|default:"100,000" }} messages from <code>{{ queue_name }}</code> &mdash; this can take a few seconds on deep queues.</p>
       </div>
     </div>
     <script src="{% static 'redis_admin/js/celery_chart_fragment.js' %}" defer></script>

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -18,12 +18,89 @@ from django.contrib.admin.models import LogEntry
 from django.test import TestCase
 
 from redis_admin import conn as redis_admin_conn
+from redis_admin.admin import FamilyFilter, LockFamilyFilter, QueueFamilyFilter
 from redis_admin.families import (
     _resolve_celery_queue_names as _celery_queue_names,  # noqa: PLC2701
 )
 from shared.django_apps.codecov_auth.tests.factories import UserFactory
 from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
 from utils.test_utils import Client
+
+# ---- Family filter lookups (does not require django_db / TestCase) --------
+
+
+def _family_filter_choices(filter_cls):
+    """Return `lookups()` output for `filter_cls` without running the
+    Django `SimpleListFilter.__init__` (which wants a real request,
+    params, model, and model_admin). `lookups` only reads class-level
+    `category` / `excluded_names`, so bypassing __init__ keeps the
+    test a pure unit test that never touches the DB or the HTTP
+    stack.
+    """
+
+    instance = filter_cls.__new__(filter_cls)
+    return dict(instance.lookups(request=None, model_admin=None))
+
+
+def test_queue_family_filter_lookups_omit_celery_broker():
+    """The RedisQueue changelist hides `celery_broker` rows via
+    `family_exclude`, so its sidebar filter must not offer
+    `celery_broker` as a clickable choice — that would be a dead
+    option that filters the page to zero rows.
+    """
+
+    choices = _family_filter_choices(QueueFamilyFilter)
+
+    assert "celery_broker" not in choices
+
+
+def test_queue_family_filter_lookups_keep_other_queue_families():
+    """Safety rail: the exclusion above must leave the *other*
+    queue-category families in the dropdown, so the filter still
+    works as a filter.
+    """
+
+    choices = _family_filter_choices(QueueFamilyFilter)
+
+    assert "uploads" in choices
+    assert "ta_flake_key" in choices
+    assert "latest_upload" in choices
+
+
+def test_queue_family_filter_rejects_lock_family_choices():
+    """`category='queue'` must not leak lock-category families
+    (coordination_lock, ta_flake_lock, etc.) into the queue filter
+    dropdown; those live on the RedisLock admin instead.
+    """
+
+    choices = _family_filter_choices(QueueFamilyFilter)
+
+    assert "coordination_lock" not in choices
+    assert "ta_flake_lock" not in choices
+
+
+def test_base_family_filter_still_exposes_celery_broker_for_non_queue_callers():
+    """`FamilyFilter` itself (no exclusion) still returns
+    `celery_broker` so other non-queue-admin callers — or a future
+    admin that intentionally *wants* the family visible — aren't
+    silently stripped of it.
+    """
+
+    choices = _family_filter_choices(FamilyFilter)
+
+    assert "celery_broker" in choices
+
+
+def test_lock_family_filter_unaffected_by_celery_exclusion():
+    """Sanity check: the locks filter is on a separate category and
+    has no overlap with celery_broker either way; make sure we
+    didn't bleed the exclusion into a different subclass by mistake.
+    """
+
+    choices = _family_filter_choices(LockFamilyFilter)
+
+    assert "celery_broker" not in choices
+    assert "coordination_lock" in choices
 
 
 class RedisAdminSmokeTest(TestCase):

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_drain_verification.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_drain_verification.py
@@ -1,0 +1,309 @@
+"""Defensive end-to-end coverage for the `celery_broker_clear` /
+`_streaming_celery_clear` drain semantics on deep queues.
+
+These tests sit in their own module to insulate them from churn on
+the much larger `test_celery_broker_queue.py` suite -- the
+clear-queue path has regressed twice on this PR (#904 and #903's
+synthetic-target fix) and we want a small, focused file that:
+
+* asserts post-call `LLEN` arithmetic explicitly (initial - matches),
+* walks the full queue post-call with `parse_celery_envelope` to
+  *positively* prove no targeted envelope survives, and
+* exercises queues with `LLEN > CELERY_BROKER_DISPLAY_LIMIT` so
+  any future regression that re-introduces a queryset-bounded scan
+  fails immediately.
+
+All tests use `fakeredis` and `SimpleNamespace` so they run under
+`-m 'not django_db'` (the `_record_audit` helper inside
+`celery_broker_clear` swallows DB failures, which keeps the
+audit-log write best-effort and lets these tests skip the
+Postgres-bound `TestCase` machinery).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import fakeredis
+import pytest
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin import settings as redis_admin_settings
+from redis_admin.families import parse_celery_envelope
+from redis_admin.models import CeleryBrokerQueue
+from redis_admin.services import celery_broker_clear
+from redis_admin.tests.test_celery_broker_queue import _build_envelope
+
+
+@pytest.fixture
+def patched_broker(monkeypatch) -> fakeredis.FakeStrictRedis:
+    """Route both cache and broker `get_connection` to one fakeredis,
+    matching the fixture used by `test_celery_broker_queue.py`.
+    """
+
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(
+        redis_admin_conn, "get_connection", lambda kind="default": server
+    )
+    return server
+
+
+def _count_matches_in_queue(
+    redis,
+    queue: str,
+    *,
+    task: str,
+    repoid: int,
+    commitid: str,
+) -> list[int]:
+    """Walk the entire queue post-clear and return the indexes of
+    every envelope whose `(task, repoid, commitid)` triple matches.
+
+    Used by the deep-queue regression tests to *positively* verify
+    "no match remains" rather than just inferring it from `LLEN`
+    arithmetic. Catches the family of regressions where the
+    streaming clear silently leaves matches behind beyond a capped
+    scan window.
+    """
+
+    raw_items = redis.lrange(queue, 0, -1)
+    matches: list[int] = []
+    for idx, raw in enumerate(raw_items):
+        meta = parse_celery_envelope(raw if isinstance(raw, bytes) else raw.encode())
+        if (meta.task, meta.repoid, meta.commitid) == (task, repoid, commitid):
+            matches.append(idx)
+    return matches
+
+
+def test_celery_broker_clear_drains_deep_queue_end_to_end(patched_broker):
+    """`celery_broker_clear(dry_run=False, keep_one=False)` on a
+    queue deeper than `CELERY_BROKER_DISPLAY_LIMIT` must drain every
+    matching envelope.
+
+    Reproduces the "Clear queue" admin action's exact wire-up from
+    `clear_by_filter_view` (synthetic single-target with the
+    operator's filter triple) and asserts both:
+
+    * `LLEN(queue) == initial_total - matches` (here: initial_total
+      == matches, so `LLEN == 0`), AND
+    * walking the entire queue post-call finds zero envelopes
+      whose `(task, repoid, commitid)` triple still matches the
+      filter.
+
+    This is the core regression-class test for the first failure
+    mode the user got burned by on PR #903 / fixed in PR #904: the
+    streaming clear walking a capped window instead of the full
+    `LLEN(queue)`.
+    """
+
+    queue = "bundle_analysis"
+    task = "app.tasks.bundle_analysis.BundleAnalysisProcessor"
+    repoid = 21222368
+    commitid = "0832c11a1f43c5e2a1b9f8a3e5d1c2b7e9a8d3f0"
+
+    # `+ 500` so the queue is comfortably deeper than the
+    # display window the queryset path would have materialised.
+    matches = redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT + 500
+    pipe = patched_broker.pipeline(transaction=False)
+    for _ in range(matches):
+        pipe.rpush(
+            queue,
+            _build_envelope(task=task, kwargs={"repoid": repoid, "commitid": commitid}),
+        )
+    pipe.execute()
+    initial_total = patched_broker.llen(queue)
+    assert initial_total == matches
+    user = SimpleNamespace(id=1, pk=1)
+
+    synthetic_target = CeleryBrokerQueue(
+        queue_name=queue,
+        task_name=task,
+        repoid=repoid,
+        commitid=commitid,
+        index_in_queue=None,
+    )
+
+    result = celery_broker_clear(
+        [synthetic_target],
+        user=user,
+        dry_run=False,
+        keep_one=False,
+    )
+
+    assert result.dry_run is False
+    assert result.count == matches
+    # LLEN dropped by exactly `matches` (here: every envelope was a
+    # match, so the queue is empty).
+    assert patched_broker.llen(queue) == initial_total - matches == 0
+    # Positive walk: zero remaining matches.
+    surviving = _count_matches_in_queue(
+        patched_broker, queue, task=task, repoid=repoid, commitid=commitid
+    )
+    assert surviving == [], f"expected zero remaining matches, got {len(surviving)}"
+
+
+def test_celery_broker_clear_keep_one_deep_queue_leaves_exactly_one_at_head(
+    patched_broker,
+):
+    """`celery_broker_clear(keep_one=True)` on a queue deeper than
+    `CELERY_BROKER_DISPLAY_LIMIT` must leave *exactly one* matching
+    message, at the head of the queue.
+
+    The existing `test_streaming_clear_keep_one_leaves_lowest_index`
+    runs against 4 messages, well within the display window, so it
+    can't catch a regression that re-introduces a queryset-bounded
+    scan -- on a deep queue, that bug would either skip the keeper
+    (clearing all matches) or short-circuit before reaching the
+    tail. This test pins the "deep queue + survivor at index 0"
+    invariant.
+    """
+
+    queue = "bundle_analysis"
+    task = "app.tasks.bundle_analysis.BundleAnalysisProcessor"
+    repoid = 21222368
+    commitid = "0832c11a1f43c5e2a1b9f8a3e5d1c2b7e9a8d3f0"
+
+    matches = redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT + 100
+    pipe = patched_broker.pipeline(transaction=False)
+    for _ in range(matches):
+        pipe.rpush(
+            queue,
+            _build_envelope(task=task, kwargs={"repoid": repoid, "commitid": commitid}),
+        )
+    pipe.execute()
+    initial_total = patched_broker.llen(queue)
+    assert initial_total == matches
+    user = SimpleNamespace(id=1, pk=1)
+
+    synthetic_target = CeleryBrokerQueue(
+        queue_name=queue,
+        task_name=task,
+        repoid=repoid,
+        commitid=commitid,
+        index_in_queue=None,
+    )
+
+    result = celery_broker_clear(
+        [synthetic_target],
+        user=user,
+        dry_run=False,
+        keep_one=True,
+    )
+
+    # `result.count` reports cleared (not surviving) -- one match
+    # is preserved per queue with at least one match.
+    assert result.count == matches - 1
+    # LLEN dropped by exactly the cleared count.
+    assert patched_broker.llen(queue) == initial_total - (matches - 1) == 1
+    # Positive walk: exactly one survivor, sitting at index 0
+    # (head-of-queue, which is the next message a Celery worker
+    # would BLPOP).
+    surviving = _count_matches_in_queue(
+        patched_broker, queue, task=task, repoid=repoid, commitid=commitid
+    )
+    assert surviving == [0], (
+        f"expected exactly one surviving match at index 0, got {surviving}"
+    )
+
+
+def test_celery_broker_clear_mixed_content_deep_queue_clears_only_filter(
+    patched_broker,
+):
+    """End-to-end clear on a deep queue with three task buckets must
+    drain every envelope matching the filter triple A and leave
+    every non-matching envelope (B and C) intact, regardless of
+    position in the queue.
+
+    Three buckets, interleaved through the queue:
+
+    * A (`(task_a, repoid_a, commitid_a)`): the targeted filter
+      triple. `n_a` copies (> CELERY_BROKER_DISPLAY_LIMIT) so any
+      cap-bounded clear would silently leave matches in the tail.
+    * B (`(task_b, repoid_a, commitid_a)`): same repoid + commitid
+      as A but a different task. The synthetic target's filter
+      triple includes `task_name`, so B must not be tombstoned.
+    * C (`(task_a, repoid_c, commitid_c)`): same task as A but a
+      different repoid + commitid. Must not be tombstoned.
+
+    B and C are seeded both before A (head-of-queue) and after A
+    (tail-of-queue, past the display window) so the clear can't
+    get a free pass by stopping early or by accidentally walking
+    only the head slice.
+    """
+
+    queue = "bundle_analysis"
+    task_a = "app.tasks.bundle_analysis.BundleAnalysisProcessor"
+    repoid_a = 21222368
+    commitid_a = "0832c11a1f43c5e2a1b9f8a3e5d1c2b7e9a8d3f0"
+    task_b = "app.tasks.notify.NotifyTask"
+    repoid_c = 99999
+    commitid_c = "ffffffffffffffffffffffffffffffffffffffff"
+
+    n_a = redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT + 500
+    head_b = head_c = 25
+    tail_b = tail_c = 25
+    n_b = head_b + tail_b
+    n_c = head_c + tail_c
+
+    envelope_a = _build_envelope(
+        task=task_a, kwargs={"repoid": repoid_a, "commitid": commitid_a}
+    )
+    envelope_b = _build_envelope(
+        task=task_b, kwargs={"repoid": repoid_a, "commitid": commitid_a}
+    )
+    envelope_c = _build_envelope(
+        task=task_a, kwargs={"repoid": repoid_c, "commitid": commitid_c}
+    )
+
+    pipe = patched_broker.pipeline(transaction=False)
+    for _ in range(head_b):
+        pipe.rpush(queue, envelope_b)
+        pipe.rpush(queue, envelope_c)
+    for _ in range(n_a):
+        pipe.rpush(queue, envelope_a)
+    for _ in range(tail_b):
+        pipe.rpush(queue, envelope_b)
+        pipe.rpush(queue, envelope_c)
+    pipe.execute()
+
+    initial_total = patched_broker.llen(queue)
+    assert initial_total == n_a + n_b + n_c
+    user = SimpleNamespace(id=1, pk=1)
+
+    synthetic_target = CeleryBrokerQueue(
+        queue_name=queue,
+        task_name=task_a,
+        repoid=repoid_a,
+        commitid=commitid_a,
+        index_in_queue=None,
+    )
+
+    result = celery_broker_clear(
+        [synthetic_target],
+        user=user,
+        dry_run=False,
+        keep_one=False,
+    )
+
+    assert result.count == n_a
+    # LLEN dropped by exactly `n_a`; every B + C remains.
+    assert patched_broker.llen(queue) == initial_total - n_a == n_b + n_c
+    # Positive walks: zero A survivors, every B + C survives.
+    surviving_a = _count_matches_in_queue(
+        patched_broker, queue, task=task_a, repoid=repoid_a, commitid=commitid_a
+    )
+    surviving_b = _count_matches_in_queue(
+        patched_broker, queue, task=task_b, repoid=repoid_a, commitid=commitid_a
+    )
+    surviving_c = _count_matches_in_queue(
+        patched_broker, queue, task=task_a, repoid=repoid_c, commitid=commitid_c
+    )
+    assert surviving_a == [], (
+        f"expected zero A survivors, got {len(surviving_a)} at indexes {surviving_a[:5]}"
+    )
+    assert len(surviving_b) == n_b, (
+        f"expected {n_b} B survivors, got {len(surviving_b)}"
+    )
+    assert len(surviving_c) == n_c, (
+        f"expected {n_c} C survivors, got {len(surviving_c)}"
+    )

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -2540,3 +2540,122 @@ def test_celery_broker_clear_with_synthetic_filter_target_clears_full_queue(
     # `_streaming_celery_clear` LREMs tombstones at the end of each
     # pass, so the queue should be fully drained.
     assert patched_broker.llen(queue) == 0
+
+
+def test_streaming_celery_count_wildcard_task_name_matches_any_task(patched_broker):
+    """Regression for the pre-existing wildcard bug surfaced by the
+    synthetic-target fix on PR #903: `streaming_celery_count` (and
+    the underlying `_streaming_celery_clear` filter) used exact-
+    tuple equality on `(task, repoid, commit)`. When the operator
+    left `task_name` unset (None), the filter tuple
+    `(None, 1, "aaaa")` could never match a real envelope (whose
+    `meta.task` is always populated), so the preview reported zero
+    matches even when the queryset's
+    `filter(repoid=1, commitid__startswith="aaaa")` would surface
+    rows.
+
+    With the wildcard fix, `None` slots in a filter tuple act as
+    "don't constrain on this field" -- mirroring the queryset's
+    "filter by what's set" semantic -- so the streaming counter
+    and the streaming clear agree with the queryset's match set.
+    """
+
+    queue = "celery"
+    repoid = 7
+    commitid = "deadbeefcafebabe1111222233334444aaaaaaaa"
+    task_a = "app.tasks.notify.NotifyTask"
+    task_b = "app.tasks.upload.UploadTask"
+
+    pipe = patched_broker.pipeline(transaction=False)
+    for _ in range(3):
+        pipe.rpush(
+            queue,
+            _build_envelope(
+                task=task_a, kwargs={"repoid": repoid, "commitid": commitid}
+            ),
+        )
+    for _ in range(2):
+        pipe.rpush(
+            queue,
+            _build_envelope(
+                task=task_b, kwargs={"repoid": repoid, "commitid": commitid}
+            ),
+        )
+    pipe.rpush(
+        queue,
+        _build_envelope(
+            task=task_a, kwargs={"repoid": repoid + 1, "commitid": commitid}
+        ),
+    )
+    pipe.execute()
+
+    match_count, first_index = streaming_celery_count(
+        queue,
+        task_name=None,
+        repoid=repoid,
+        commitid=commitid,
+    )
+    assert match_count == 5
+    assert first_index == 0
+    assert patched_broker.llen(queue) == 6
+
+
+def test_celery_broker_clear_synthetic_target_with_wildcard_task_name_drains_all_matches(
+    patched_broker,
+):
+    """Companion for the wildcard fix: the synthetic-target path
+    constructed by `clear_by_filter_view` carries `task_name=None`
+    when the operator filtered by repoid/commit only, so the
+    clear path must honour the same wildcard semantic the
+    streaming counter uses -- otherwise the preview reports N
+    matches but "Clear all" silently no-ops.
+    """
+
+    queue = "celery"
+    repoid = 7
+    commitid = "deadbeefcafebabe1111222233334444aaaaaaaa"
+
+    pipe = patched_broker.pipeline(transaction=False)
+    for _ in range(3):
+        pipe.rpush(
+            queue,
+            _build_envelope(
+                task="app.tasks.notify.NotifyTask",
+                kwargs={"repoid": repoid, "commitid": commitid},
+            ),
+        )
+    for _ in range(2):
+        pipe.rpush(
+            queue,
+            _build_envelope(
+                task="app.tasks.upload.UploadTask",
+                kwargs={"repoid": repoid, "commitid": commitid},
+            ),
+        )
+    pipe.rpush(
+        queue,
+        _build_envelope(
+            task="app.tasks.notify.NotifyTask",
+            kwargs={"repoid": repoid + 1, "commitid": commitid},
+        ),
+    )
+    pipe.execute()
+    user = SimpleNamespace(id=1, pk=1)
+
+    synthetic = CeleryBrokerQueue(
+        queue_name=queue,
+        task_name=None,
+        repoid=repoid,
+        commitid=commitid,
+        index_in_queue=None,
+    )
+
+    result = celery_broker_clear(
+        [synthetic],
+        user=user,
+        dry_run=False,
+        keep_one=False,
+    )
+
+    assert result.count == 5
+    assert patched_broker.llen(queue) == 1

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -1624,6 +1624,86 @@ def test_queryset_summary_mode_lists_known_queues_with_depth(patched_broker):
     assert by_name["celery"].pk_token == "celery#summary"
 
 
+# ---- Summary-mode default ordering ----------------------------------------
+
+
+def test_queryset_summary_mode_default_sort_is_depth_desc_then_name_asc(
+    patched_broker, monkeypatch
+):
+    """Summary mode must surface the deepest queues first, with
+    ties broken alphabetically by queue name.
+
+    The admin landing page is an on-call surface: an operator
+    arriving from a Grafana alert scans the top of the page looking
+    for the hot spot. Alphabetical-by-name (the pre-change default)
+    would bury a 100-deep `ingest` below a 0-deep `bundle_analysis`
+    simply because of its name. Depth-DESC fixes that; name-ASC
+    ties-break keeps the list stable so refreshing doesn't reshuffle
+    queues at equal depth.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset  # noqa: PLC0415
+
+    # Pin the enumerated queue set — the test env's
+    # `_resolve_celery_queue_names` only returns `("celery",
+    # "healthcheck")`, which isn't enough to exercise both the
+    # tie-break and the distinct-depth sort dimensions.
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_celery_queue_names",
+        lambda: ("bundle_analysis", "ingest", "notifications", "process_pulls"),
+    )
+
+    # bundle_analysis: 5  |  ingest: 100  |  notifications: 100  |  process_pulls: 0
+    for _ in range(5):
+        patched_broker.rpush("bundle_analysis", _build_envelope(kwargs={}))
+    for _ in range(100):
+        patched_broker.rpush("ingest", _build_envelope(kwargs={}))
+    for _ in range(100):
+        patched_broker.rpush("notifications", _build_envelope(kwargs={}))
+    # process_pulls intentionally left empty (LLEN==0).
+
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue).order_by(
+        *CeleryBrokerQueueAdmin.summary_ordering
+    )
+    rows = list(qs)
+
+    assert [(r.queue_name, r.depth) for r in rows] == [
+        ("ingest", 100),
+        ("notifications", 100),
+        ("bundle_analysis", 5),
+        ("process_pulls", 0),
+    ]
+
+
+def test_admin_get_ordering_returns_summary_sort_when_no_queue_filter():
+    """`CeleryBrokerQueueAdmin.get_ordering` must flip to
+    `(-depth, queue_name)` on the summary URL so Django's ChangeList
+    applies the right default `.order_by(...)` before paginating.
+    Operators can still click column headers to override (Django's
+    `?o=` handling sits on top of this value).
+    """
+
+    admin_instance = CeleryBrokerQueueAdmin(CeleryBrokerQueue, AdminSite())
+    request = SimpleNamespace(GET={})
+
+    assert admin_instance.get_ordering(request) == ("-depth", "queue_name")
+
+
+def test_admin_get_ordering_falls_back_to_index_order_in_drill_down():
+    """Drill-down mode (per-message view) preserves `index_in_queue`
+    order so `matches[0]` is always the next message a Celery
+    consumer would pop. The streaming clear + keep-one-survivor
+    paths rely on that invariant; the summary-mode sort must not
+    leak into it.
+    """
+
+    admin_instance = CeleryBrokerQueueAdmin(CeleryBrokerQueue, AdminSite())
+    request = SimpleNamespace(GET={"queue_name__exact": "notify"})
+
+    assert admin_instance.get_ordering(request) == ("index_in_queue",)
+
+
 # ---- family_exclude --------------------------------------------------------
 
 

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -2475,3 +2475,68 @@ def test_streaming_clear_dry_run_keep_one_skips_empty_queues(patched_broker):
     assert result.count == n - 1
     assert patched_broker.llen(queue_with) == n
     assert patched_broker.llen(queue_empty) == 0
+
+
+def test_celery_broker_clear_with_synthetic_filter_target_clears_full_queue(
+    patched_broker,
+):
+    """Regression for Bugbot review on PR #903 (HIGH severity):
+    `clear_by_filter_view` previously passed `sample_targets` (the
+    materialised window capped at `CELERY_BROKER_DISPLAY_LIMIT`) as
+    the `targets` arg to `celery_broker_clear`. When every match
+    sat *beyond* that window -- e.g. a recent burst that filled the
+    tail of a queue with `LLEN > CELERY_BROKER_DISPLAY_LIMIT` --
+    `sample_targets` was empty, `_celery_broker_clear` derived
+    `by_queue_filters = {}`, the streaming-clear loop never
+    executed, and the operator saw "Cleared 0 of N matching
+    message(s)" while the queue stayed full.
+
+    The view now synthesises a single `CeleryBrokerQueue` directly
+    from the operator's filter inputs (queue + task_name? +
+    repoid? + commitid?). This test pins that contract: a single
+    synthetic target carrying just the filter triple must fan out
+    to *every* matching envelope across the full `LLEN`, not just
+    the first `CELERY_BROKER_DISPLAY_LIMIT` rows.
+    """
+
+    queue = "bundle_analysis"
+    task = "app.tasks.bundle_analysis.BundleAnalysisProcessor"
+    repoid = 21222368
+    commitid = "0832c11a1f43c5e2a1b9f8a3e5d1c2b7e9a8d3f0"
+
+    # > CELERY_BROKER_DISPLAY_LIMIT so the queryset-bounded window
+    # would have been empty for any caller that filtered on the
+    # tail end of the queue.
+    n = redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT + 1_000
+    pipe = patched_broker.pipeline(transaction=False)
+    for _ in range(n):
+        pipe.rpush(
+            queue,
+            _build_envelope(task=task, kwargs={"repoid": repoid, "commitid": commitid}),
+        )
+    pipe.execute()
+    user = SimpleNamespace(id=1, pk=1)
+
+    # The single synthetic target the view now constructs:
+    # one row carrying the operator's filter triple, no
+    # `index_in_queue` requirement (the streaming clear walks
+    # every position in the queue).
+    synthetic_target = CeleryBrokerQueue(
+        queue_name=queue,
+        task_name=task,
+        repoid=repoid,
+        commitid=commitid,
+        index_in_queue=None,
+    )
+
+    result = celery_broker_clear(
+        [synthetic_target],
+        user=user,
+        dry_run=False,
+        keep_one=False,
+    )
+
+    assert result.count == n
+    # `_streaming_celery_clear` LREMs tombstones at the end of each
+    # pass, so the queue should be fully drained.
+    assert patched_broker.llen(queue) == 0

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -2298,3 +2298,58 @@ def test_streaming_clear_drains_queue_with_no_artificial_cap(broker_redis):
     assert broker_redis.llen("notify") == 1
     survivor = json.loads(broker_redis.lrange("notify", 0, -1)[0])
     assert survivor["headers"]["task"] == "t.B"
+
+
+def test_streaming_clear_dry_run_returns_full_queue_match_count(patched_broker):
+    """Dry-run preview must walk the full queue, not just the capped
+    target list. Regression for the case where a deep queue (e.g.
+    200k messages, 190k matching one filter triple) reported only
+    ~2k matches because `pending_count` was bounded by
+    `CELERY_BROKER_DISPLAY_LIMIT`.
+    """
+
+    queue = "bundle_analysis"
+    task = "app.tasks.bundle_analysis.BundleAnalysisProcessor"
+    repoid = 21222368
+    commitid = "0832c11a1f43c5e2a1b9f8a3e5d1c2b7e9a8d3f0"
+
+    n = 5_000
+    pipe = patched_broker.pipeline(transaction=False)
+    for _ in range(n):
+        pipe.rpush(
+            queue,
+            _build_envelope(task=task, kwargs={"repoid": repoid, "commitid": commitid}),
+        )
+    pipe.execute()
+    # SimpleNamespace user keeps this regression test free of the
+    # Django-DB fixture so it runs in any sandbox; `_record_audit`
+    # is best-effort and swallows DB failures.
+    user = SimpleNamespace(id=1, pk=1)
+
+    targets = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name=queue).filter(
+            task_name=task,
+            repoid=repoid,
+            commitid=commitid,
+        )[:1]
+    )
+    assert len(targets) == 1
+
+    result = celery_broker_clear(
+        targets,
+        user=user,
+        dry_run=True,
+        keep_one=False,
+    )
+    assert result.dry_run is True
+    assert result.count == n
+
+    result_keep = celery_broker_clear(
+        targets,
+        user=user,
+        dry_run=True,
+        keep_one=True,
+    )
+    assert result_keep.count == n - 1
+
+    assert patched_broker.llen(queue) == n

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -36,6 +36,7 @@ from django.test import Client as DjClient
 from django.test import TestCase
 
 from redis_admin import conn as redis_admin_conn
+from redis_admin import settings as redis_admin_settings
 from redis_admin.admin import CeleryBrokerQueueAdmin, _resolve_repo_displays
 from redis_admin.families import parse_celery_envelope
 from redis_admin.models import CeleryBrokerQueue, RedisQueue
@@ -51,6 +52,7 @@ from redis_admin.services import (
     _CELERY_TOMBSTONE_PREFIX,
     _streaming_celery_clear,
     celery_broker_clear,
+    streaming_celery_count,
 )
 from shared.django_apps.codecov_auth.tests.factories import UserFactory
 from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
@@ -991,6 +993,14 @@ class CeleryFrequencyChartTest(TestCase):
         # block it. See settings_base.py CSP_DEFAULT_SRC.
         assert "celery_chart_fragment.js" in body
         assert 'src="' in body  # confirms external script form, not inline
+        # Loader styles ship as an EXTERNAL stylesheet for the same CSP
+        # reason as the JS — inline <style> would be blocked. The
+        # bordered/centred loader card replaces the previous subtle
+        # "Loading frequency chart…" help line so the loading state is
+        # obvious while the fragment endpoint materialises the chart.
+        assert "celery_chart_fragment.css" in body
+        assert "celery-chart-loader" in body
+        assert 'role="status"' in body
 
         # Fetch the chart fragment directly (as the browser's JS would).
         fragment_response = self.client.get(
@@ -2352,4 +2362,51 @@ def test_streaming_clear_dry_run_returns_full_queue_match_count(patched_broker):
     )
     assert result_keep.count == n - 1
 
+    assert patched_broker.llen(queue) == n
+
+
+def test_streaming_celery_count_returns_full_queue_match_count(patched_broker):
+    """Regression for the case where the clear-by-filter preview page
+    reported only ~2k matches on a queue with ~190k matches. The
+    streaming counter must walk the full LLEN(queue), not the capped
+    queryset window — the queryset path materialises only the first
+    `CELERY_BROKER_DISPLAY_LIMIT` (default 2_000) messages before
+    filtering, so on a queue dominated by one filter triple the
+    preview's `match_count` would underreport while "Clear all"
+    (unbounded) drained the full set.
+
+    `clear_by_filter_view` is a thin wrapper around this helper, so
+    pinning the helper's behaviour here covers the view fix too
+    without requiring the Django test client / Postgres.
+    """
+
+    queue = "bundle_analysis"
+    task = "app.tasks.bundle_analysis.BundleAnalysisProcessor"
+    repoid = 21222368
+    commitid = "0832c11a1f43c5e2a1b9f8a3e5d1c2b7e9a8d3f0"
+
+    # > CELERY_BROKER_DISPLAY_LIMIT so the queryset-bounded window
+    # would have underreported by `n - DISPLAY_LIMIT`.
+    n = redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT + 1_000
+    pipe = patched_broker.pipeline(transaction=False)
+    for _ in range(n):
+        pipe.rpush(
+            queue,
+            _build_envelope(task=task, kwargs={"repoid": repoid, "commitid": commitid}),
+        )
+    pipe.execute()
+
+    match_count, first_index = streaming_celery_count(
+        queue,
+        task_name=task,
+        repoid=repoid,
+        commitid=commitid,
+    )
+
+    assert match_count == n
+    # First match is at index 0 (every message in the queue matches
+    # the filter, and pass 1 walks ascending).
+    assert first_index == 0
+    # No mutation — `streaming_celery_count` is built on the dry-run
+    # streaming clear path.
     assert patched_broker.llen(queue) == n

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -2243,3 +2243,58 @@ def test_streaming_clear_keep_one_short_circuits_after_first_pass(broker_redis):
 
     assert stats.total_lset == 1
     assert stats.passes_run == 1
+
+
+def test_streaming_clear_drains_queue_with_no_artificial_cap(broker_redis):
+    """Regression for PR #899: a queue saturated with matching messages
+    deeper than what the per-pass cap *used* to be was not fully drained.
+
+    The previous implementation capped each pass at the first
+    `cap` positions (`min(depth, cap)`), so on a queue dominated by a
+    single `(task, repoid, commitid)` triple:
+
+    * pass 1 tombstoned the first `cap` matches and `LREM` swept them,
+    * pass 2 tombstoned another `cap` matches that shifted in from
+      beyond cap (now occupying positions 0..cap-1),
+    * the `prev_lset == matches_lset` plateau check (both `cap`)
+      then declared convergence and exited.
+
+    Net effect: a saturated queue dropped by ~2 * cap per "Clear all"
+    click instead of draining fully — what the user perceived as
+    "queue does not shrink".
+
+    The clear is now intentionally unbounded (walks the full
+    `LLEN(queue)` every pass), so a single click drains every match
+    regardless of depth. This test pushes 41_000 matching messages
+    (just over 2× what the old 20k cap was) so the buggy code path
+    would have tombstoned exactly 40_000 across two passes, hit the
+    plateau exit, and left 1_000 messages behind. The fix walks the
+    entire queue every pass, so a single click drains all 41_000
+    matches.
+    """
+
+    matching_count = 41_000
+    raw_match = _build_envelope(task="t.A", kwargs={"repoid": 1, "commitid": "x"})
+    raw_other = _build_envelope(task="t.B", kwargs={"repoid": 999, "commitid": "y"})
+    pipe = broker_redis.pipeline(transaction=False)
+    for _ in range(matching_count):
+        pipe.rpush("notify", raw_match)
+    pipe.rpush("notify", raw_other)
+    pipe.execute()
+
+    initial_depth = broker_redis.llen("notify")
+    assert initial_depth == matching_count + 1
+
+    tombstone = f"{_CELERY_TOMBSTONE_PREFIX}:test-deep-saturation"
+    filter_tuples = _make_filter(("t.A", 1, "x"))
+    stats = _streaming_celery_clear(
+        broker_redis, "notify", filter_tuples, tombstone, dry_run=False
+    )
+
+    # Every matching message is cleared in a single click; only the
+    # one unrelated message survives.
+    assert stats.total_lset == matching_count
+    assert stats.total_drifted == 0
+    assert broker_redis.llen("notify") == 1
+    survivor = json.loads(broker_redis.lrange("notify", 0, -1)[0])
+    assert survivor["headers"]["task"] == "t.B"

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -2410,3 +2410,68 @@ def test_streaming_celery_count_returns_full_queue_match_count(patched_broker):
     # No mutation — `streaming_celery_count` is built on the dry-run
     # streaming clear path.
     assert patched_broker.llen(queue) == n
+
+
+def test_streaming_clear_dry_run_keep_one_skips_empty_queues(patched_broker):
+    """Regression for Bugbot review on PR #903: when the dry-run
+    preview spans multiple queues with `keep_one=True`, the
+    subtraction must only deduct for queues that actually have at
+    least one match, *not* for every queue in the filter set.
+
+    Otherwise a queue that drained to zero matches between the
+    changelist render and the preview (e.g. a consumer popped the
+    last match) shaves one extra off the count, so the preview
+    underreports vs the real `_streaming_celery_clear` path —
+    which only reserves a survivor in queues that have a match.
+    """
+
+    queue_with = "bundle_analysis"
+    queue_empty = "ingest"
+    task = "app.tasks.bundle_analysis.BundleAnalysisProcessor"
+    repoid = 21222368
+    commitid = "0832c11a1f43c5e2a1b9f8a3e5d1c2b7e9a8d3f0"
+
+    n = 100
+    pipe = patched_broker.pipeline(transaction=False)
+    for _ in range(n):
+        pipe.rpush(
+            queue_with,
+            _build_envelope(task=task, kwargs={"repoid": repoid, "commitid": commitid}),
+        )
+    pipe.execute()
+    # `queue_empty` is intentionally never seeded so the streaming
+    # counter returns total_found=0 for that queue.
+    user = SimpleNamespace(id=1, pk=1)
+
+    targets = [
+        CeleryBrokerQueue(
+            queue_name=queue_with,
+            task_name=task,
+            repoid=repoid,
+            commitid=commitid,
+            index_in_queue=0,
+        ),
+        CeleryBrokerQueue(
+            queue_name=queue_empty,
+            task_name=task,
+            repoid=repoid,
+            commitid=commitid,
+            index_in_queue=0,
+        ),
+    ]
+
+    result = celery_broker_clear(
+        targets,
+        user=user,
+        dry_run=True,
+        keep_one=True,
+    )
+    # n matches in queue_with, 0 in queue_empty. keep_one=True
+    # reserves exactly one survivor (in queue_with), so the
+    # preview must report `n - 1`. Pre-fix this returned `n - 2`
+    # because the subtraction was per-queue regardless of whether
+    # the queue had any matches.
+    assert result.dry_run is True
+    assert result.count == n - 1
+    assert patched_broker.llen(queue_with) == n
+    assert patched_broker.llen(queue_empty) == 0

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -33,6 +33,7 @@ from redis_admin.families import (
     _ta_flake_pattern,
     _uploads_pattern,
     find_family,
+    iter_families,
     iter_keys,
 )
 
@@ -638,3 +639,48 @@ def test_iter_keys_finds_ta_notifier_fence_filtered_by_repoid_and_commit(
     }
 
     assert rows == {"ta_notifier_fence:42_abcdef"}
+
+
+# ---- iter_families ---------------------------------------------------------
+
+
+def test_iter_families_unfiltered_matches_full_registry():
+    """Without a category or exclude filter `iter_families` must yield
+    every registered family in order — it's the single entry point
+    the admin filter UIs call, so a drift here would silently drop
+    families from every list filter at once.
+    """
+
+    assert tuple(iter_families()) == FAMILIES
+
+
+def test_iter_families_narrows_by_category():
+    """`category='queue'` / `category='lock'` partitions the registry
+    so the admin UI can render the right subset per surface.
+    """
+
+    queue_families = {f.name for f in iter_families(category="queue")}
+    lock_families = {f.name for f in iter_families(category="lock")}
+
+    assert "uploads" in queue_families
+    assert "celery_broker" in queue_families
+    assert queue_families.isdisjoint(lock_families)
+    assert "coordination_lock" in lock_families
+
+
+def test_iter_families_drops_excluded_names():
+    """`exclude` lets the queue filter hide families served by a
+    dedicated admin (today: `celery_broker`) so operators don't see
+    a clickable option that returns zero rows on the generic queue
+    changelist.
+    """
+
+    queue_families = {
+        f.name for f in iter_families(category="queue", exclude=["celery_broker"])
+    }
+
+    assert "celery_broker" not in queue_families
+    # Sanity: unrelated queue families are still present so we
+    # didn't accidentally drop the whole category.
+    assert "uploads" in queue_families
+    assert "ta_flake_key" in queue_families


### PR DESCRIPTION
## Summary

The single `REDIS_ADMIN_MAX_ITEMS_PER_KEY = 20_000` knob was bounding three call sites with very different cost profiles:
- The **changelist row materialisation** keeps full parsed envelopes in the per-request `_result_cache` — RAM-heavy.
- The **frequency chart aggregator** walks the queue in chunks and only retains `(task_name, repoid, commitid)` counts — CPU-light.
- The **streaming clear** needs to drain the entire matching set, not a sample.
- The **clear-by-filter preview** needs to count the entire matching set so the operator sees the same number both before and after submitting.

Tuning one number forced a bad trade: lowering it for page-load made the chart shallow; raising it for the chart bloated the changelist; and either way the clear inherited the wrong behaviour. After PR #897 lowered the cap to 20_000 the clear silently capped at that window too, so on a saturated queue the per-pass plateau check fired before the clear had drained.

Splits + drops the cap on the right things, then polishes the chart loading UX:

| Setting / call site | Default | Used by |
| --- | ---: | --- |
| `REDIS_ADMIN_CELERY_BROKER_DISPLAY_LIMIT` | `2_000` | per-message rows on the changelist drill-down |
| `REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT` | `100_000` | frequency chart aggregator only |
| streaming clear | *unbounded* | walks `LLEN(queue)` so "Clear all" always fully drains |
| dry-run preview (`celery_broker_clear`) | *unbounded* | runs the streaming counter so `result.count` matches what the actual clear will do |
| clear-by-filter preview page | *unbounded* | uses the new `streaming_celery_count` helper so `match_count` agrees with `result.count` |

`REDIS_ADMIN_MAX_ITEMS_PER_KEY` keeps its existing 20_000 default and stays wired to the unrelated SET/HASH browsing path in `RedisItemQuerySet`.

Folds in #904 (clear-cap regression) and #905 (visible loader card UX). Both source PRs left OPEN as historical references.

## Test plan

- [x] Updated chart / clear / cap fakeredis tests for the renamed/dropped settings.
- [x] Regression: unbounded streaming clear drains a 41k-match queue to `LLEN == 1` in a single pass.
- [x] Regression: dry-run preview returns the full-queue count (5k matches → `result.count == 5_000`, `keep_one=True → 4_999`, `LLEN` intact).
- [x] Regression: clear-by-filter preview page shows `Matched: N message(s)` for a queue with N > `CELERY_BROKER_DISPLAY_LIMIT`.
- [x] Drill-down rendering test asserts the loader card markup, CSS link, and `role="status"` are present.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Manually verify on api-admin.codecov.io after deploy: chart sample size is back to ~100k AND the clear-by-filter preview page agrees with the post-clear `LLEN` delta AND clicking "Clear all" drains the queue AND the loader card is visible while the chart fragment fetches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes celery broker admin/clear behavior and limits, including unbounded queue-draining logic; mistakes could over/under-delete messages or slow deep-queue operations.
> 
> **Overview**
> Splits the previous single `MAX_ITEMS_PER_KEY` cap into two celery-specific settings: `CELERY_BROKER_DISPLAY_LIMIT` (bounds per-message drill-down materialisation/cache) and `CELERY_BROKER_SCAN_LIMIT` (bounds the frequency-chart sampler), and updates docs/UI text accordingly.
> 
> Fixes celery clear/preview semantics on deep queues by making the streaming clear walk the full `LLEN(queue)` (no artificial cap), adding wildcard-aware filter matching, and ensuring clear-by-filter preview + dry-run counts come from a new streaming counter (`streaming_celery_count`) rather than the display-limited queryset.
> 
> Polishes the drill-down chart loading UX with a CSP-safe external loader stylesheet + richer loading card, tweaks admin filtering (hide `celery_broker` from the generic queue family filter), adjusts summary-mode default ordering, and adds focused regression tests for deep-queue draining and filter/preview correctness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f86eee7c8350e5634ad952e3e823119626d3d19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->