### PR TITLE
chore(redis_admin): lower frequency-chart sample limit to 20k

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -156,7 +156,7 @@ All configurable via `REDIS_ADMIN_*` Django settings; defaults shown.
 | `REDIS_ADMIN_ITEM_PAGE_SIZE` | `100` | Page size for the items-in-a-queue view. |
 | `REDIS_ADMIN_MAX_ITEMS_PER_KEY` | `20_000` | Hard cap on members materialised from a single SET/HASH for admin browsing (M4). LIST keys use bounded LRANGE windows so they aren't constrained here. |
 | `REDIS_ADMIN_CELERY_BROKER_DISPLAY_LIMIT` | `2_000` | Number of per-message rows materialised on the `celery_broker` changelist drill-down. Smaller than the scan limit because each row keeps a parsed envelope in the per-request cache. |
-| `REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT` | `100_000` | Sample window used by the `celery_broker` frequency chart aggregator. The streaming clear (Clear queue → Clear all) intentionally is *not* bounded by this — it walks the full `LLEN(queue)` so a clear action always drains the entire queue regardless of the chart's sample size. |
+| `REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT` | `20_000` | Sample window used by the `celery_broker` frequency chart aggregator. The streaming clear (Clear queue → Clear all) intentionally is *not* bounded by this — it walks the full `LLEN(queue)` so a clear action always drains the entire queue regardless of the chart's sample size. |
 | `REDIS_ADMIN_MAX_DECODE_BYTES` | `4_096` | Per-value display truncation. |
 | `REDIS_ADMIN_DELETE_BATCH_SIZE` | `500` | Pipeline batch size for `DEL` / `LREM` / `SREM` / `HDEL`. |
 | `REDIS_ADMIN_CONNECTION_FACTORY` | unset | Dotted path to a callable returning a `redis.Redis`. Defaults to `shared.helpers.redis.get_redis_connection`. |

--- a/apps/codecov-api/redis_admin/settings.py
+++ b/apps/codecov-api/redis_admin/settings.py
@@ -48,7 +48,7 @@ CELERY_BROKER_DISPLAY_LIMIT: int = getattr(
 # always drains the entire queue, even if the user is targeting matches
 # beyond the chart's sample window.
 CELERY_BROKER_SCAN_LIMIT: int = getattr(
-    settings, "REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT", 100_000
+    settings, "REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT", 20_000
 )
 
 # Pipeline batch size for delete operations (M5). Keeps a single delete action

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/change_list.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/change_list.html
@@ -29,7 +29,7 @@ In summary mode (queue_name is absent) the block renders nothing extra.
       <div class="celery-chart-loader" role="status" aria-live="polite">
         <div class="celery-chart-loader__spinner" aria-hidden="true"></div>
         <p class="celery-chart-loader__label">Loading frequency chart&hellip;</p>
-        <p class="celery-chart-loader__hint">Sampling up to {{ scan_limit_label|default:"100,000" }} messages from <code>{{ queue_name }}</code> &mdash; this can take a few seconds on deep queues.</p>
+        <p class="celery-chart-loader__hint">Sampling up to {{ scan_limit_label|default:"20,000" }} messages from <code>{{ queue_name }}</code> &mdash; this can take a few seconds on deep queues.</p>
       </div>
     </div>
     <script src="{% static 'redis_admin/js/celery_chart_fragment.js' %}" defer></script>


### PR DESCRIPTION
## Summary

`REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT` defaults from `100_000` → `20_000`. This is the sample window the streaming frequency chart aggregator (`_stream_frequency_aggregate`) walks against the queue's head before bucketing by `(task, repoid, commitid)`. 100k was well-sized for accuracy on huge queues but rendered slowly on operator drill-down for the typical case; 20k matches `MAX_ITEMS_PER_KEY` (the generic Redis-browsing cap) so operators only have one "drill-down sample size" mental model.

## What this does NOT change

The streaming clear (`services._streaming_celery_clear`) is intentionally unbounded — it walks the full `LLEN(queue)` so a "Clear queue → Clear all" action always drains the entire queue regardless of this knob. Lowering the chart sample limit therefore can never affect what a clear actually drains; only the chart's accuracy on queues whose head distribution differs from their tail distribution.

## Files changed

- ``apps/codecov-api/redis_admin/settings.py`` — default `100_000` → `20_000`. The setting is still env-overridable via ``REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT`` for operators who want a deeper chart sample on a specific environment.
- ``apps/codecov-api/redis_admin/README.md`` — settings-defaults table updated to ``20_000``.
- ``apps/codecov-api/redis_admin/templates/.../change_list.html`` — fallback label in the chart loader card updated to ``"20,000"`` so a missing-context-variable render still shows the new default rather than the old ``100,000``.

## Test plan

- [ ] Existing tests still pass — none reference the literal value (they use ``redis_admin_settings.CELERY_BROKER_SCAN_LIMIT``).
- [ ] Manual: load ``/admin/redis_admin/celerybrokerqueue/?queue_name__exact=bundle_analysis`` against a deep queue; chart loader card now reads "Sampling up to 20,000 messages…", chart renders faster than before, top-N buckets look reasonable.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts the default sampling cap used for the celery broker frequency chart and updates related UI/docs, with no impact on queue clearing behavior or data mutation.
> 
> **Overview**
> Lowers the default `REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT` from `100_000` to `20_000`, reducing how many messages the celery broker drill-down frequency chart samples by default.
> 
> Updates the admin drill-down loader hint and `redis_admin` README settings table to reflect the new default value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d67d13cb6a176d5aeead23ca60b44f18134dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->