### PR TITLE
feat(redis_admin): chunked celery broker clear with progress bar + wildcard sentinel fix

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -315,14 +315,9 @@ spawns a background daemon thread, then 302s the operator to a
 progress page that polls a status JSON view every ~1s.
 
 **Why this exists.** A 200–500k-deep queue clear can run for
-many minutes, well past common upstream timeouts. The api pod's
-own gunicorn `--timeout` defaults to 600s
-(`apps/codecov-api/api.sh:118`, configurable via
-`GUNICORN_TIMEOUT`), but the user-observed 120s ceiling
-originates from an upstream proxy (Cloudflare's free-tier or
-the GCP HTTPS LB backend timeout) outside this repo. Decoupling
-the clear's wall-clock from the HTTP request lifetime means the
-operator-facing surface is sub-second regardless of queue depth.
+many minutes. Decoupling the clear's wall-clock from the HTTP
+request lifetime means the operator-facing surface is sub-second
+regardless of queue depth.
 
 **Job state hash.** Each chunked job lives in the
 **cache** Redis (`_conn.get_connection(kind="default")`) under
@@ -396,68 +391,6 @@ JSON has `mode` ∈ `chunked-dry-run` /
 synchronous `dry-run` / `all-from-bucket` / `all-but-first` so
 queries can distinguish the two paths) and an `extra` payload
 with `job_id`, `passes_run`, `total_drifted`, `cancelled`.
-
-### Request timeouts — short-term and long-term knobs
-
-The user-observed 120s timeout on big-queue clears + chart
-loads has both a known short-term operational lever and a
-long-term durable fix.
-
-**Short-term (operational).** The api pod's gunicorn
-`--timeout` is set in `apps/codecov-api/api.sh:118`:
-
-```
---timeout "${GUNICORN_TIMEOUT:-600}"
-```
-
-The default is **600s**, configurable via the `GUNICORN_TIMEOUT`
-env var. **Do not change this in this PR** — that's a deploy-
-tuning decision; document only. Memory + concurrency
-implications: a longer worker timeout means a stuck request
-holds its worker slot for that long, so raising it without
-also bumping `GUNICORN_WORKERS` reduces the pod's effective
-concurrency proportionally.
-
-The user-reported 120s ceiling does **not** originate from
-this in-repo file. The most likely sources, in order of
-likelihood, are external to this repo and need to be
-investigated by an infra-side operator:
-
-1. **Cloudflare's per-request timeout.** Free-tier is 100s,
-   paid is configurable up to several minutes (see
-   Cloudflare's "request_timeout" setting and the
-   `proxy_read_timeout`-equivalent for orange-cloud
-   proxying).
-2. **GCP HTTPS LB backend timeout.** The default is 30s
-   on a Backend Service, often raised to 120s. Lives in
-   the cluster's Terraform / Helm chart.
-3. **Kubernetes ingress / `terminationGracePeriodSeconds`**
-   — usually 30s by default; less likely to be the source
-   of a 120s ceiling but worth checking for any
-   `nginx.ingress.kubernetes.io/proxy-read-timeout` or
-   similar annotations on the api Service.
-
-The Helm chart and the GCP infra config are NOT in
-`codecov/umbrella` — they live in the deploy repo. Search
-there for `GUNICORN_TIMEOUT`, `proxy_read_timeout`,
-`timeoutSeconds`, and the api Backend Service config.
-
-**Long-term (durable, this PR's contribution).** The chunked
-clear job decouples the clear's wall-clock from the HTTP
-request lifetime entirely. The POST that starts the clear
-spawns a thread + 302s in well under a second; each subsequent
-poll request reads a single hash from the cache redis (sub-
-millisecond on real Redis). No HTTP request ever sits on the
-actual clearing work, so no upstream timeout — Cloudflare,
-LB, gunicorn, ingress — can interrupt it.
-
-**Gap.** The changelist load itself (the page, not the chart)
-can still be slow on big queues because a `count()` /
-`LLEN` per visible queue runs synchronously in the request.
-PR #902 already moved the chart fragment to a lazy-loaded
-`{% static %}` JS path — the analogous follow-up would be to
-async-load the changelist's depth column the same way. **Not
-in scope for this PR**; see follow-up tracking.
 
 ### Per-message clear (LSET-tombstone)
 

--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -40,7 +40,10 @@ accidentally surfaces them under `RedisQueue`.
 | `/admin/redis_admin/redisqueueitem/<token>/change/` | Inspect a single item |
 | `/admin/redis_admin/celerybrokerqueue/` | **Celery summary** — one row per known celery_broker queue with current `LLEN` and a drill-in link |
 | `/admin/redis_admin/celerybrokerqueue/?queue_name__exact=<queue>` | **Celery drill-down** — messages inside a celery broker queue with structured task / repoid / commitid columns, a `(repoid, commitid)` frequency chart, and per-message clear |
-| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/` | Preview + clear messages in `<queue>` matching a `(task_name?, repoid?, commitid?)` filter (POST-only, superuser-only). Wired up by the frequency chart's per-row "Clear queue" button; the preview page exposes three explicit actions (dry-run, clear all but first, clear all). |
+| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/` | Preview + clear messages in `<queue>` matching a `(task_name?, repoid?, commitid?)` filter (POST-only, superuser-only). Wired up by the frequency chart's per-row "Clear queue" button; the preview page exposes three explicit actions (dry-run, clear all but first, clear all). Destructive actions spawn a chunked background job and 302 to the progress page. |
+| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/` | Progress page for a chunked clear job (HTML, superuser-only). Polls the status JSON view every ~1s; renders a `<progress>` bar, matched / total / drift / pass counters, and a Cancel button. |
+| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/status/` | JSON snapshot of a chunked clear job (superuser-only); 404s on unknown / expired ids. |
+| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/cancel/` | POST-only cancel endpoint (superuser-only); flags `cancel_requested=1` and returns 202 with the latest snapshot. Cancel lands at the next chunk boundary. |
 | `/admin/redis_admin/redislock/` | Browse Redis locks (read-only) |
 | `/admin/redis_admin/redisqueue/clear-by-scope/` | M6 — cross-family clear-by-scope (superuser only) |
 
@@ -303,6 +306,158 @@ and the audit log captures the operation under
 For backward compatibility, the older `action=confirm` form
 shape (paired with `mode=all` / `mode=keep_one`) is aliased to
 the new actions so stale tabs and scripts keep working.
+
+### Chunked clear jobs (background-thread variant)
+
+The destructive actions on `clear-by-filter/` no longer block the
+HTTP request: a confirmed `clear_all` / `clear_keep_one` submit
+spawns a background daemon thread, then 302s the operator to a
+progress page that polls a status JSON view every ~1s.
+
+**Why this exists.** A 200–500k-deep queue clear can run for
+many minutes, well past common upstream timeouts. The api pod's
+own gunicorn `--timeout` defaults to 600s
+(`apps/codecov-api/api.sh:118`, configurable via
+`GUNICORN_TIMEOUT`), but the user-observed 120s ceiling
+originates from an upstream proxy (Cloudflare's free-tier or
+the GCP HTTPS LB backend timeout) outside this repo. Decoupling
+the clear's wall-clock from the HTTP request lifetime means the
+operator-facing surface is sub-second regardless of queue depth.
+
+**Job state hash.** Each chunked job lives in the
+**cache** Redis (`_conn.get_connection(kind="default")`) under
+`redis_admin:celery_clear_job:<uuid>`. Keeping it off the broker
+Redis means a clear that drains the broker can't accidentally
+evict its own progress hash. Fields:
+
+| Field | Purpose |
+|---|---|
+| `status` | `pending` / `running` / `completed` / `cancelled` / `failed` |
+| `queue` | queue name |
+| `filter_task`, `filter_repoid`, `filter_commitid` | operator filter (empty string = unconstrained) |
+| `dry_run`, `keep_one` | `0` / `1` |
+| `user_id` | initiator (audit-log attribution) |
+| `started_at`, `updated_at`, `completed_at` | ISO-8601 UTC |
+| `total_estimated` | `LLEN(queue)` snapshot at submission |
+| `processed`, `matched`, `drifted` | running counters, HINCRBY-ed per chunk |
+| `passes_run` | repeat-until-stable pass index |
+| `error` | empty unless `status=failed` |
+| `cancel_requested` | `0` / `1`; polled by the worker between chunks |
+
+Hashes get a 24h TTL on creation so abandoned jobs auto-expire —
+gunicorn reload, container restart, or operator-closed-the-tab
+won't accumulate zombie state in the cache redis.
+
+**Cancel semantics.** The Cancel button POSTs to
+`…/clear-by-filter/job/<uuid>/cancel/`, which sets
+`cancel_requested=1`. The worker thread polls this between
+LRANGE chunks. On the next chunk boundary (default 1000
+messages → sub-second on real Redis) it `LREM`s any in-flight
+tombstones for the current pass, sets `status=cancelled`, and
+exits. **Cancel only ever lands at chunk boundaries**, never
+mid-`LSET`, so a tombstone we already wrote is always paired
+with the matching `LREM` — the queue is left in a clean state,
+not a partial graveyard.
+
+**Restart safety.** The clear runs on a daemon thread on the
+api pod's gunicorn worker. If the worker is killed mid-job
+(rolling deploy, OOM, `terminationGracePeriodSeconds` exceeded),
+the in-flight tombstones (`__redis_admin_celery_tombstone__:<uuid>`)
+stay parked in the queue. Operator can either re-run the clear
+(the new pass walks the full queue and skips them — they're
+recognised as garbage at task-decode time and at LRANGE-snapshot
+time both) or `LREM 0 __redis_admin_celery_tombstone__:*` by
+hand. The job hash flips to `failed` only on raised exceptions,
+not on worker death — a killed worker leaves the hash in
+`running` until the 24h TTL elapses.
+
+**Why threading and not Celery.** The queue we're clearing is
+the Celery broker. Submitting a control task to a broker we're
+emptying creates a circular dependency (the control task may
+sit behind the messages we're about to tombstone), and the
+operator pod isn't part of the worker fleet so even if we
+queued the task it wouldn't get picked up. Threading keeps
+everything inside the api pod's process; the trade-off is the
+restart-safety caveat above.
+
+**URLs:**
+
+| Path | Purpose |
+|---|---|
+| `…/clear-by-filter/job/<uuid>/` | Progress page (HTML, polls status JSON) |
+| `…/clear-by-filter/job/<uuid>/status/` | JSON snapshot of the job hash (200 / 404) |
+| `…/clear-by-filter/job/<uuid>/cancel/` | POST-only; flags `cancel_requested=1` (202) |
+
+**Audit log.** A `LogEntry` row is written **at job
+completion** (not job-start), so a clear that's still running
+isn't yet attributed in the audit feed. The `change_message`
+JSON has `mode` ∈ `chunked-dry-run` /
+`chunked-all-from-bucket` / `chunked-all-but-first` (vs the
+synchronous `dry-run` / `all-from-bucket` / `all-but-first` so
+queries can distinguish the two paths) and an `extra` payload
+with `job_id`, `passes_run`, `total_drifted`, `cancelled`.
+
+### Request timeouts — short-term and long-term knobs
+
+The user-observed 120s timeout on big-queue clears + chart
+loads has both a known short-term operational lever and a
+long-term durable fix.
+
+**Short-term (operational).** The api pod's gunicorn
+`--timeout` is set in `apps/codecov-api/api.sh:118`:
+
+```
+--timeout "${GUNICORN_TIMEOUT:-600}"
+```
+
+The default is **600s**, configurable via the `GUNICORN_TIMEOUT`
+env var. **Do not change this in this PR** — that's a deploy-
+tuning decision; document only. Memory + concurrency
+implications: a longer worker timeout means a stuck request
+holds its worker slot for that long, so raising it without
+also bumping `GUNICORN_WORKERS` reduces the pod's effective
+concurrency proportionally.
+
+The user-reported 120s ceiling does **not** originate from
+this in-repo file. The most likely sources, in order of
+likelihood, are external to this repo and need to be
+investigated by an infra-side operator:
+
+1. **Cloudflare's per-request timeout.** Free-tier is 100s,
+   paid is configurable up to several minutes (see
+   Cloudflare's "request_timeout" setting and the
+   `proxy_read_timeout`-equivalent for orange-cloud
+   proxying).
+2. **GCP HTTPS LB backend timeout.** The default is 30s
+   on a Backend Service, often raised to 120s. Lives in
+   the cluster's Terraform / Helm chart.
+3. **Kubernetes ingress / `terminationGracePeriodSeconds`**
+   — usually 30s by default; less likely to be the source
+   of a 120s ceiling but worth checking for any
+   `nginx.ingress.kubernetes.io/proxy-read-timeout` or
+   similar annotations on the api Service.
+
+The Helm chart and the GCP infra config are NOT in
+`codecov/umbrella` — they live in the deploy repo. Search
+there for `GUNICORN_TIMEOUT`, `proxy_read_timeout`,
+`timeoutSeconds`, and the api Backend Service config.
+
+**Long-term (durable, this PR's contribution).** The chunked
+clear job decouples the clear's wall-clock from the HTTP
+request lifetime entirely. The POST that starts the clear
+spawns a thread + 302s in well under a second; each subsequent
+poll request reads a single hash from the cache redis (sub-
+millisecond on real Redis). No HTTP request ever sits on the
+actual clearing work, so no upstream timeout — Cloudflare,
+LB, gunicorn, ingress — can interrupt it.
+
+**Gap.** The changelist load itself (the page, not the chart)
+can still be slow on big queues because a `count()` /
+`LLEN` per visible queue runs synchronously in the request.
+PR #902 already moved the chart fragment to a lazy-loaded
+`{% static %}` JS path — the analogous follow-up would be to
+async-load the changelist's depth column the same way. **Not
+in scope for this PR**; see follow-up tracking.
 
 ### Per-message clear (LSET-tombstone)
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -25,7 +25,13 @@ from urllib.parse import urlencode
 from django.contrib import admin, messages
 from django.contrib.admin.utils import quote, unquote
 from django.core.exceptions import PermissionDenied
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseNotAllowed,
+    HttpResponseRedirect,
+    JsonResponse,
+)
 from django.shortcuts import render
 from django.urls import NoReverseMatch, path, reverse
 from django.utils.html import format_html, format_html_join
@@ -47,9 +53,13 @@ from .queryset import (
     resolve_payload_preview,
 )
 from .services import (
+    _CELERY_CLEAR_JOB_TERMINAL_STATES,
     _FILTER_ANY,
     celery_broker_clear,
+    get_celery_broker_clear_job,
     redis_delete,
+    request_cancel_celery_broker_clear_job,
+    start_celery_broker_clear_job,
     streaming_celery_count,
 )
 
@@ -1764,6 +1774,27 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             self.admin_site.admin_view(self.clear_by_filter_view),
             name=f"{opts.app_label}_{opts.model_name}_clear_by_filter",
         )
+        # Three new URLs for the chunked-clear background job: a
+        # progress page (HTML), a status JSON endpoint that the
+        # progress page polls, and a cancel POST endpoint. All three
+        # are routed under `clear-by-filter/job/<uuid:job_id>/...`
+        # so they share the per-instance superuser gate and live
+        # alongside the existing preview page in the URL tree.
+        clear_progress_url = path(
+            "clear-by-filter/job/<uuid:job_id>/",
+            self.admin_site.admin_view(self.clear_by_filter_progress_view),
+            name=(f"{opts.app_label}_{opts.model_name}_clear_by_filter_progress"),
+        )
+        clear_status_url = path(
+            "clear-by-filter/job/<uuid:job_id>/status/",
+            self.admin_site.admin_view(self.clear_by_filter_status_view),
+            name=(f"{opts.app_label}_{opts.model_name}_clear_by_filter_status"),
+        )
+        clear_cancel_url = path(
+            "clear-by-filter/job/<uuid:job_id>/cancel/",
+            self.admin_site.admin_view(self.clear_by_filter_cancel_view),
+            name=(f"{opts.app_label}_{opts.model_name}_clear_by_filter_cancel"),
+        )
         chart_fragment_url = path(
             "<str:queue_name>/chart-fragment/",
             self.admin_site.admin_view(self.chart_fragment_view),
@@ -1771,7 +1802,14 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         )
         # Inserted before the catch-all `<path:object_id>/` patterns so
         # custom routes don't get swallowed as object_ids.
-        return [clear_url, chart_fragment_url, *urls]
+        return [
+            clear_url,
+            clear_progress_url,
+            clear_status_url,
+            clear_cancel_url,
+            chart_fragment_url,
+            *urls,
+        ]
 
     def clear_by_filter_view(self, request: HttpRequest) -> HttpResponse:
         """Targeted clear by `(queue_name, task_name?, repoid?, commitid?)`.
@@ -1996,10 +2034,21 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             else:
                 dry_run = action == "dry_run"
                 keep_one = action == "clear_keep_one"
-                result = celery_broker_clear(
-                    targets, user=request.user, dry_run=dry_run, keep_one=keep_one
-                )
+                # Dry-run keeps the synchronous shape: the request
+                # already does the streaming-count walk above, so
+                # the dry-run service call is fast (no LSET/LREM)
+                # and the operator gets the audit-log entry +
+                # re-rendered preview in one shot. The destructive
+                # actions, by contrast, fan out to a background
+                # thread so a 500k-deep queue clear never sits on
+                # the gunicorn worker.
                 if dry_run:
+                    result = celery_broker_clear(
+                        targets,
+                        user=request.user,
+                        dry_run=True,
+                        keep_one=keep_one,
+                    )
                     messages.info(
                         request,
                         f"Dry-run: would clear {result.count} of {match_count} "
@@ -2007,19 +2056,21 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
                         f"entry written; queue untouched).",
                     )
                 else:
-                    if action == "clear_keep_one":
-                        messages.success(
-                            request,
-                            f"Cleared {result.count} of {match_count} matching "
-                            f"message(s) from {queue_name} "
-                            f"(kept index={kept_index}).",
-                        )
-                    else:
-                        messages.success(
-                            request,
-                            f"Cleared {result.count} message(s) from {queue_name}",
-                        )
-                    return HttpResponseRedirect(changelist_url)
+                    job_id = start_celery_broker_clear_job(
+                        queue_name,
+                        user=request.user,
+                        task_name=task_name or None,
+                        repoid=repoid,
+                        commitid=commitid or None,
+                        keep_one=keep_one,
+                        dry_run=False,
+                    )
+                    progress_url = reverse(
+                        f"admin:{opts.app_label}_{opts.model_name}"
+                        "_clear_by_filter_progress",
+                        kwargs={"job_id": job_id},
+                    )
+                    return HttpResponseRedirect(progress_url)
 
         ctx = {
             **self.admin_site.each_context(request),
@@ -2039,6 +2090,223 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         }
         return render(
             request, "admin/redis_admin/celerybrokerqueue/clear_by_filter.html", ctx
+        )
+
+    # ---- Chunked-clear background-job views ------------------------------
+    #
+    # Three superuser-only views back the chunked clear's progress page:
+    #
+    # * `clear_by_filter_progress_view` — renders the HTML page with an
+    #   initial server-side snapshot, a `<progress>` bar, status pill,
+    #   matched/total counters, and a Cancel button. Loads
+    #   `celery_clear_progress.{js,css}` from `{% static %}` so the page
+    #   stays CSP-compliant (the production admin only allows
+    #   `'self'` + a single fixed sha256 hash for inline scripts).
+    # * `clear_by_filter_status_view` — JSON endpoint polled every ~1s
+    #   by the JS for progress updates. Pinned shape (see test
+    #   `test_clear_job_status_view_returns_json_for_running_job`):
+    #   `{job_id, status, processed, matched, drifted, ...}`.
+    # * `clear_by_filter_cancel_view` — POST-only. Sets
+    #   `cancel_requested=1` on the job hash; the worker thread polls
+    #   it at the next chunk boundary, drains in-flight tombstones,
+    #   and exits with `status=cancelled`.
+    #
+    # All three reuse the existing per-instance `is_superuser` gate
+    # (`clear_by_filter_view` already requires it; the same staff /
+    # superuser guard the rest of `CeleryBrokerQueueAdmin` uses).
+
+    def _job_progress_context(
+        self, *, job_id: str, job: dict[str, str]
+    ) -> dict[str, Any]:
+        """Shape the job hash + URL set for the progress template.
+
+        Cast numeric fields to int so the template can do arithmetic
+        without a `|add:0` dance. Empty strings remain empty so the
+        template's `{% if commitid %}` checks behave as expected.
+        Resolves both the status JSON URL and the cancel URL up
+        front so the template (and the JS data attributes) doesn't
+        have to know URL names.
+        """
+
+        def _int(field: str, default: int = 0) -> int:
+            try:
+                return int(job.get(field) or default)
+            except (TypeError, ValueError):
+                return default
+
+        opts = self.model._meta
+        status_url = reverse(
+            f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_status",
+            kwargs={"job_id": job_id},
+        )
+        cancel_url = reverse(
+            f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_cancel",
+            kwargs={"job_id": job_id},
+        )
+        changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+        queue_name = job.get("queue", "")
+        if queue_name:
+            changelist_url = (
+                f"{changelist_url}?{urlencode({'queue_name__exact': queue_name})}"
+            )
+
+        status = job.get("status", "pending")
+        return {
+            "job_id": job_id,
+            "job": job,
+            "status": status,
+            "is_terminal": status in _CELERY_CLEAR_JOB_TERMINAL_STATES,
+            "queue_name": queue_name,
+            "filter_task": job.get("filter_task", ""),
+            "filter_repoid": job.get("filter_repoid", ""),
+            "filter_commitid": job.get("filter_commitid", ""),
+            "dry_run": job.get("dry_run") == "1",
+            "keep_one": job.get("keep_one") == "1",
+            "started_at": job.get("started_at", ""),
+            "updated_at": job.get("updated_at", ""),
+            "completed_at": job.get("completed_at", ""),
+            "total_estimated": _int("total_estimated"),
+            "processed": _int("processed"),
+            "matched": _int("matched"),
+            "drifted": _int("drifted"),
+            "passes_run": _int("passes_run"),
+            "error": job.get("error", ""),
+            "cancel_requested": job.get("cancel_requested") == "1",
+            "status_url": status_url,
+            "cancel_url": cancel_url,
+            "changelist_url": changelist_url,
+        }
+
+    def clear_by_filter_progress_view(
+        self, request: HttpRequest, job_id
+    ) -> HttpResponse:
+        """Render the progress page for a chunked clear job.
+
+        The Django URL converter passes `job_id` as a `uuid.UUID`
+        because the route uses `<uuid:job_id>`. We coerce to its
+        hex form so it matches `start_celery_broker_clear_job`'s
+        `uuid.uuid4().hex` storage key. Unknown / expired ids land
+        on the changelist with an error message instead of a bare
+        404 — the operator just clicked a stale link / refreshed
+        past the 24h TTL, and the changelist is the most useful
+        next step.
+        """
+
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-filter is restricted to superusers"
+            )
+
+        opts = self.model._meta
+        changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+        # Django's `<uuid:>` converter hands us a `uuid.UUID`; cast
+        # to canonical hyphenated string so the storage key matches
+        # what `start_celery_broker_clear_job` wrote.
+        job_id_str = str(job_id)
+        job = get_celery_broker_clear_job(job_id_str)
+        if job is None:
+            messages.error(
+                request,
+                f"Clear job {job_id_str} not found (may have expired or "
+                f"been submitted on a different deployment).",
+            )
+            return HttpResponseRedirect(changelist_url)
+
+        progress_ctx = self._job_progress_context(job_id=job_id_str, job=job)
+        ctx = {
+            **self.admin_site.each_context(request),
+            "title": f"Clearing {progress_ctx['queue_name']} (job {job_id_str[:8]})",
+            "opts": opts,
+            **progress_ctx,
+        }
+        return render(
+            request,
+            "admin/redis_admin/celerybrokerqueue/clear_by_filter_progress.html",
+            ctx,
+        )
+
+    def clear_by_filter_status_view(self, request: HttpRequest, job_id) -> HttpResponse:
+        """JSON endpoint for the progress page's polling loop.
+
+        Returns a stable shape regardless of state. Pinned by
+        `test_clear_job_status_view_returns_json_for_running_job` so
+        the JS poll handler can rely on the field set even as the
+        underlying job hash grows / shrinks across deploys.
+        """
+
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-filter is restricted to superusers"
+            )
+
+        job_id_str = str(job_id)
+        job = get_celery_broker_clear_job(job_id_str)
+        if job is None:
+            return JsonResponse(
+                {"error": "not_found", "job_id": job_id_str}, status=404
+            )
+
+        progress_ctx = self._job_progress_context(job_id=job_id_str, job=job)
+        # Trim the rendered context for the JSON wire shape: drop
+        # the `job` raw blob (the polling client only needs decoded
+        # fields) and the URLs (the page already has them).
+        return JsonResponse(
+            {
+                "job_id": job_id_str,
+                "status": progress_ctx["status"],
+                "is_terminal": progress_ctx["is_terminal"],
+                "queue_name": progress_ctx["queue_name"],
+                "filter_task": progress_ctx["filter_task"],
+                "filter_repoid": progress_ctx["filter_repoid"],
+                "filter_commitid": progress_ctx["filter_commitid"],
+                "dry_run": progress_ctx["dry_run"],
+                "keep_one": progress_ctx["keep_one"],
+                "started_at": progress_ctx["started_at"],
+                "updated_at": progress_ctx["updated_at"],
+                "completed_at": progress_ctx["completed_at"],
+                "total_estimated": progress_ctx["total_estimated"],
+                "processed": progress_ctx["processed"],
+                "matched": progress_ctx["matched"],
+                "drifted": progress_ctx["drifted"],
+                "passes_run": progress_ctx["passes_run"],
+                "error": progress_ctx["error"],
+                "cancel_requested": progress_ctx["cancel_requested"],
+            }
+        )
+
+    def clear_by_filter_cancel_view(self, request: HttpRequest, job_id) -> HttpResponse:
+        """POST-only endpoint that flags the job for cancellation.
+
+        Returns 202 (request accepted; effect lands at the next
+        chunk boundary in the worker thread) with the latest job
+        snapshot so the UI can update without waiting for the next
+        poll cycle. Idempotent: re-cancelling a cancelled job is a
+        no-op.
+        """
+
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-filter is restricted to superusers"
+            )
+        if request.method != "POST":
+            return HttpResponseNotAllowed(["POST"])
+
+        job_id_str = str(job_id)
+        ok = request_cancel_celery_broker_clear_job(job_id_str)
+        if not ok:
+            return JsonResponse(
+                {"error": "not_found", "job_id": job_id_str}, status=404
+            )
+        # Re-fetch so the response carries `cancel_requested=1`
+        # without the client needing a follow-up poll.
+        job = get_celery_broker_clear_job(job_id_str) or {}
+        return JsonResponse(
+            {
+                "job_id": job_id_str,
+                "cancel_requested": job.get("cancel_requested") == "1",
+                "status": job.get("status", ""),
+            },
+            status=202,
         )
 
     def get_search_results(self, request, queryset, search_term):

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -54,7 +54,7 @@ from .queryset import (
 )
 from .services import (
     _CELERY_CLEAR_JOB_TERMINAL_STATES,
-    _FILTER_ANY,
+    _substitute_filter_any,
     celery_broker_clear,
     get_celery_broker_clear_job,
     redis_delete,
@@ -1981,13 +1981,16 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         # which the per-message paths legitimately rely on for
         # tasks like `sync_repos` whose envelope leaves repoid /
         # commitid as `None`.
+        task_any, repoid_any, commitid_any = _substitute_filter_any(
+            task_name, repoid, commitid
+        )
         filter_target = CeleryBrokerQueue(
             pk_token=f"{queue_name}#{kept_index if kept_index is not None else 'filter'}",
             queue_name=queue_name,
             index_in_queue=kept_index,
-            task_name=task_name if task_name else _FILTER_ANY,
-            repoid=repoid if repoid is not None else _FILTER_ANY,
-            commitid=commitid if commitid else _FILTER_ANY,
+            task_name=task_any,
+            repoid=repoid_any,
+            commitid=commitid_any,
         )
         matches = [filter_target]
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -47,6 +47,7 @@ from .queryset import (
     resolve_payload_preview,
 )
 from .services import (
+    _FILTER_ANY,
     celery_broker_clear,
     redis_delete,
     streaming_celery_count,
@@ -1935,13 +1936,20 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         # `clear_dry_run`) still pass real materialised rows — those
         # are intentionally index-driven, not filter-driven, so they
         # don't go through this code path.
+        # `_FILTER_ANY` (not `None`) for unset slots so the
+        # streaming match treats them as wildcards. `None` would
+        # require an exact-equality match against `meta.task is
+        # None` / `meta.repoid is None` / `meta.commitid is None`,
+        # which the per-message paths legitimately rely on for
+        # tasks like `sync_repos` whose envelope leaves repoid /
+        # commitid as `None`.
         filter_target = CeleryBrokerQueue(
             pk_token=f"{queue_name}#{kept_index if kept_index is not None else 'filter'}",
             queue_name=queue_name,
             index_in_queue=kept_index,
-            task_name=task_name or None,
-            repoid=repoid,
-            commitid=commitid or None,
+            task_name=task_name if task_name else _FILTER_ANY,
+            repoid=repoid if repoid is not None else _FILTER_ANY,
+            commitid=commitid if commitid else _FILTER_ANY,
         )
         matches = [filter_target]
 

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -21,10 +21,12 @@ single chokepoint for:
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import logging
+import threading
 import uuid
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -511,6 +513,32 @@ class _StreamingClearStats:
     total_found: int
     first_match_index: int | None
     passes_run: int
+    # Set by `_streaming_celery_clear` when a `progress_callback`
+    # returned `True` to abort. The chunked background-job worker
+    # uses this to flip the job hash's `status` to `"cancelled"`.
+    # Synchronous callers (`celery_broker_clear`) never pass a
+    # callback, so they always see `cancelled=False`.
+    cancelled: bool = False
+
+
+# Per-chunk progress payload handed to the optional
+# `progress_callback` in `_streaming_celery_clear`. Kept as a small
+# frozen dataclass (rather than a bare dict) so the callback signature
+# is self-documenting and stable across the in-flight chunked-clear
+# worker, future chunked callers, and any progress-snapshot test
+# fixtures.
+@dataclass(frozen=True)
+class _ChunkProgress:
+    pass_num: int  # 1-based pass index
+    chunk_index: int  # 0-based chunk index within the current pass
+    chunks_total: int  # number of chunks in the current pass
+    processed_delta: int  # messages walked in this chunk (LRANGE size)
+    matched_delta: int  # matches LSET-tombstoned in this chunk
+    drifted_delta: int  # LRANGE/LINDEX drifts skipped in this chunk
+    found_delta: int  # all matches observed in this chunk (incl. drift)
+    total_lset: int  # cumulative across all passes/chunks so far
+    total_drifted: int
+    total_found: int
 
 
 def _streaming_celery_clear(
@@ -521,6 +549,8 @@ def _streaming_celery_clear(
     *,
     keep_one: bool = False,
     dry_run: bool = False,
+    chunk_size: int | None = None,
+    progress_callback: Callable[[_ChunkProgress], bool] | None = None,
 ) -> _StreamingClearStats:
     """Streaming LRANGE+verify-before-LSET clear for `queue_name`.
 
@@ -557,11 +587,34 @@ def _streaming_celery_clear(
     tombstoned), `total_drifted` (slots skipped due to LRANGE/LINDEX
     drift), `total_found` (every match observed across passes —
     populated for the dry-run preview), and `passes_run`.
+
+    `chunk_size`, when set, overrides `_CELERY_CLEAR_CHUNK` for the
+    LRANGE step. The chunked background-job worker
+    (`start_celery_broker_clear_job`) drops it to
+    `_CELERY_CLEAR_CHUNK_JOB` (1k) so the progress bar updates and
+    cancel checks happen at sub-second granularity even on multi-
+    hundred-thousand-deep queues; synchronous callers leave it at
+    the default 10k for fewer LRANGE round-trips.
+
+    `progress_callback`, when supplied, is invoked at each chunk
+    boundary with a `_ChunkProgress` snapshot (per-chunk deltas and
+    running totals). Returning `True` from the callback aborts the
+    clear: the in-flight tombstones for the current pass are
+    LREMmed (so we leave a clean queue, not a partial graveyard) and
+    `_StreamingClearStats.cancelled` is set so the chunked worker
+    can flip the job hash to `"cancelled"`. Returning `False` (or
+    `None`) lets the loop continue. Cancel only ever lands at chunk
+    boundaries — never mid-LSET — so an LSET we already issued is
+    always paired with the corresponding LREM at the next pass-end
+    or cancel-drain.
     """
+
+    chunk = chunk_size if chunk_size is not None else _CELERY_CLEAR_CHUNK
 
     total_lset = 0
     total_drifted = 0
     total_found = 0
+    cancelled = False
     # Tracks the lowest-index match seen across all passes. Pass 1
     # walks the queue in ascending index order, so the first match
     # we see IS the lowest. Used by the clear-by-filter preview to
@@ -597,9 +650,19 @@ def _streaming_celery_clear(
         # `prev_lset == matches_lset` plateau exit then declared
         # convergence with most of the queue still in place.
         depth = int(redis.llen(queue_name) or 0)
-        for chunk_start in range(0, depth, _CELERY_CLEAR_CHUNK):
-            chunk_end = chunk_start + _CELERY_CLEAR_CHUNK - 1
+        # Track chunk index + count for the progress callback so the
+        # progress page can render "pass 2 / 3, chunk 47 / 213". The
+        # `chunks_total` is computed off the snapshot depth — fine
+        # for the progress UI; the loop itself walks the same range.
+        chunks_total = (depth + chunk - 1) // chunk if chunk > 0 else 0
+        chunk_index = 0
+        for chunk_start in range(0, depth, chunk):
+            chunk_end = chunk_start + chunk - 1
             raw_chunk = redis.lrange(queue_name, chunk_start, chunk_end)
+            chunk_processed = len(raw_chunk)
+            chunk_lset_before = matches_lset
+            chunk_drifted_before = matches_drifted
+            chunk_found_before = matches_found
             for offset, raw in enumerate(raw_chunk):
                 # Skip already-tombstoned slots from this or a
                 # concurrent clear.
@@ -639,6 +702,61 @@ def _streaming_celery_clear(
                     # Out-of-range: consumer drained this slot.
                     matches_drifted += 1
 
+            chunk_index += 1
+            if progress_callback is not None:
+                snapshot = _ChunkProgress(
+                    pass_num=passes_run,
+                    chunk_index=chunk_index,
+                    chunks_total=chunks_total,
+                    processed_delta=chunk_processed,
+                    matched_delta=matches_lset - chunk_lset_before,
+                    drifted_delta=matches_drifted - chunk_drifted_before,
+                    found_delta=matches_found - chunk_found_before,
+                    total_lset=total_lset + matches_lset,
+                    total_drifted=total_drifted + matches_drifted,
+                    total_found=total_found + matches_found,
+                )
+                # Defensive: a misbehaving callback that itself
+                # raises must not strand in-flight tombstones nor
+                # crash the streaming clear. Treat it the same as
+                # "no cancel requested" and keep going. The chunked-
+                # job worker traps and reports its own callback
+                # failures via the job hash's `error` field.
+                try:
+                    cancel_now = bool(progress_callback(snapshot))
+                except Exception:  # pragma: no cover - defensive
+                    log.exception(
+                        "redis_admin._streaming_celery_clear: "
+                        "progress_callback raised; treating as no-cancel"
+                    )
+                    cancel_now = False
+                if cancel_now:
+                    cancelled = True
+                    if not dry_run:
+                        # Drain in-flight tombstones for this pass
+                        # so the queue is left in a clean state
+                        # rather than a partial-graveyard. Mirrors
+                        # the pass-end LREM below.
+                        try:
+                            redis.lrem(queue_name, 0, tombstone)
+                        except Exception:  # pragma: no cover - best-effort
+                            log.exception(
+                                "redis_admin._streaming_celery_clear: "
+                                "cancel-drain LREM failed for %r",
+                                queue_name,
+                            )
+                    total_lset += matches_lset
+                    total_drifted += matches_drifted
+                    total_found += matches_found
+                    return _StreamingClearStats(
+                        total_lset=total_lset,
+                        total_drifted=total_drifted,
+                        total_found=total_found,
+                        first_match_index=first_match_index,
+                        passes_run=passes_run,
+                        cancelled=True,
+                    )
+
         if not dry_run:
             redis.lrem(queue_name, 0, tombstone)
 
@@ -675,6 +793,7 @@ def _streaming_celery_clear(
         total_found=total_found,
         first_match_index=first_match_index,
         passes_run=passes_run,
+        cancelled=cancelled,
     )
 
 
@@ -894,3 +1013,429 @@ def _celery_broker_clear(
     except AttributeError:  # pragma: no cover - older sdks
         pass
     return result
+
+
+# ---- Chunked celery_broker clear jobs (background-thread variant) ----------
+#
+# Synchronous `celery_broker_clear` is fine for changelist actions and
+# the dry-run preview because operators expect the action handler to
+# block; but the "Clear all" path on a 200-500k-deep queue can run
+# well past the gunicorn worker `--timeout` (api.sh's 600s default
+# is comfortably above that, but upstream proxies may impose lower
+# ceilings — Cloudflare's free-tier is 100s, GCP HTTPS LB defaults
+# to 30s). The chunked variant here decouples the clear's wall-clock
+# from the HTTP request lifetime: `start_celery_broker_clear_job`
+# returns a `job_id` immediately, the actual clear runs in a daemon
+# thread, and the operator polls a status hash for progress + drives
+# cancellation through it.
+#
+# Why threading and not Celery: the queue we're clearing is the
+# Celery broker. Submitting a control task to a broker we're
+# emptying creates a circular dependency (the control task may sit
+# behind the messages we're about to tombstone); the operator pod
+# would also need to be in the worker fleet to pick the task up.
+# Threading keeps the entire job within the api pod's process, so
+# the lifecycle is "as long as gunicorn keeps the worker alive".
+# That's a documented restart-safety trade-off (see README): a
+# gunicorn worker killed mid-job leaves any in-flight tombstones
+# (`__redis_admin_celery_tombstone__:<uuid>`) parked in the queue.
+# Operator can re-run the clear (the new pass skips them) or sweep
+# manually.
+
+# Job state lives in the cache redis (`_conn.get_connection(kind=
+# "default")`), NOT the broker — keeping the operator's job
+# bookkeeping off the same Redis instance we're clearing means a
+# clear that drains the broker doesn't accidentally also evict its
+# own progress hash.
+_CELERY_CLEAR_JOB_KEY_PREFIX: str = "redis_admin:celery_clear_job"
+
+# Smaller LRANGE chunk for the chunked worker — finer-grained
+# progress updates and sub-second cancel landings on multi-hundred-
+# thousand-deep queues. The synchronous path keeps
+# `_CELERY_CLEAR_CHUNK` (10k) so existing tests + call sites don't
+# change behaviour.
+_CELERY_CLEAR_CHUNK_JOB: int = 1_000
+
+# Auto-expire abandoned job hashes so the cache redis doesn't
+# accumulate zombie state (gunicorn reload, container restart,
+# operator closed the tab and forgot). 24h gives the on-call
+# enough headroom to come back the next morning and inspect a
+# completed run via the status URL before it disappears.
+_CELERY_CLEAR_JOB_TTL_SECONDS: int = 24 * 60 * 60
+
+
+# Terminal states that release the polling client.
+_CELERY_CLEAR_JOB_TERMINAL_STATES: frozenset[str] = frozenset(
+    {"completed", "cancelled", "failed"}
+)
+
+# Test-only handle to the worker thread per job_id so tests can
+# `.join(timeout=...)` deterministically. Cleared by the worker on
+# exit. NEVER rely on this in production paths; production polls
+# via the JSON status endpoint. Module-private with the leading
+# underscore convention so it's clearly off-limits to callers.
+_clear_job_threads: dict[str, threading.Thread] = {}
+# A lock around the dict because the worker thread itself mutates
+# it (clears its entry on exit) and production paths read it from
+# the gunicorn HTTP thread. The dict is small (one entry per
+# in-flight job per worker process) and contention is rare.
+_clear_job_threads_lock = threading.Lock()
+
+
+def _job_key(job_id: str) -> str:
+    return f"{_CELERY_CLEAR_JOB_KEY_PREFIX}:{job_id}"
+
+
+def _utc_now_iso() -> str:
+    """Timestamp for job hash fields. Uses timezone-aware UTC ISO 8601
+    (seconds resolution) so the progress page can render durations
+    and the audit trail has a stable cross-deploy ordering.
+    """
+    return _dt.datetime.now(_dt.UTC).isoformat(timespec="seconds")
+
+
+def _decode_job_hash(raw: dict[bytes | str, bytes | str]) -> dict[str, str]:
+    """Decode a fakeredis / redis-py HGETALL result into a flat
+    `{str: str}` mapping. Bytes get decoded as UTF-8; non-bytes pass
+    through unchanged. Used by both `get_celery_broker_clear_job`
+    and the worker's cancel-poll path so the JSON status view sees
+    a consistent shape regardless of which Redis client was used.
+    """
+    decoded: dict[str, str] = {}
+    for k, v in raw.items():
+        kk = k.decode() if isinstance(k, bytes) else str(k)
+        vv = v.decode() if isinstance(v, bytes) else str(v)
+        decoded[kk] = vv
+    return decoded
+
+
+def start_celery_broker_clear_job(
+    queue_name: str,
+    *,
+    user,
+    task_name: str | None = None,
+    repoid: int | None = None,
+    commitid: str | None = None,
+    keep_one: bool = False,
+    dry_run: bool = False,
+) -> str:
+    """Spawn a background `celery_broker_clear` job; return its `job_id`.
+
+    Initialises a hash at `redis_admin:celery_clear_job:<job_id>` in
+    the cache redis with the operator's filter shape, snapshots the
+    current `LLEN(queue)` as `total_estimated`, then launches a
+    daemon thread that walks the queue in
+    `_CELERY_CLEAR_CHUNK_JOB`-message chunks. The HTTP request that
+    triggers this returns immediately so the gunicorn worker never
+    sits on the actual clear; the operator polls a status JSON view
+    for progress and can request cancellation (lands at the next
+    chunk boundary).
+    """
+
+    # Hyphenated canonical form (8-4-4-4-12) so the value round-
+    # trips through Django's `<uuid:>` URL converter — which only
+    # accepts the canonical regex — without a separate normalising
+    # layer in the view.
+    job_id = str(uuid.uuid4())
+    cache = _conn.get_connection(kind="default")
+    # Snapshot LLEN once at submission so the progress bar has a
+    # stable denominator for the operator's benefit. The actual
+    # streaming clear re-LLENs on every pass (the queue may shift
+    # during a long clear), but the "estimated total" rendered in
+    # the UI is best-effort.
+    try:
+        broker = _conn.get_connection(kind="broker")
+        total_estimated = int(broker.llen(queue_name) or 0)
+    except Exception:  # pragma: no cover - broker outage path
+        total_estimated = 0
+
+    user_id = getattr(user, "id", None) or getattr(user, "pk", None) or 0
+    now = _utc_now_iso()
+    initial = {
+        "status": "pending",
+        "queue": queue_name,
+        "filter_task": task_name or "",
+        "filter_repoid": "" if repoid is None else str(repoid),
+        "filter_commitid": commitid or "",
+        "dry_run": "1" if dry_run else "0",
+        "keep_one": "1" if keep_one else "0",
+        "user_id": str(user_id),
+        "started_at": now,
+        "updated_at": now,
+        "completed_at": "",
+        "total_estimated": str(total_estimated),
+        "processed": "0",
+        "matched": "0",
+        "drifted": "0",
+        "passes_run": "0",
+        "error": "",
+        "cancel_requested": "0",
+    }
+    key = _job_key(job_id)
+    pipe = cache.pipeline(transaction=False)
+    pipe.hset(key, mapping=initial)
+    pipe.expire(key, _CELERY_CLEAR_JOB_TTL_SECONDS)
+    pipe.execute()
+
+    thread = threading.Thread(
+        target=_run_celery_broker_clear_job,
+        kwargs={
+            "job_id": job_id,
+            "queue_name": queue_name,
+            "task_name": task_name,
+            "repoid": repoid,
+            "commitid": commitid,
+            "keep_one": keep_one,
+            "dry_run": dry_run,
+            "user": user,
+        },
+        # Truncated UUID so threadnames are easy to grep in pstacks
+        # without becoming unreadable.
+        name=f"redis_admin.clear_job.{job_id[:8]}",
+        daemon=True,
+    )
+    with _clear_job_threads_lock:
+        _clear_job_threads[job_id] = thread
+    thread.start()
+    return job_id
+
+
+def get_celery_broker_clear_job(job_id: str) -> dict[str, str] | None:
+    """Read the job's state hash from cache redis. Returns `None`
+    when the hash is absent (unknown id, or the 24h TTL elapsed).
+    Values are returned as strings — the JSON status view casts
+    `processed` / `matched` / `total_estimated` to int before
+    serialising.
+    """
+
+    cache = _conn.get_connection(kind="default")
+    raw = cache.hgetall(_job_key(job_id))
+    if not raw:
+        return None
+    return _decode_job_hash(raw)
+
+
+def request_cancel_celery_broker_clear_job(job_id: str) -> bool:
+    """Set `cancel_requested=1` on the job hash. Returns `True`
+    when the hash existed (cancel will land at the next chunk
+    boundary), `False` when the id is unknown or the hash already
+    expired. Idempotent: re-cancelling a cancelled or terminal
+    job is a no-op.
+    """
+
+    cache = _conn.get_connection(kind="default")
+    key = _job_key(job_id)
+    if not cache.exists(key):
+        return False
+    cache.hset(
+        key,
+        mapping={
+            "cancel_requested": "1",
+            "updated_at": _utc_now_iso(),
+        },
+    )
+    return True
+
+
+def _run_celery_broker_clear_job(
+    *,
+    job_id: str,
+    queue_name: str,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+    keep_one: bool,
+    dry_run: bool,
+    user,
+) -> None:
+    """Daemon-thread worker for `start_celery_broker_clear_job`.
+
+    Owns the lifecycle of one chunked clear: it flips `status` to
+    `running`, calls `_streaming_celery_clear` with a callback that
+    updates the progress hash and polls `cancel_requested`, and on
+    completion writes a final `status` (`completed` / `cancelled` /
+    `failed`) plus the `_record_audit` row so the operator audit
+    trail captures chunked-mode clears alongside synchronous ones.
+
+    Exceptions are swallowed: a misbehaving streaming clear must
+    not crash the gunicorn worker. We log to Sentry via
+    `log.exception(...)` and surface the error string to the
+    operator through the job hash's `error` field instead.
+    """
+
+    try:
+        _run_celery_broker_clear_job_body(
+            job_id=job_id,
+            queue_name=queue_name,
+            task_name=task_name,
+            repoid=repoid,
+            commitid=commitid,
+            keep_one=keep_one,
+            dry_run=dry_run,
+            user=user,
+        )
+    finally:
+        # Drop the test-handle on exit so a re-run with the same
+        # job_id (operator clicked twice through some flake) starts
+        # cleanly. Best-effort: a failure to remove leaves a stale
+        # entry, which only matters for tests, not production.
+        with _clear_job_threads_lock:
+            _clear_job_threads.pop(job_id, None)
+
+
+def _run_celery_broker_clear_job_body(
+    *,
+    job_id: str,
+    queue_name: str,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+    keep_one: bool,
+    dry_run: bool,
+    user,
+) -> None:
+    """Inner body of the worker, separated from `_run_celery_broker_clear_job`
+    so the wrapper can own the test-handle cleanup in a `finally`
+    block. The split keeps the cleanup correct even if a future
+    refactor introduces a new early-return path inside the body.
+    """
+
+    cache = _conn.get_connection(kind="default")
+    key = _job_key(job_id)
+    cache.hset(key, "status", "running")
+    cache.hset(key, "updated_at", _utc_now_iso())
+
+    # Build the same `_FILTER_ANY`-substituted filter the
+    # synchronous `streaming_celery_count` uses, so an unset
+    # operator slot becomes a wildcard rather than an exact-`None`
+    # match (which would zero-match for any envelope whose field
+    # wasn't literally `None`).
+    filter_tuples = frozenset(
+        {
+            (
+                task_name if task_name else _FILTER_ANY,
+                repoid if repoid is not None else _FILTER_ANY,
+                commitid if commitid else _FILTER_ANY,
+            )
+        }
+    )
+
+    def _progress_callback(snapshot: _ChunkProgress) -> bool:
+        """Per-chunk hook: pump `processed/matched/drifted` into
+        the job hash via HINCRBY, refresh `passes_run` /
+        `updated_at`, then check `cancel_requested`. Returning
+        `True` aborts the loop in `_streaming_celery_clear` and
+        triggers an in-flight tombstone drain.
+        """
+
+        try:
+            pipe = cache.pipeline(transaction=False)
+            if snapshot.processed_delta:
+                pipe.hincrby(key, "processed", snapshot.processed_delta)
+            if snapshot.matched_delta:
+                pipe.hincrby(key, "matched", snapshot.matched_delta)
+            if snapshot.drifted_delta:
+                pipe.hincrby(key, "drifted", snapshot.drifted_delta)
+            pipe.hset(
+                key,
+                mapping={
+                    "passes_run": str(snapshot.pass_num),
+                    "updated_at": _utc_now_iso(),
+                },
+            )
+            pipe.execute()
+        except Exception:  # pragma: no cover - cache outage shouldn't kill clear
+            log.exception(
+                "redis_admin.clear_job(%s): failed to write progress",
+                job_id,
+            )
+        try:
+            cancel_raw = cache.hget(key, "cancel_requested")
+        except Exception:  # pragma: no cover - cache outage
+            return False
+        if cancel_raw is None:
+            return False
+        if isinstance(cancel_raw, bytes):
+            return cancel_raw == b"1"
+        return cancel_raw == "1"
+
+    error_str: str | None = None
+    stats: _StreamingClearStats | None = None
+    try:
+        broker = _conn.get_connection(kind="broker")
+        tombstone = _celery_clear_tombstone()
+        stats = _streaming_celery_clear(
+            broker,
+            queue_name,
+            filter_tuples,
+            tombstone,
+            keep_one=keep_one,
+            dry_run=dry_run,
+            chunk_size=_CELERY_CLEAR_CHUNK_JOB,
+            progress_callback=_progress_callback,
+        )
+    except Exception as exc:
+        log.exception("redis_admin.clear_job(%s): worker failed", job_id)
+        error_str = str(exc)
+
+    finalise: dict[str, str] = {
+        "completed_at": _utc_now_iso(),
+        "updated_at": _utc_now_iso(),
+    }
+    if error_str is not None:
+        finalise["status"] = "failed"
+        finalise["error"] = error_str
+    elif stats is not None and stats.cancelled:
+        finalise["status"] = "cancelled"
+    else:
+        finalise["status"] = "completed"
+    try:
+        cache.hset(key, mapping=finalise)
+    except Exception:  # pragma: no cover - cache outage at finalise
+        log.exception(
+            "redis_admin.clear_job(%s): failed to write terminal state",
+            job_id,
+        )
+
+    # Audit at job-completion (not job-start). `result.count` here
+    # mirrors the synchronous path: total tombstoned for live runs,
+    # total_found for dry-run previews. Extra fields capture the
+    # chunked-mode shape so log queries can distinguish chunked from
+    # synchronous clears.
+    if dry_run:
+        mode = "chunked-dry-run"
+    elif keep_one:
+        mode = "chunked-all-but-first"
+    else:
+        mode = "chunked-all-from-bucket"
+    sample = (f"{queue_name}#filter",)
+    families = ("celery_broker",)
+    extra: dict[str, Any] = {
+        "mode": mode,
+        "job_id": job_id,
+        "cancelled": bool(stats and stats.cancelled),
+    }
+    if stats is not None:
+        extra.update(
+            {
+                "passes_run": stats.passes_run,
+                "total_lset": stats.total_lset,
+                "total_drifted": stats.total_drifted,
+                "total_found": stats.total_found,
+            }
+        )
+        count = stats.total_found if dry_run else stats.total_lset
+    else:
+        count = 0
+    if error_str is not None:
+        extra["error"] = error_str
+    _record_audit(
+        user=user,
+        scope="celery_broker_clear",
+        count=count,
+        refused=(),
+        sample=sample,
+        families=families,
+        dry_run=dry_run,
+        extra=extra,
+    )

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -33,6 +33,7 @@ from typing import Any
 import sentry_sdk
 from django.contrib.admin.models import DELETION, LogEntry
 from django.contrib.contenttypes.models import ContentType
+from django.db import close_old_connections
 
 from . import conn as _conn
 from . import settings as redis_admin_settings
@@ -1283,6 +1284,15 @@ def _run_celery_broker_clear_job(
         # entry, which only matters for tests, not production.
         with _clear_job_threads_lock:
             _clear_job_threads.pop(job_id, None)
+        # Close DB connections opened by this worker thread (the
+        # audit-log write goes through the ORM, which lazily opens
+        # one per thread). Without this, a long-lived gunicorn
+        # process would slowly leak connections, and Django's
+        # `TransactionTestCase` truncate-on-teardown would block
+        # waiting for our idle connection to drain. `close_old_
+        # connections` is the documented helper for this exact
+        # background-thread cleanup case.
+        close_old_connections()
 
 
 def _run_celery_broker_clear_job_body(

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -1017,17 +1017,14 @@ def _celery_broker_clear(
 
 # ---- Chunked celery_broker clear jobs (background-thread variant) ----------
 #
-# Synchronous `celery_broker_clear` is fine for changelist actions and
-# the dry-run preview because operators expect the action handler to
-# block; but the "Clear all" path on a 200-500k-deep queue can run
-# well past the gunicorn worker `--timeout` (api.sh's 600s default
-# is comfortably above that, but upstream proxies may impose lower
-# ceilings — Cloudflare's free-tier is 100s, GCP HTTPS LB defaults
-# to 30s). The chunked variant here decouples the clear's wall-clock
-# from the HTTP request lifetime: `start_celery_broker_clear_job`
-# returns a `job_id` immediately, the actual clear runs in a daemon
-# thread, and the operator polls a status hash for progress + drives
-# cancellation through it.
+# Synchronous `celery_broker_clear` is fine for changelist actions
+# and the dry-run preview because operators expect the action
+# handler to block; but the "Clear all" path on a 200-500k-deep
+# queue can run for many minutes. The chunked variant here
+# decouples the clear's wall-clock from the HTTP request lifetime:
+# `start_celery_broker_clear_job` returns a `job_id` immediately,
+# the actual clear runs in a daemon thread, and the operator polls
+# a status hash for progress + drives cancellation through it.
 #
 # Why threading and not Celery: the queue we're clearing is the
 # Celery broker. Submitting a control task to a broker we're

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -447,32 +447,56 @@ def _celery_clear_tombstone() -> str:
     return f"{_CELERY_TOMBSTONE_PREFIX}:{uuid.uuid4().hex}"
 
 
+class _FilterWildcard:
+    """Sentinel for "this filter slot is unconstrained".
+
+    Distinct from `None` so the per-message clear paths
+    (`clear_selected`, `clear_dry_run`, `delete_model`,
+    `delete_queryset`) keep exact-tuple-membership semantics for
+    materialised rows whose envelope legitimately carries `None`
+    in a slot (e.g. a `sync_repos` task with `repoid=None` and
+    `commitid=None`). If `None` doubled as the wildcard value, a
+    single-row clear of a `sync_repos` envelope would tombstone
+    *every* `sync_repos` message in the queue rather than just
+    the one the operator selected.
+
+    Operator-input paths (`streaming_celery_count` and the
+    `clear_by_filter_view` synthetic target) substitute this
+    sentinel for any unset filter slot before building the
+    `(task, repoid, commitid)` tuple.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return "FILTER_ANY"
+
+
+_FILTER_ANY = _FilterWildcard()
+
+
 def _envelope_matches_any_filter(meta, filter_tuples: frozenset) -> bool:
     """Return True if `meta` matches any tuple in `filter_tuples`.
 
     Each filter tuple is `(task_name, repoid, commitid)` where any
-    slot may be `None` to mean "wildcard / don't constrain on this
-    field". Mirrors the queryset's "filter by what's set" semantic
-    (`queryset.filter(repoid=repoid)` doesn't constrain `task_name`),
-    so callers like `streaming_celery_count` and the clear-by-filter
-    path can reuse the same triple-shaped frozenset they would build
-    for an exact-tuple match without silently undercounting when the
-    operator left a slot unset.
+    slot may be the `_FILTER_ANY` sentinel to mean "wildcard / do
+    not constrain on this field". `None` in a slot means "match
+    only envelopes whose corresponding parsed field is `None`",
+    which is what materialised per-message targets need so they
+    never over-match envelopes whose envelope happens to carry the
+    same task name but a different `(repoid, commitid)` shape.
 
-    Without the wildcard semantics, a filter built from operator
-    input (e.g. `(None, 1, "abc")` for "repoid=1 AND commitid=abc",
-    no task constraint) would never match a real envelope (whose
-    `meta.task` is always populated), so both the streaming counter
-    and the streaming clear would silently report zero matches even
-    when the queryset path would have surfaced rows.
+    Mirrors the queryset's "filter by what's set" semantic only
+    for callers that opt in by substituting `_FILTER_ANY` for
+    unset slots before building the frozenset.
     """
 
     for ft_task, ft_repoid, ft_commitid in filter_tuples:
-        if ft_task is not None and ft_task != meta.task:
+        if ft_task is not _FILTER_ANY and ft_task != meta.task:
             continue
-        if ft_repoid is not None and ft_repoid != meta.repoid:
+        if ft_repoid is not _FILTER_ANY and ft_repoid != meta.repoid:
             continue
-        if ft_commitid is not None and ft_commitid != meta.commitid:
+        if ft_commitid is not _FILTER_ANY and ft_commitid != meta.commitid:
             continue
         return True
     return False
@@ -681,7 +705,20 @@ def streaming_celery_count(
     """
 
     redis = _conn.get_connection(kind="broker")
-    filter_tuples = frozenset({(task_name or None, repoid, commitid or None)})
+    # Substitute `_FILTER_ANY` (not `None`) for unset slots so the
+    # streaming match treats them as wildcards. `None` would mean
+    # "match only envelopes whose corresponding field is literally
+    # `None`" which would zero-out the count for any operator
+    # input that didn't pin every slot of the triple.
+    filter_tuples = frozenset(
+        {
+            (
+                task_name if task_name else _FILTER_ANY,
+                repoid if repoid is not None else _FILTER_ANY,
+                commitid if commitid else _FILTER_ANY,
+            )
+        }
+    )
     tombstone = _celery_clear_tombstone()
     stats = _streaming_celery_clear(
         redis,

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -478,6 +478,45 @@ class _FilterWildcard:
 _FILTER_ANY = _FilterWildcard()
 
 
+def _substitute_filter_any(
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+) -> tuple:
+    """Substitute `_FILTER_ANY` for unset operator filter slots.
+
+    Operator-input clear paths (`streaming_celery_count`, the
+    chunked clear job in `_run_celery_broker_clear_job_body`,
+    and the `clear_by_filter_view` synthetic target) all need
+    to convert the form's per-slot `None` / empty-string into
+    the wildcard sentinel before handing the triple to
+    `_envelope_matches_any_filter` (or to a synthetic
+    `CeleryBrokerQueue` row carrying the same comparison
+    semantics). Centralising the substitution rule keeps the
+    dry-run count, the chunked clear, and the synchronous
+    `clear_by_filter_view` preview from drifting if the rule
+    later changes (e.g. a new filter field is added or a
+    slot's truthiness check is loosened) — a divergence here
+    would manifest as the dry-run count disagreeing with the
+    chunked clear's matched count, which is a data-loss
+    vector.
+
+    The truthiness-vs-`is None` asymmetry is intentional:
+    `repoid` is an integer where `0` could in principle be a
+    legitimate value, so we explicitly check `is not None` to
+    avoid silently treating it as wildcard. `task_name` and
+    `commitid` are strings where the empty string and `None`
+    should both mean "unset" because the admin form coerces
+    missing input to `""`.
+    """
+
+    return (
+        task_name if task_name else _FILTER_ANY,
+        repoid if repoid is not None else _FILTER_ANY,
+        commitid if commitid else _FILTER_ANY,
+    )
+
+
 def _envelope_matches_any_filter(meta, filter_tuples: frozenset) -> bool:
     """Return True if `meta` matches any tuple in `filter_tuples`.
 
@@ -835,15 +874,7 @@ def streaming_celery_count(
     # "match only envelopes whose corresponding field is literally
     # `None`" which would zero-out the count for any operator
     # input that didn't pin every slot of the triple.
-    filter_tuples = frozenset(
-        {
-            (
-                task_name if task_name else _FILTER_ANY,
-                repoid if repoid is not None else _FILTER_ANY,
-                commitid if commitid else _FILTER_ANY,
-            )
-        }
-    )
+    filter_tuples = frozenset({_substitute_filter_any(task_name, repoid, commitid)})
     tombstone = _celery_clear_tombstone()
     stats = _streaming_celery_clear(
         redis,
@@ -1322,15 +1353,7 @@ def _run_celery_broker_clear_job_body(
     # operator slot becomes a wildcard rather than an exact-`None`
     # match (which would zero-match for any envelope whose field
     # wasn't literally `None`).
-    filter_tuples = frozenset(
-        {
-            (
-                task_name if task_name else _FILTER_ANY,
-                repoid if repoid is not None else _FILTER_ANY,
-                commitid if commitid else _FILTER_ANY,
-            )
-        }
-    )
+    filter_tuples = frozenset({_substitute_filter_any(task_name, repoid, commitid)})
 
     def _progress_callback(snapshot: _ChunkProgress) -> bool:
         """Per-chunk hook: pump `processed/matched/drifted` into

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -702,8 +702,12 @@ def _streaming_celery_clear(
                     # Out-of-range: consumer drained this slot.
                     matches_drifted += 1
 
-            chunk_index += 1
             if progress_callback is not None:
+                # `chunk_index` is 0-based: the first chunk in a
+                # pass reports 0, the last reports `chunks_total - 1`.
+                # `chunk_index += 1` lives AFTER the callback so the
+                # snapshot describes the chunk that just finished,
+                # not the one about to start.
                 snapshot = _ChunkProgress(
                     pass_num=passes_run,
                     chunk_index=chunk_index,
@@ -756,6 +760,7 @@ def _streaming_celery_clear(
                         passes_run=passes_run,
                         cancelled=True,
                     )
+            chunk_index += 1
 
         if not dry_run:
             redis.lrem(queue_name, 0, tombstone)

--- a/apps/codecov-api/redis_admin/static/redis_admin/css/celery_clear_progress.css
+++ b/apps/codecov-api/redis_admin/static/redis_admin/css/celery_clear_progress.css
@@ -1,0 +1,231 @@
+/* Styles for the chunked celery_broker clear progress page.
+ *
+ * Lives in an external file so the production CSP — `'self'` plus
+ * a single fixed sha256 hash for inline scripts — does not block
+ * inline <style> tags. See settings_base.py CSP_DEFAULT_SRC.
+ *
+ * Variables come from Django admin's theme (light + dark) so the
+ * progress bar / pills / cards re-tint automatically when the
+ * operator's admin theme switches.
+ */
+
+.celery-clear-progress-root {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.celery-clear-job-id {
+  margin-left: 8px;
+  font-family: var(--font-family-monospace, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.85em;
+  color: var(--body-quiet-color, #666);
+}
+
+.celery-clear-summary {
+  margin-bottom: 0.5em;
+}
+
+.celery-clear-status-pill {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  font-size: 0.85em;
+  background: var(--darkened-bg, #f0f0f0);
+  color: var(--body-fg, #333);
+  border: 1px solid var(--border-color, #ccc);
+}
+
+/* State-specific pill colours.
+ *
+ * `pending` / `running` keep the neutral default; only the terminal
+ * states get colour so the operator's eye lands on "are we done?"
+ * without having to read the label.
+ */
+.celery-clear-status-running {
+  background: var(--primary, #417690);
+  color: var(--header-link-color, #fff);
+  border-color: var(--primary, #417690);
+}
+.celery-clear-status-completed {
+  background: #2e7d32;
+  color: #fff;
+  border-color: #2e7d32;
+}
+.celery-clear-status-cancelled {
+  background: #f1c40f;
+  color: #1f1f1f;
+  border-color: #d4a90c;
+}
+.celery-clear-status-failed {
+  background: var(--error-fg, #ba2121);
+  color: #fff;
+  border-color: var(--error-fg, #ba2121);
+}
+
+.celery-clear-dry-run-tag,
+.celery-clear-keep-one-tag {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 8px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  font-weight: 600;
+  background: var(--darkened-bg, #f0f0f0);
+  color: var(--body-fg, #333);
+  border: 1px solid var(--border-color, #ccc);
+}
+
+.celery-clear-progress-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.celery-clear-progress-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Use the native <progress> element so screen readers announce
+ * progress without us having to fake it with ARIA. Style both the
+ * webkit-style (`-webkit-progress-bar`) and the moz-style
+ * (`-moz-progress-bar`) pseudo-elements so the bar tints in both
+ * Chromium and Firefox. */
+.celery-clear-progress-bar {
+  flex: 1 1 auto;
+  height: 16px;
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 4px;
+  background: var(--darkened-bg, #f0f0f0);
+  overflow: hidden;
+}
+.celery-clear-progress-bar::-webkit-progress-bar {
+  background: var(--darkened-bg, #f0f0f0);
+}
+.celery-clear-progress-bar::-webkit-progress-value {
+  background: var(--primary, #417690);
+  transition: width 0.4s ease-in-out;
+}
+.celery-clear-progress-bar::-moz-progress-bar {
+  background: var(--primary, #417690);
+}
+
+.celery-clear-progress-pct {
+  flex: 0 0 auto;
+  min-width: 4em;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.celery-clear-counters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.celery-clear-counter {
+  padding: 12px 14px;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 6px;
+  background: var(--darkened-bg, #f8f8f8);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.celery-clear-counter dt {
+  font-size: 0.8em;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--body-quiet-color, #666);
+  margin: 0;
+}
+
+.celery-clear-counter dd {
+  margin: 0;
+  font-size: 1.4em;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.celery-clear-counter-denom {
+  font-size: 0.75em;
+  font-weight: 400;
+  color: var(--body-quiet-color, #666);
+  margin-left: 4px;
+}
+
+.celery-clear-timestamps {
+  font-size: 0.85em;
+  color: var(--body-quiet-color, #666);
+}
+
+.celery-clear-error {
+  color: var(--error-fg, #ba2121);
+}
+
+.celery-clear-hidden {
+  display: none;
+}
+
+.celery-clear-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.celery-clear-cancel-form {
+  margin: 0;
+}
+
+.celery-clear-cancel-button {
+  background: var(--button-bg, var(--primary, #417690));
+  color: var(--button-fg, #fff);
+  border: 1px solid transparent;
+  padding: 8px 14px;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.celery-clear-cancel-button:hover:not(:disabled),
+.celery-clear-cancel-button:focus:not(:disabled) {
+  background: var(--button-hover-bg, #205067);
+}
+.celery-clear-cancel-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.celery-clear-back-link {
+  text-decoration: none;
+}
+
+.celery-clear-disabled-link {
+  /* Until terminal status, the back link is dimmed but still
+   * functional so an operator who navigates away mid-clear knows
+   * the run keeps going (it's a daemon thread on the api pod, not
+   * tied to this tab). */
+  opacity: 0.6;
+}
+
+/* Reduced-motion fallback: replace the bar's animated fill with a
+ * static fill so operators with vestibular sensitivity don't see
+ * the bar visibly redraw on every poll. */
+@media (prefers-reduced-motion: reduce) {
+  .celery-clear-progress-bar::-webkit-progress-value {
+    transition: none;
+  }
+}

--- a/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_progress.js
+++ b/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_progress.js
@@ -26,6 +26,18 @@
   var POLL_INTERVAL_OK_MS = 1000;
   var POLL_BACKOFF_STEPS_MS = [1000, 2000, 5000];
   var POLL_BACKOFF_MAX_MS = 5000;
+  // Enumerated rather than stripped by prefix because the pill's
+  // base class (`celery-clear-status-pill`) shares the same prefix
+  // as the state-specific classes; a prefix-strip would drop the
+  // base styling (display, padding, border-radius, etc.) on the
+  // first poll update and leave only the colour overrides.
+  var STATE_CLASSES = [
+    'celery-clear-status-pending',
+    'celery-clear-status-running',
+    'celery-clear-status-completed',
+    'celery-clear-status-cancelled',
+    'celery-clear-status-failed'
+  ];
 
   function $(id) { return document.getElementById(id); }
 
@@ -45,13 +57,14 @@
     if (!pill) return;
     pill.textContent = status;
     pill.dataset.status = status;
-    // Strip any prior celery-clear-status-* class then re-add the
-    // current one so the CSS pill colour follows state changes.
-    var classes = pill.className.split(/\s+/).filter(function (c) {
-      return c && c.indexOf('celery-clear-status-') !== 0;
-    });
-    classes.push('celery-clear-status-' + status);
-    pill.className = classes.join(' ');
+    // Strip any prior state class then add the current one. We
+    // explicitly enumerate STATE_CLASSES rather than filtering by
+    // prefix so the base `celery-clear-status-pill` class survives
+    // and the pill keeps its layout / typography styling.
+    for (var i = 0; i < STATE_CLASSES.length; i += 1) {
+      pill.classList.remove(STATE_CLASSES[i]);
+    }
+    pill.classList.add('celery-clear-status-' + status);
   }
 
   function updateProgress(snapshot) {

--- a/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_progress.js
+++ b/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_progress.js
@@ -1,0 +1,218 @@
+// Polls the chunked celery_broker clear job's status JSON endpoint,
+// updates the progress bar + counters, and hijacks the cancel form
+// to fire via fetch(). Loaded as an external file (not inline) so
+// the production CSP on api-admin.codecov.io — `'self'` plus a
+// single fixed sha256 hash for inline scripts — does not block it.
+// See settings_base.py CSP_DEFAULT_SRC.
+//
+// Lifecycle:
+//   - On DOMContentLoaded, read the job id + URLs from data
+//     attributes on `#celery-clear-progress-root`.
+//   - If the initial server-rendered status is non-terminal, start
+//     polling every 1s. Backs off (1s → 2s → 5s, capped at 5s) on
+//     fetch errors so a transient cache outage doesn't hammer the
+//     api with retries.
+//   - On terminal status (`completed` / `cancelled` / `failed`),
+//     stop polling, disable the Cancel button, and enable the
+//     "back to changelist" link.
+//   - The Cancel button click fires a fetch() POST to the cancel
+//     URL with the CSRF token. The button reads "Cancelling…" until
+//     the next poll confirms `status=cancelled`. Double-clicks are
+//     prevented by toggling `disabled` while a request is in flight.
+(function () {
+  'use strict';
+
+  var TERMINAL_STATES = { completed: 1, cancelled: 1, failed: 1 };
+  var POLL_INTERVAL_OK_MS = 1000;
+  var POLL_BACKOFF_STEPS_MS = [1000, 2000, 5000];
+  var POLL_BACKOFF_MAX_MS = 5000;
+
+  function $(id) { return document.getElementById(id); }
+
+  function getCsrfToken(form) {
+    if (!form) return '';
+    var input = form.querySelector('input[name=csrfmiddlewaretoken]');
+    return input ? input.value : '';
+  }
+
+  function setText(id, value) {
+    var el = $(id);
+    if (el) el.textContent = value;
+  }
+
+  function setStatusPill(status) {
+    var pill = $('celery-clear-status-pill');
+    if (!pill) return;
+    pill.textContent = status;
+    pill.dataset.status = status;
+    // Strip any prior celery-clear-status-* class then re-add the
+    // current one so the CSS pill colour follows state changes.
+    var classes = pill.className.split(/\s+/).filter(function (c) {
+      return c && c.indexOf('celery-clear-status-') !== 0;
+    });
+    classes.push('celery-clear-status-' + status);
+    pill.className = classes.join(' ');
+  }
+
+  function updateProgress(snapshot) {
+    var bar = $('celery-clear-progress-bar');
+    var pct = $('celery-clear-progress-pct');
+    var total = snapshot.total_estimated || 0;
+    var processed = snapshot.processed || 0;
+    if (bar) {
+      bar.value = processed;
+      // <progress> with max=0 renders as indeterminate; use 1 as a
+      // floor so the bar shows zero progress rather than spinning.
+      bar.max = total > 0 ? total : 1;
+    }
+    if (pct) {
+      if (total > 0) {
+        var p = Math.min(100, Math.floor((processed / total) * 100));
+        pct.textContent = p + '%';
+      } else {
+        pct.textContent = '—';
+      }
+    }
+    setText('celery-clear-matched', snapshot.matched);
+    setText('celery-clear-processed', snapshot.processed);
+    setText('celery-clear-total-estimated', snapshot.total_estimated);
+    setText('celery-clear-drifted', snapshot.drifted);
+    setText('celery-clear-passes', snapshot.passes_run);
+    setText('celery-clear-started-at', snapshot.started_at || '—');
+    setText('celery-clear-updated-at', snapshot.updated_at || '—');
+    setText('celery-clear-completed-at', snapshot.completed_at || '—');
+    var errorEl = $('celery-clear-error');
+    var errorRow = $('celery-clear-error-row');
+    if (errorEl && errorRow) {
+      if (snapshot.error) {
+        errorEl.textContent = snapshot.error;
+        errorRow.classList.remove('celery-clear-hidden');
+      } else {
+        errorEl.textContent = '';
+        errorRow.classList.add('celery-clear-hidden');
+      }
+    }
+  }
+
+  function isTerminal(status) {
+    return Object.prototype.hasOwnProperty.call(TERMINAL_STATES, status);
+  }
+
+  function setTerminalUI(status) {
+    var cancelBtn = $('celery-clear-cancel-button');
+    if (cancelBtn) {
+      cancelBtn.disabled = true;
+      // Show what the final state was, not the in-flight verb.
+      cancelBtn.textContent = (
+        status === 'cancelled' ? 'Cancelled'
+          : status === 'failed' ? 'Failed'
+            : 'Done'
+      );
+    }
+    var back = $('celery-clear-back-link');
+    if (back) back.classList.remove('celery-clear-disabled-link');
+  }
+
+  function init() {
+    var root = $('celery-clear-progress-root');
+    if (!root) return;
+    var statusUrl = root.dataset.statusUrl;
+    var cancelUrl = root.dataset.cancelUrl;
+    if (!statusUrl) return;
+
+    var initialStatus = root.dataset.initialStatus || 'pending';
+    var initialTerminal = root.dataset.isTerminal === '1';
+    if (initialTerminal) {
+      setTerminalUI(initialStatus);
+      return;
+    }
+
+    var backoffStep = 0;
+    var pollTimer = null;
+    var inFlight = false;
+
+    function scheduleNextPoll(intervalMs) {
+      if (pollTimer) clearTimeout(pollTimer);
+      pollTimer = setTimeout(poll, intervalMs);
+    }
+
+    function poll() {
+      if (inFlight) return;
+      inFlight = true;
+      fetch(statusUrl, { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+        .then(function (r) {
+          if (!r.ok) {
+            throw new Error('status HTTP ' + r.status);
+          }
+          return r.json();
+        })
+        .then(function (snapshot) {
+          backoffStep = 0;
+          updateProgress(snapshot);
+          var status = snapshot.status || 'pending';
+          setStatusPill(status);
+          var cancelBtn = $('celery-clear-cancel-button');
+          if (cancelBtn && snapshot.cancel_requested && !isTerminal(status)) {
+            cancelBtn.textContent = 'Cancelling…';
+            cancelBtn.disabled = true;
+          }
+          if (isTerminal(status)) {
+            setTerminalUI(status);
+            return;
+          }
+          scheduleNextPoll(POLL_INTERVAL_OK_MS);
+        })
+        .catch(function () {
+          // Backoff on errors. Step through 1s → 2s → 5s, then stay
+          // at 5s. Doesn't escalate to "give up": a transient cache
+          // outage may resolve and we still want the page to update
+          // when it does.
+          var step = backoffStep < POLL_BACKOFF_STEPS_MS.length
+            ? POLL_BACKOFF_STEPS_MS[backoffStep]
+            : POLL_BACKOFF_MAX_MS;
+          backoffStep += 1;
+          scheduleNextPoll(step);
+        })
+        .then(function () { inFlight = false; });
+    }
+
+    var cancelForm = $('celery-clear-cancel-form');
+    if (cancelForm && cancelUrl) {
+      cancelForm.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var cancelBtn = $('celery-clear-cancel-button');
+        if (cancelBtn) {
+          if (cancelBtn.disabled) return;
+          cancelBtn.disabled = true;
+          cancelBtn.textContent = 'Cancelling…';
+        }
+        fetch(cancelUrl, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'X-CSRFToken': getCsrfToken(cancelForm),
+            'Accept': 'application/json'
+          }
+        })
+          .then(function () { /* poll will pick up the new state */ })
+          .catch(function () {
+            // If the cancel POST itself errored we re-enable the
+            // button so the operator can retry; the next poll will
+            // also reflect whatever the server thinks the state is.
+            if (cancelBtn) {
+              cancelBtn.disabled = false;
+              cancelBtn.textContent = 'Cancel clear';
+            }
+          });
+      });
+    }
+
+    poll();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/clear_by_filter_progress.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/clear_by_filter_progress.html
@@ -1,0 +1,157 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% comment %}
+Progress page for a chunked celery_broker clear job. Spawned by
+`clear_by_filter_view` for any destructive action (clear_all /
+clear_keep_one). The HTTP request that submitted the clear has
+already returned with a 302 to this URL — the actual clearing is
+running in a daemon thread on the api pod's gunicorn worker, and
+this page polls a status JSON view every ~1s to render progress.
+
+CSP-compliant: all JS / CSS loads via {% static %} from
+`redis_admin/static/redis_admin/...`. Production
+(api-admin.codecov.io) only allows `'self'` + a single fixed
+sha256 for inline scripts. No inline <script>/<style> tags here.
+
+The initial server-side render is informative even before JS
+loads: it surfaces the job's status, filter shape, and current
+counters so an operator on a flaky network or with JS disabled
+still sees the run is happening.
+{% endcomment %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list celery-clear-progress{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'redis_admin/css/celery_clear_progress.css' %}">
+{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{{ changelist_url }}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; Clear progress
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+  <div id="celery-clear-progress-root"
+       class="celery-clear-progress-root"
+       data-job-id="{{ job_id }}"
+       data-status-url="{{ status_url }}"
+       data-cancel-url="{{ cancel_url }}"
+       data-changelist-url="{{ changelist_url }}"
+       data-initial-status="{{ status }}"
+       data-is-terminal="{{ is_terminal|yesno:'1,0' }}">
+
+    <fieldset class="module">
+      <h2>
+        Clearing <code>{{ queue_name }}</code>
+        <span class="celery-clear-job-id" title="{{ job_id }}">{{ job_id|slice:":8" }}…</span>
+      </h2>
+      <p class="celery-clear-summary">
+        Status:
+        <span id="celery-clear-status-pill"
+              class="celery-clear-status-pill celery-clear-status-{{ status }}"
+              data-status="{{ status }}">{{ status }}</span>
+        {% if dry_run %}<span class="celery-clear-dry-run-tag">dry-run</span>{% endif %}
+        {% if keep_one %}<span class="celery-clear-keep-one-tag">keep-one</span>{% endif %}
+      </p>
+
+      <p>
+        Filter:
+        Task: {% if filter_task %}<code>{{ filter_task }}</code>{% else %}<em>(any)</em>{% endif %} ·
+        Repo: {% if filter_repoid %}<code>{{ filter_repoid }}</code>{% else %}<em>(any)</em>{% endif %} ·
+        Commit: {% if filter_commitid %}<code title="{{ filter_commitid }}">{{ filter_commitid|slice:":7" }}</code>{% else %}<em>(any)</em>{% endif %}
+      </p>
+    </fieldset>
+
+    <fieldset class="module celery-clear-progress-card">
+      <h2>Progress</h2>
+
+      <div class="celery-clear-progress-bar-wrap">
+        <progress id="celery-clear-progress-bar"
+                  class="celery-clear-progress-bar"
+                  value="{{ processed }}"
+                  max="{{ total_estimated|default:1 }}"></progress>
+        <span id="celery-clear-progress-pct" class="celery-clear-progress-pct">
+          {% if total_estimated > 0 %}
+            {% widthratio processed total_estimated 100 %}%
+          {% else %}
+            —
+          {% endif %}
+        </span>
+      </div>
+
+      <dl class="celery-clear-counters">
+        <div class="celery-clear-counter">
+          <dt>Matched</dt>
+          <dd id="celery-clear-matched">{{ matched }}</dd>
+        </div>
+        <div class="celery-clear-counter">
+          <dt>Processed</dt>
+          <dd>
+            <span id="celery-clear-processed">{{ processed }}</span>
+            <span class="celery-clear-counter-denom">
+              / <span id="celery-clear-total-estimated">{{ total_estimated }}</span>
+            </span>
+          </dd>
+        </div>
+        <div class="celery-clear-counter">
+          <dt>Drift</dt>
+          <dd id="celery-clear-drifted">{{ drifted }}</dd>
+        </div>
+        <div class="celery-clear-counter">
+          <dt>Pass</dt>
+          <dd id="celery-clear-passes">{{ passes_run }}</dd>
+        </div>
+      </dl>
+
+      <p class="celery-clear-timestamps">
+        Started: <code id="celery-clear-started-at">{{ started_at|default:"—" }}</code>
+        · Updated: <code id="celery-clear-updated-at">{{ updated_at|default:"—" }}</code>
+        · Completed: <code id="celery-clear-completed-at">{{ completed_at|default:"—" }}</code>
+      </p>
+
+      <p id="celery-clear-error-row"
+         class="celery-clear-error{% if not error %} celery-clear-hidden{% endif %}">
+        Error: <code id="celery-clear-error">{{ error }}</code>
+      </p>
+    </fieldset>
+
+    <fieldset class="module">
+      <div class="submit-row celery-clear-actions">
+        {# Cancel form is a real <form>; the JS hijacks submit and #}
+        {# fires fetch() with the CSRF token. If JS fails to load,  #}
+        {# the form still submits and the server still cancels —  #}
+        {# graceful degradation. #}
+        <form id="celery-clear-cancel-form"
+              method="post"
+              action="{{ cancel_url }}"
+              class="celery-clear-cancel-form">
+          {% csrf_token %}
+          <button type="submit"
+                  id="celery-clear-cancel-button"
+                  class="celery-clear-cancel-button"
+                  {% if is_terminal %}disabled{% endif %}>
+            {% if cancel_requested and not is_terminal %}Cancelling…{% else %}Cancel clear{% endif %}
+          </button>
+        </form>
+        <a id="celery-clear-back-link"
+           class="celery-clear-back-link{% if not is_terminal %} celery-clear-disabled-link{% endif %}"
+           href="{{ changelist_url }}">
+          &larr; back to {{ queue_name|default:"changelist" }}
+        </a>
+      </div>
+    </fieldset>
+
+  </div>
+
+  <script src="{% static 'redis_admin/js/celery_clear_progress.js' %}" defer></script>
+
+</div>
+{% endblock %}

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
@@ -1,0 +1,686 @@
+"""Coverage for the chunked celery_broker clear background-job
+machinery added in this PR.
+
+Two layers of coverage:
+
+* Service layer (`start_celery_broker_clear_job`,
+  `get_celery_broker_clear_job`,
+  `request_cancel_celery_broker_clear_job`,
+  `_run_celery_broker_clear_job`): end-to-end on fakeredis. We
+  push messages onto a fake broker, spawn the worker thread, and
+  poll the job hash via the public service helpers to assert
+  progress monotonicity, cancellation semantics, keep_one
+  preservation, and failure-path swallowing.
+
+* View layer (`clear_by_filter_progress_view`,
+  `clear_by_filter_status_view`, `clear_by_filter_cancel_view`,
+  and the modified `clear_by_filter_view`): exercised via
+  `RequestFactory` + a `SimpleNamespace` user so we don't need
+  Postgres for the request lifecycle. The user fixture's
+  `is_superuser=True` skirts the model-level permission check.
+
+All tests run under `-m 'not django_db'`. The audit-log test that
+needs `LogEntry` inspection lives behind `@pytest.mark.django_db`
+because asserting on `LogEntry.change_message` requires the auth
+DB; in the sandbox it errors with the documented `could not
+translate host name "postgres"` and is verified in CI.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+import fakeredis
+import pytest
+from django.contrib.admin.models import LogEntry
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin import services as redis_admin_services
+from redis_admin import settings as redis_admin_settings
+from redis_admin.admin import CeleryBrokerQueueAdmin
+from redis_admin.models import CeleryBrokerQueue
+from redis_admin.services import (
+    _CELERY_CLEAR_CHUNK_JOB,
+    _CELERY_CLEAR_JOB_KEY_PREFIX,
+    _CELERY_CLEAR_JOB_TTL_SECONDS,
+    _ChunkProgress,
+    _streaming_celery_clear,
+    get_celery_broker_clear_job,
+    request_cancel_celery_broker_clear_job,
+    start_celery_broker_clear_job,
+)
+from redis_admin.tests.test_celery_broker_queue import _build_envelope
+from shared.django_apps.codecov_auth.tests.factories import UserFactory
+
+# ---- Fixtures --------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_broker(monkeypatch) -> fakeredis.FakeStrictRedis:
+    """Single fakeredis backing both `kind="default"` (cache, where
+    the job hash lives) and `kind="broker"` (the queue we're
+    clearing). Mirrors the fixture in `test_celery_broker_queue.py`
+    so tests can co-locate broker pushes and job-hash reads on the
+    same in-memory server.
+    """
+
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(
+        redis_admin_conn, "get_connection", lambda kind="default": server
+    )
+    return server
+
+
+@pytest.fixture
+def superuser():
+    """A `SimpleNamespace` superuser stand-in for tests that don't
+    need the auth DB. `start_celery_broker_clear_job` only reads
+    `id` / `pk` for audit-log attribution; the view-layer permission
+    checks read `is_superuser`.
+    """
+
+    return SimpleNamespace(
+        id=42,
+        pk=42,
+        is_superuser=True,
+        is_staff=True,
+        is_active=True,
+        is_authenticated=True,
+        is_anonymous=False,
+        username="testop",
+    )
+
+
+def _wait_for_job(job_id: str, *, timeout: float = 10.0) -> None:
+    """Block until the worker thread for `job_id` exits.
+
+    Uses the `_clear_job_threads` test handle in `services.py`. We
+    avoid `threading.enumerate()` so a parent test runner's
+    background threads don't confuse the lookup.
+    """
+
+    thread = redis_admin_services._clear_job_threads.get(job_id)
+    if thread is None:
+        return
+    thread.join(timeout=timeout)
+    assert not thread.is_alive(), (
+        f"clear job worker thread for {job_id} did not exit within {timeout}s"
+    )
+
+
+def _push_envelopes(
+    redis: fakeredis.FakeStrictRedis,
+    queue: str,
+    *,
+    n: int,
+    task: str = "app.tasks.bundle_analysis.BundleAnalysisProcessor",
+    repoid: int = 1234,
+    commitid: str = "abcdef" + "0" * 34,
+) -> None:
+    """Push `n` matching envelopes onto `queue` in a single
+    pipeline so even 5_000-message setups complete in a fraction
+    of a second.
+    """
+
+    pipe = redis.pipeline(transaction=False)
+    envelope = _build_envelope(
+        task=task, kwargs={"repoid": repoid, "commitid": commitid}
+    )
+    for _ in range(n):
+        pipe.rpush(queue, envelope)
+    pipe.execute()
+
+
+# ---- Service layer ---------------------------------------------------------
+
+
+def test_start_celery_broker_clear_job_returns_uuid_and_initialises_state(
+    patched_broker, superuser
+):
+    """`start_celery_broker_clear_job` returns a UUID-shaped job_id
+    and writes a fully-populated initial hash with status=pending,
+    the operator's filter shape, and a snapshotted total_estimated.
+    Pinning the hash shape so the JSON status view's contract stays
+    stable across refactors.
+    """
+
+    queue = "bundle_analysis"
+    _push_envelopes(patched_broker, queue, n=3, repoid=99)
+
+    job_id = start_celery_broker_clear_job(
+        queue,
+        user=superuser,
+        task_name=None,
+        repoid=99,
+        commitid=None,
+        keep_one=False,
+        dry_run=True,  # dry_run so the worker doesn't mutate
+    )
+    _wait_for_job(job_id)
+
+    # UUID canonical form so the URL converter accepts it.
+    assert len(job_id) == 36
+    assert job_id.count("-") == 4
+
+    job = get_celery_broker_clear_job(job_id)
+    assert job is not None
+    # Initial fields the views + JSON shape rely on.
+    expected_keys = {
+        "status",
+        "queue",
+        "filter_task",
+        "filter_repoid",
+        "filter_commitid",
+        "dry_run",
+        "keep_one",
+        "user_id",
+        "started_at",
+        "updated_at",
+        "completed_at",
+        "total_estimated",
+        "processed",
+        "matched",
+        "drifted",
+        "passes_run",
+        "error",
+        "cancel_requested",
+    }
+    assert expected_keys <= set(job.keys())
+    assert job["queue"] == queue
+    assert job["filter_repoid"] == "99"
+    assert job["filter_task"] == ""
+    assert job["filter_commitid"] == ""
+    assert job["dry_run"] == "1"
+    assert job["keep_one"] == "0"
+    # Worker has had time to finish (3 messages on fakeredis); the
+    # status should be terminal by now.
+    assert job["status"] in {"completed", "running", "pending"}
+    # Snapshotted depth is the total at submit time.
+    assert int(job["total_estimated"]) == 3
+
+    # 24h TTL set on creation.
+    key = f"{_CELERY_CLEAR_JOB_KEY_PREFIX}:{job_id}"
+    ttl = patched_broker.ttl(key)
+    assert 0 < ttl <= _CELERY_CLEAR_JOB_TTL_SECONDS
+
+
+def test_clear_job_processes_in_chunks_and_updates_progress_monotonically(
+    patched_broker,
+):
+    """The progress callback is called once per LRANGE chunk and
+    deltas accumulate monotonically.
+
+    Rather than chase the worker thread for snapshots (timing-
+    flaky), drive `_streaming_celery_clear` directly with a
+    snapshot-recording callback; this is exactly the chunk loop
+    the worker thread runs, so monotonicity here is what the
+    progress page sees.
+    """
+
+    queue = "bundle_analysis"
+    matches = 5_000
+    _push_envelopes(patched_broker, queue, n=matches, repoid=1, commitid="x" * 40)
+
+    snapshots: list[_ChunkProgress] = []
+
+    def _record(snapshot: _ChunkProgress) -> bool:
+        snapshots.append(snapshot)
+        return False
+
+    stats = _streaming_celery_clear(
+        patched_broker,
+        queue,
+        frozenset({("app.tasks.bundle_analysis.BundleAnalysisProcessor", 1, "x" * 40)}),
+        tombstone="__redis_admin_celery_tombstone__:test",
+        keep_one=False,
+        dry_run=True,
+        chunk_size=_CELERY_CLEAR_CHUNK_JOB,
+        progress_callback=_record,
+    )
+
+    assert stats.total_found == matches
+    # 5_000 / chunk-size 1_000 → 5 callbacks (the loop short-
+    # circuits after the first dry-run pass so only one pass
+    # contributes to the snapshot list).
+    assert len(snapshots) == matches // _CELERY_CLEAR_CHUNK_JOB
+    # Monotonic non-decreasing across chunks.
+    prev_total_found = 0
+    for snap in snapshots:
+        assert snap.total_found >= prev_total_found
+        prev_total_found = snap.total_found
+    # Final snapshot's running totals match the stats return.
+    assert snapshots[-1].total_found == stats.total_found
+    # Per-chunk processed delta is at most `chunk_size`.
+    for snap in snapshots:
+        assert snap.processed_delta <= _CELERY_CLEAR_CHUNK_JOB
+
+
+def test_clear_job_drains_deep_queue_end_to_end(patched_broker, superuser):
+    """End-to-end drain: push more matches than the synchronous
+    display window, spawn the chunked job, wait for the worker, and
+    assert every match is gone via a positive walk.
+
+    Mirrors `test_celery_broker_clear_drains_deep_queue_end_to_end`
+    in `test_celery_broker_clear_drain_verification.py` but exercises
+    the chunked-job code path end-to-end.
+    """
+
+    queue = "bundle_analysis"
+    matches = redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT + 500
+    _push_envelopes(
+        patched_broker, queue, n=matches, repoid=21222368, commitid="abc" + "0" * 37
+    )
+    initial = patched_broker.llen(queue)
+    assert initial == matches
+
+    job_id = start_celery_broker_clear_job(
+        queue,
+        user=superuser,
+        task_name=None,
+        repoid=21222368,
+        commitid="abc" + "0" * 37,
+        keep_one=False,
+        dry_run=False,
+    )
+    _wait_for_job(job_id, timeout=30.0)
+
+    job = get_celery_broker_clear_job(job_id)
+    assert job is not None
+    assert job["status"] == "completed"
+    assert int(job["matched"]) == matches
+    # Queue is fully drained.
+    assert patched_broker.llen(queue) == 0
+
+
+def test_clear_job_cancel_stops_at_chunk_boundary(patched_broker, superuser):
+    """An in-flight cancel halts the worker at the next chunk
+    boundary, leaves remaining matches intact, and records
+    `status=cancelled`. We coordinate via a sentinel callback that
+    blocks the first chunk until the test triggers cancel — that
+    guarantees the cancel lands on the SECOND chunk boundary check
+    (not after the worker already finished).
+    """
+
+    queue = "bundle_analysis"
+    matches = 10_000
+    _push_envelopes(patched_broker, queue, n=matches, repoid=1, commitid="x" * 40)
+
+    cancel_seen = threading.Event()
+    chunks_seen_before_cancel = []
+
+    real_streaming = redis_admin_services._streaming_celery_clear
+
+    def _slow_streaming(*args, progress_callback=None, **kwargs):
+        # Wrap the operator's progress_callback with a sleep so the
+        # cancel request has time to land between chunks. Each
+        # chunk advances the LRANGE; the sleep gives the test main
+        # thread a window to flip cancel_requested=1 before the
+        # next chunk is processed.
+        original_cb = progress_callback
+
+        def _gated_cb(snapshot):
+            chunks_seen_before_cancel.append(snapshot)
+            cancel_seen.set()
+            time.sleep(0.05)  # let the test thread set cancel
+            if original_cb is None:
+                return False
+            return original_cb(snapshot)
+
+        return real_streaming(*args, progress_callback=_gated_cb, **kwargs)
+
+    with mock.patch.object(
+        redis_admin_services, "_streaming_celery_clear", _slow_streaming
+    ):
+        job_id = start_celery_broker_clear_job(
+            queue,
+            user=superuser,
+            task_name=None,
+            repoid=1,
+            commitid="x" * 40,
+            keep_one=False,
+            dry_run=False,
+        )
+        # Wait for the first chunk callback to fire so the worker
+        # has loaded its filter and seen at least one chunk's worth
+        # of envelopes.
+        assert cancel_seen.wait(timeout=5.0)
+        ok = request_cancel_celery_broker_clear_job(job_id)
+        assert ok is True
+        _wait_for_job(job_id, timeout=30.0)
+
+    job = get_celery_broker_clear_job(job_id)
+    assert job is not None
+    assert job["status"] == "cancelled"
+    matched = int(job["matched"])
+    # Cancel landed mid-pass: matched should be > 0 (at least one
+    # chunk's worth) and < the total match count.
+    assert 0 < matched < matches
+    # The queue still has remaining matches (cancel left them in
+    # place) — LLEN is at most `matches` minus whatever was LSET'd.
+    remaining = patched_broker.llen(queue)
+    assert remaining == matches - matched, (
+        f"expected remaining={matches - matched}, got {remaining}; matched={matched}"
+    )
+
+
+def test_clear_job_keep_one_leaves_one_at_head(patched_broker, superuser):
+    """`keep_one=True` chunked variant: every match cleared except
+    the lowest-index one, which survives at index 0. Mirrors
+    `test_celery_broker_clear_keep_one_deep_queue_leaves_exactly_one_at_head`
+    but exercises the chunked code path.
+    """
+
+    queue = "bundle_analysis"
+    matches = 2_500  # > CELERY_BROKER_DISPLAY_LIMIT in the default test
+    repoid = 1
+    commitid = "y" * 40
+    _push_envelopes(patched_broker, queue, n=matches, repoid=repoid, commitid=commitid)
+
+    job_id = start_celery_broker_clear_job(
+        queue,
+        user=superuser,
+        task_name=None,
+        repoid=repoid,
+        commitid=commitid,
+        keep_one=True,
+        dry_run=False,
+    )
+    _wait_for_job(job_id, timeout=30.0)
+
+    job = get_celery_broker_clear_job(job_id)
+    assert job is not None
+    assert job["status"] == "completed"
+    assert int(job["matched"]) == matches - 1
+    # Exactly one survivor remains, at the head of the queue.
+    assert patched_broker.llen(queue) == 1
+    survivor_raw = patched_broker.lindex(queue, 0)
+    assert isinstance(survivor_raw, bytes)
+    parsed = json.loads(survivor_raw.decode())
+    body_b64 = parsed["body"]
+    decoded_body = json.loads(base64.b64decode(body_b64).decode())
+    assert decoded_body[1]["repoid"] == repoid
+
+
+def test_clear_job_failure_records_status_failed_and_swallows_exception(
+    patched_broker, superuser
+):
+    """A worker exception (broker outage, malformed envelope,
+    LLEN miss-fire) lands as `status=failed` with the exception's
+    `str(...)` recorded in the `error` field, and never propagates
+    to the caller. The thread must exit cleanly.
+    """
+
+    _push_envelopes(patched_broker, "bundle_analysis", n=10, repoid=1)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated broker outage")
+
+    with mock.patch.object(redis_admin_services, "_streaming_celery_clear", _boom):
+        job_id = start_celery_broker_clear_job(
+            "bundle_analysis",
+            user=superuser,
+            task_name=None,
+            repoid=1,
+            commitid=None,
+            keep_one=False,
+            dry_run=False,
+        )
+        _wait_for_job(job_id, timeout=10.0)
+
+    job = get_celery_broker_clear_job(job_id)
+    assert job is not None
+    assert job["status"] == "failed"
+    assert "simulated broker outage" in job["error"]
+    # No exception was raised in the test thread (we're past the
+    # `with` block); the assertion below is redundant but explicit.
+    assert True
+
+
+# ---- View layer ------------------------------------------------------------
+
+
+def _admin_instance() -> CeleryBrokerQueueAdmin:
+    return CeleryBrokerQueueAdmin(model=CeleryBrokerQueue, admin_site=AdminSite())
+
+
+def test_clear_job_status_view_returns_json_for_running_job(patched_broker, superuser):
+    """The status JSON endpoint returns the pinned shape so the
+    progress-page JS can rely on the field set across deploys.
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=3, repoid=1)
+    job_id = start_celery_broker_clear_job(
+        queue,
+        user=superuser,
+        task_name=None,
+        repoid=1,
+        commitid=None,
+        keep_one=False,
+        dry_run=True,
+    )
+    _wait_for_job(job_id)
+
+    rf = RequestFactory()
+    request = rf.get(
+        f"/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/{job_id}/status/"
+    )
+    request.user = superuser
+
+    admin_instance = _admin_instance()
+    response = admin_instance.clear_by_filter_status_view(request, uuid.UUID(job_id))
+    assert response.status_code == 200
+    payload = json.loads(response.content)
+    expected_fields = {
+        "job_id",
+        "status",
+        "is_terminal",
+        "queue_name",
+        "filter_task",
+        "filter_repoid",
+        "filter_commitid",
+        "dry_run",
+        "keep_one",
+        "started_at",
+        "updated_at",
+        "completed_at",
+        "total_estimated",
+        "processed",
+        "matched",
+        "drifted",
+        "passes_run",
+        "error",
+        "cancel_requested",
+    }
+    assert expected_fields <= set(payload.keys())
+    assert payload["job_id"] == job_id
+    assert payload["queue_name"] == queue
+    assert payload["filter_repoid"] == "1"
+    assert payload["dry_run"] is True
+    # ints stay ints in JSON, not stringified.
+    assert isinstance(payload["total_estimated"], int)
+    assert isinstance(payload["processed"], int)
+
+
+def test_clear_job_cancel_view_requires_post(patched_broker, superuser):
+    """`clear_by_filter_cancel_view` rejects GET with 405 so a
+    drive-by browser navigation can't accidentally cancel a clear.
+    """
+
+    job_id = start_celery_broker_clear_job(
+        "notify",
+        user=superuser,
+        task_name=None,
+        repoid=1,
+        commitid=None,
+        keep_one=False,
+        dry_run=True,
+    )
+    _wait_for_job(job_id)
+    rf = RequestFactory()
+    request = rf.get(
+        f"/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/{job_id}/cancel/"
+    )
+    request.user = superuser
+
+    admin_instance = _admin_instance()
+    response = admin_instance.clear_by_filter_cancel_view(request, uuid.UUID(job_id))
+    assert response.status_code == 405
+    # Allow header announces POST as the legal verb so an HTTP-
+    # aware client can recover automatically.
+    assert "POST" in response.get("Allow", "")
+
+
+def test_clear_job_status_view_404_for_unknown_id(patched_broker, superuser):
+    """Unknown / expired job ids return 404 JSON instead of 500ing
+    or rendering an empty progress page.
+    """
+
+    rf = RequestFactory()
+    fake_id = uuid.uuid4()
+    request = rf.get(
+        f"/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/{fake_id}/status/"
+    )
+    request.user = superuser
+
+    admin_instance = _admin_instance()
+    response = admin_instance.clear_by_filter_status_view(request, fake_id)
+    assert response.status_code == 404
+    payload = json.loads(response.content)
+    assert payload["error"] == "not_found"
+    assert payload["job_id"] == str(fake_id)
+
+
+def test_clear_by_filter_view_redirects_to_progress_page_on_confirmed_submit(
+    patched_broker, superuser
+):
+    """A confirmed clear_all submit on `clear_by_filter_view`
+    spawns a job (via the patched `start_celery_broker_clear_job`)
+    and 302s to `…/clear-by-filter/job/<uuid>/`. The previous
+    behaviour (synchronous `celery_broker_clear`) would have
+    redirected to the changelist instead.
+    """
+
+    queue = "notify"
+    # Push enough messages that the streaming-count path runs.
+    _push_envelopes(patched_broker, queue, n=2, repoid=1)
+    rf = RequestFactory()
+
+    fake_job_id = "11111111-2222-3333-4444-555555555555"
+
+    with (
+        mock.patch.object(
+            redis_admin_services,
+            "start_celery_broker_clear_job",
+            return_value=fake_job_id,
+        ) as start_mock,
+        mock.patch(
+            "redis_admin.admin.start_celery_broker_clear_job",
+            return_value=fake_job_id,
+        ),
+    ):
+        request = rf.post(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+            data={
+                "queue_name": queue,
+                "repoid": "1",
+                "action": "clear_all",
+                "typed_confirm": queue,
+            },
+        )
+        request.user = superuser
+        admin_instance = _admin_instance()
+        response = admin_instance.clear_by_filter_view(request)
+
+    assert response.status_code == 302
+    assert response["Location"].endswith(f"/clear-by-filter/job/{fake_job_id}/"), (
+        response["Location"]
+    )
+    # Sanity: the synchronous service was NOT invoked.
+    start_mock.assert_not_called()  # patched at module-level, not used
+
+
+def test_clear_by_filter_view_dry_run_preview_unchanged(patched_broker, superuser):
+    """The dry-run action keeps the synchronous shape: it calls
+    `celery_broker_clear(dry_run=True)`, re-renders the preview
+    page, and never spawns a chunked job. Pin so a future refactor
+    that fans dry-run out to a chunked job has to update this
+    test deliberately.
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=2, repoid=1)
+    rf = RequestFactory()
+
+    with mock.patch("redis_admin.admin.start_celery_broker_clear_job") as start_mock:
+        request = rf.post(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+            data={
+                "queue_name": queue,
+                "repoid": "1",
+                "action": "dry_run",
+            },
+        )
+        request.user = superuser
+        admin_instance = _admin_instance()
+        # `messages` middleware isn't installed on the bare
+        # RequestFactory; the view calls `messages.info(...)`. We
+        # use a stand-in storage so the call doesn't raise.
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        response = admin_instance.clear_by_filter_view(request)
+
+    # Dry-run re-renders the preview (200 OK, not 302) and never
+    # touches the chunked-job code path.
+    assert response.status_code == 200
+    start_mock.assert_not_called()
+
+
+# ---- Audit log (django_db) -------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_clear_job_writes_audit_row_on_completion_with_chunked_mode(
+    patched_broker,
+):
+    """The chunked worker writes a `LogEntry` at job-completion
+    (not job-start) with `mode` reflecting the chunked variant
+    (    `chunked-all-from-bucket` / `chunked-all-but-first` /
+    `chunked-dry-run`) and a `job_id` extra. Pinned so the audit
+    trail can distinguish chunked from synchronous clears.
+    """
+
+    user = UserFactory()
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=3, repoid=1)
+
+    initial = LogEntry.objects.filter(user_id=user.id).count()
+    job_id = start_celery_broker_clear_job(
+        queue,
+        user=user,
+        task_name=None,
+        repoid=1,
+        commitid=None,
+        keep_one=False,
+        dry_run=False,
+    )
+    _wait_for_job(job_id)
+
+    entries = list(LogEntry.objects.filter(user_id=user.id).order_by("-action_time"))
+    assert len(entries) == initial + 1
+    payload = json.loads(entries[0].change_message)
+    assert payload["scope"] == "celery_broker_clear"
+    assert payload["mode"] == "chunked-all-from-bucket"
+    assert payload["job_id"] == job_id
+    assert payload["cancelled"] is False
+    assert "passes_run" in payload
+    assert "total_lset" in payload

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
@@ -262,6 +262,13 @@ def test_clear_job_processes_in_chunks_and_updates_progress_monotonically(
     # Per-chunk processed delta is at most `chunk_size`.
     for snap in snapshots:
         assert snap.processed_delta <= _CELERY_CLEAR_CHUNK_JOB
+    # `_ChunkProgress.chunk_index` is documented as 0-based: the
+    # first snapshot reports 0, the last reports `chunks_total - 1`,
+    # and the values strictly ascend by 1 across snapshots in a pass.
+    expected_chunk_indices = list(range(len(snapshots)))
+    assert [snap.chunk_index for snap in snapshots] == expected_chunk_indices
+    assert snapshots[0].chunk_index == 0
+    assert snapshots[-1].chunk_index == snapshots[-1].chunks_total - 1
 
 
 def test_clear_job_drains_deep_queue_end_to_end(patched_broker, superuser):

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
@@ -655,7 +655,7 @@ def test_clear_by_filter_view_dry_run_preview_unchanged(patched_broker, superuse
 # ---- Audit log (django_db) -------------------------------------------------
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_clear_job_writes_audit_row_on_completion_with_chunked_mode(
     patched_broker,
 ):

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -52,6 +52,7 @@ from redis_admin.services import (
     _CELERY_TOMBSTONE_PREFIX,
     _FILTER_ANY,
     _streaming_celery_clear,
+    _substitute_filter_any,
     celery_broker_clear,
     streaming_celery_count,
 )
@@ -602,6 +603,93 @@ def test_queryset_ordering_by_repoid(patched_broker):
     )
 
     assert [r.repoid for r in rows] == [1, 2, 3]
+
+
+# ---- helper: _substitute_filter_any ----------------------------------------
+
+
+def test_substitute_filter_any_passes_through_set_slots():
+    """Set slots survive verbatim — no mangling, no `_FILTER_ANY`."""
+
+    triple = _substitute_filter_any(
+        "app.tasks.notify.NotifyTask",
+        21222368,
+        "0832c110a744ddb8185bfdf0524aad41d3c3d21a",
+    )
+
+    assert triple == (
+        "app.tasks.notify.NotifyTask",
+        21222368,
+        "0832c110a744ddb8185bfdf0524aad41d3c3d21a",
+    )
+
+
+def test_substitute_filter_any_substitutes_unset_slots_with_wildcard():
+    """All-`None` input becomes the all-wildcards triple — the
+    "unconstrained operator filter" shape that
+    `streaming_celery_count`, the chunked clear job, and the
+    `clear_by_filter_view` synthetic target all need to share so
+    they agree on which envelopes match.
+    """
+
+    triple = _substitute_filter_any(None, None, None)
+
+    assert triple == (_FILTER_ANY, _FILTER_ANY, _FILTER_ANY)
+
+
+def test_substitute_filter_any_treats_empty_string_as_unset_for_strings_only():
+    """`task_name` and `commitid` are strings whose empty value
+    means "unset" (the admin form coerces missing input to
+    `""`); `repoid` is an integer where `0` is checked via
+    `is not None` so a hypothetical literal `0` would pass
+    through verbatim rather than silently turning into
+    wildcard.
+    """
+
+    triple = _substitute_filter_any("", 0, "")
+
+    assert triple == (_FILTER_ANY, 0, _FILTER_ANY)
+
+
+def test_substitute_filter_any_keeps_streaming_count_and_clear_job_in_sync():
+    """Regression for Bugbot review on PR #904 (LOW severity):
+    the `_FILTER_ANY`-substitution rule is shared across
+    `streaming_celery_count`, `_run_celery_broker_clear_job_body`,
+    and the `clear_by_filter_view` filter target. All three must
+    produce the same triple for the same operator input or the
+    dry-run count would silently disagree with the chunked
+    clear's matched count — a data-loss vector.
+
+    Pin the contract here so a future helper-edit that breaks one
+    consumer breaks the test rather than letting the three call
+    sites drift.
+    """
+
+    inputs = [
+        (None, None, None),
+        ("app.tasks.notify.NotifyTask", None, None),
+        (None, 42, None),
+        (None, None, "abc" * 10),
+        ("app.tasks.upload.UploadTask", 7, "deadbeef" * 5),
+    ]
+
+    for task_name, repoid, commitid in inputs:
+        # Build the triple via the helper (the path the three
+        # production call sites now share) and via the literal
+        # inline expression that those sites used to repeat;
+        # they must agree element-by-element so refactoring one
+        # call site can never make it disagree with the others.
+        helper_triple = _substitute_filter_any(task_name, repoid, commitid)
+        inline_triple = (
+            task_name if task_name else _FILTER_ANY,
+            repoid if repoid is not None else _FILTER_ANY,
+            commitid if commitid else _FILTER_ANY,
+        )
+        assert helper_triple == inline_triple, (
+            f"helper diverged from inline contract for input "
+            f"{(task_name, repoid, commitid)!r}: "
+            f"{helper_triple!r} != {inline_triple!r}"
+        )
 
 
 # ---- service: celery_broker_clear ------------------------------------------

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -50,6 +50,7 @@ from redis_admin.queryset import (
 from redis_admin.services import (
     _CELERY_MAX_PASSES,
     _CELERY_TOMBSTONE_PREFIX,
+    _FILTER_ANY,
     _streaming_celery_clear,
     celery_broker_clear,
     streaming_celery_count,
@@ -2724,7 +2725,7 @@ def test_celery_broker_clear_synthetic_target_with_wildcard_task_name_drains_all
 
     synthetic = CeleryBrokerQueue(
         queue_name=queue,
-        task_name=None,
+        task_name=_FILTER_ANY,
         repoid=repoid,
         commitid=commitid,
         index_in_queue=None,
@@ -2739,3 +2740,70 @@ def test_celery_broker_clear_synthetic_target_with_wildcard_task_name_drains_all
 
     assert result.count == 5
     assert patched_broker.llen(queue) == 1
+
+
+def test_celery_broker_clear_per_message_target_does_not_overmatch_on_none_slots(
+    patched_broker,
+):
+    """Regression for Bugbot review on PR #903 (HIGH severity): the
+    wildcard semantic must NOT bleed into the per-message clear
+    paths (`clear_selected`, `clear_dry_run`, `delete_model`,
+    `delete_queryset`). Those paths build filter tuples from
+    materialised rows whose envelope legitimately carries `None`
+    in a slot (e.g. a `sync_repos` task with `repoid=None` and
+    `commitid=None`); if `None` doubled as the wildcard value, a
+    single-row clear of one such envelope would tombstone EVERY
+    message with that task name across the queue.
+
+    The fix uses a dedicated `_FILTER_ANY` sentinel for "do not
+    constrain on this slot", so materialised targets carrying
+    real `None` values keep exact-tuple-membership semantics:
+    they match only envelopes with the same `(task, None, None)`
+    triple, not any envelope sharing the task name.
+    """
+
+    queue = "celery"
+    task = "app.tasks.sync_repos.SyncReposTask"
+
+    pipe = patched_broker.pipeline(transaction=False)
+    # Two `sync_repos` envelopes that legitimately carry no
+    # repoid / commitid (the SyncReposTask doesn't ship those).
+    for _ in range(2):
+        pipe.rpush(queue, _build_envelope(task=task, kwargs={}))
+    # Three `sync_repos` envelopes carrying a real `(repoid, commitid)`
+    # -- a hypothetical future call shape, but the test only needs
+    # them to be distinguishable from the `(None, None)` shape so
+    # the no-overmatch assertion has bite.
+    for repoid in (1, 2, 3):
+        pipe.rpush(
+            queue,
+            _build_envelope(
+                task=task, kwargs={"repoid": repoid, "commitid": "abc" * 10}
+            ),
+        )
+    pipe.execute()
+    user = SimpleNamespace(id=1, pk=1)
+
+    # Per-message target shape: materialised row carrying the
+    # envelope's actual `(None, None)` slots.
+    materialised_target = CeleryBrokerQueue(
+        queue_name=queue,
+        task_name=task,
+        repoid=None,
+        commitid=None,
+        index_in_queue=0,
+    )
+
+    result = celery_broker_clear(
+        [materialised_target],
+        user=user,
+        dry_run=False,
+        keep_one=False,
+    )
+
+    # Only the two `(task, None, None)` envelopes get tombstoned;
+    # the three task-matching envelopes with real (repoid, commit)
+    # slots survive because exact-tuple-membership distinguishes
+    # `None` from "unconstrained."
+    assert result.count == 2
+    assert patched_broker.llen(queue) == 3


### PR DESCRIPTION
## Summary

Re-purposes the (already-approved) PR #904 for this next round of redis_admin work, layered on top of #903's just-merged `main`:

1. **HIGH-severity wildcard data-loss fix** (cherry-pick of `77047ba8` from the now-orphaned post-#903 branch). `_envelope_matches_any_filter` was treating `None` slots in any filter tuple as wildcards, but per-message clear paths build filter tuples directly from materialised rows whose envelope legitimately carries `None` (e.g. a `sync_repos` task with `repoid=None, commitid=None`). Single-row clear of one such message would have tombstoned EVERY message sharing the task name. Fix introduces a dedicated `_FILTER_ANY` sentinel singleton distinct from `None`; per-message paths keep exact-tuple semantics, operator-input paths (`streaming_celery_count`, `clear_by_filter_view`'s synthetic target) substitute `_FILTER_ANY` for unset slots and get wildcard semantics.

2. **Chunked clear with progress bar.** `clear_by_filter_view`'s confirmed-submit no longer runs the streaming clear synchronously inside the HTTP request — it spawns a background daemon thread tracked in the Redis cache connection under `redis_admin:celery_clear_job:<uuid>` and 302s the browser to a progress page that polls a status JSON endpoint every 1s. The page renders a live `<progress>` bar, matched / total / drift / pass counters, status pill (neutral / blue / green / amber / red), and a Cancel button that drops out at the next chunk boundary (default 1000 messages per chunk in the chunked variant; the synchronous path keeps its existing 10k chunk size). Job hashes get a 24h TTL so abandoned ones auto-cleanup.

## Why this lives on PR #904 (not a fresh PR)

PR #904 was already approved before #903 merged. We've reset its branch to `main`, cherry-picked the data-loss sentinel fix on top, and rebuilt the chunked-progress diff there so we can ride the existing approval through the merge queue rather than block on a fresh review cycle. **Approval may auto-invalidate on the force-push depending on branch protection — re-request review if so.**

## Folded historical PRs

- #903 — merged on main as `b96458ca9`. Its diff (streaming chart + clear + orjson + display vs scan caps) is already on `main`.
- #904 — repurposed as this PR (you're reading it). The original diff (streaming-clear-unbounded fix) shipped via #903's chain.
- #905 — left **OPEN** as historical reference; do not close.

## Call sites

| Site | Line | Calls |
|---|---|---|
| `redis_admin/admin.py` (`clear_by_filter_view` confirmed submit) | `services.py:~2059` | `start_celery_broker_clear_job(...)` then 302 to progress page |
| `redis_admin/admin.py` (`get_urls`) | `~1785–1798` | Three new URL patterns under `clear-by-filter/job/<uuid:job_id>/` |
| `redis_admin/admin.py` (`clear_by_filter_progress_view`) | `~2180` | `get_celery_broker_clear_job(job_id_str)` |
| `redis_admin/admin.py` (`clear_by_filter_status_view`) | `~2228` | `get_celery_broker_clear_job(job_id_str)` |
| `redis_admin/admin.py` (`clear_by_filter_cancel_view`) | `~2277` | `request_cancel_celery_broker_clear_job(job_id_str)` then `get_celery_broker_clear_job` |
| `redis_admin/services.py` (`_run_celery_broker_clear_job_body`) | inside the worker thread | `_streaming_celery_clear(..., chunk_size=_CELERY_CLEAR_CHUNK_JOB, progress_callback=...)`, `_record_audit(..., extra={"mode": "chunked-...", "job_id": ..., "cancelled": ...})` |
| `redis_admin/services.py` (`_streaming_celery_clear`) | unchanged callers | Synchronous `celery_broker_clear` continues to call without `chunk_size` / `progress_callback`; default behaviour preserved (no test regressions). |

## Test plan

- [ ] Wildcard sentinel: per-message clear of `sync_repos`-shaped envelope tombstones only the selected message (covered by tests cherry-picked in `8566f3f83`).
- [ ] Chunked clear: 5k-deep queue drains via background job + progress polling (`test_clear_job_drains_deep_queue_end_to_end`).
- [ ] Cancel: mid-job cancel halts at chunk boundary, leaves remaining matches intact (`test_clear_job_cancel_stops_at_chunk_boundary`).
- [ ] Keep_one chunked: leaves exactly one survivor at head of queue (`test_clear_job_keep_one_leaves_one_at_head`).
- [ ] Audit log: chunked-mode entry written at job completion (`test_clear_job_writes_audit_row_on_completion_with_chunked_mode`, `django_db`).
- [ ] Failure path: worker exception sets `status=failed`, doesn't bubble to caller (`test_clear_job_failure_records_status_failed_and_swallows_exception`).
- [ ] Status JSON shape pinned by tests (`test_clear_job_status_view_returns_json_for_running_job`).
- [ ] Cancel view requires POST (`test_clear_job_cancel_view_requires_post`).
- [ ] Unknown-id 404 (`test_clear_job_status_view_404_for_unknown_id`).
- [ ] Confirmed submit redirects to progress page, dry-run preview unchanged (`test_clear_by_filter_view_redirects_to_progress_page_on_confirmed_submit`, `test_clear_by_filter_view_dry_run_preview_unchanged`).
- [ ] Existing tests on `main` still pass (drain verification, sort order, family filter dropdown, dry-run preview, streaming-clear keep_one, etc).

## What's in this PR (file-level)

- `apps/codecov-api/redis_admin/services.py` — `_streaming_celery_clear` accepts `chunk_size` + `progress_callback`; new `start_/get_/request_cancel_celery_broker_clear_job` + the daemon worker; new `_StreamingClearStats.cancelled` field; `_FILTER_ANY` sentinel from the cherry-pick.
- `apps/codecov-api/redis_admin/admin.py` — three new URL patterns + views (`clear_by_filter_progress_view`, `clear_by_filter_status_view`, `clear_by_filter_cancel_view`); `clear_by_filter_view` rewired so destructive actions spawn a chunked job; dry-run unchanged.
- `apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/clear_by_filter_progress.html` — new (CSP-compliant; loads CSS / JS via `{% static %}`).
- `apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_progress.js` — new (IIFE, polling + cancel + 1s/2s/5s backoff).
- `apps/codecov-api/redis_admin/static/redis_admin/css/celery_clear_progress.css` — new (Django admin theme variables, `prefers-reduced-motion` fallback).
- `apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py` — new (12 tests, 11 of which run under `-m 'not django_db'`).
- `apps/codecov-api/redis_admin/README.md` — new "Chunked clear jobs" section; updated URL table.

## Things this PR explicitly does NOT do

- Does NOT close PR #905 (kept as historical reference).
- Does NOT delete the orphan `redis-admin/split-celery-broker-caps` branch (the cherry-pick source).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new background-thread, Redis-backed job system for clearing Celery broker queues and changes the destructive clear-by-filter flow to run asynchronously, which could impact operational queue-clearing behavior if bugs exist. Risk is mitigated by superuser-only gating and extensive new tests, plus a fix to prevent over-broad deletes when filter fields are `None`.
> 
> **Overview**
> Updates the `celerybrokerqueue` admin **clear-by-filter** destructive actions to run as an asynchronous, chunked clear job instead of blocking the HTTP request, redirecting operators to a new progress page that polls a status JSON endpoint and supports cancellation.
> 
> Introduces a Redis cache–stored job state hash + worker thread implementation, extends the streaming clear to support per-chunk progress/cancel callbacks, and adds new admin routes/templates/static assets for the progress UI.
> 
> Fixes a **high-severity filtering bug** by introducing a `_FILTER_ANY` sentinel (distinct from `None`) so operator-supplied “unset” filters act as wildcards without causing per-message clears of `(task, None, None)` envelopes to over-match and delete unrelated messages; adds comprehensive unit tests and docs for both changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4492208c82ff047b23998ecf5029ed1df49933b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->