### PR TITLE
perf(redis_admin): lazy clear-by-filter preview (count off the request thread)

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -40,7 +40,9 @@ accidentally surfaces them under `RedisQueue`.
 | `/admin/redis_admin/redisqueueitem/<token>/change/` | Inspect a single item |
 | `/admin/redis_admin/celerybrokerqueue/` | **Celery summary** — one row per known celery_broker queue with current `LLEN` and a drill-in link |
 | `/admin/redis_admin/celerybrokerqueue/?queue_name__exact=<queue>` | **Celery drill-down** — messages inside a celery broker queue with structured task / repoid / commitid columns, a `(repoid, commitid)` frequency chart, and per-message clear |
-| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/` | Preview + clear messages in `<queue>` matching a `(task_name?, repoid?, commitid?)` filter (POST-only, superuser-only). Wired up by the frequency chart's per-row "Clear queue" button; the preview page exposes three explicit actions (dry-run, clear all but first, clear all). Destructive actions spawn a chunked background job and 302 to the progress page. |
+| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/` | Preview + clear messages in `<queue>` matching a `(task_name?, repoid?, commitid?)` filter (POST-only, superuser-only). Wired up by the frequency chart's per-row "Clear queue" button; the preview page exposes three explicit actions (dry-run, clear all but first, clear all). Destructive actions spawn a chunked background job and 302 to the progress page. The GET handler renders only the form + skeleton placeholders; the count + sample are fetched asynchronously by the lazy-preview JS (see below). |
+| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/` | JSON preview endpoint hit by the page's JS (superuser-only). Returns `{mode: "synchronous", match_count, kept_index, sample, cached_at?}` for queues below `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT`, or `{mode: "job", job_id, status_url, sample}` for deeper queues (the JS then polls the existing clear-job status endpoint). `?bust=1` skips the cache. |
+| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/skip-count/` | Tier 4 escape hatch (superuser-only). 302s back to `clear-by-filter/?count_skipped=1` so the operator can type the queue name + clear without waiting for the count to compute. |
 | `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/` | Progress page for a chunked clear job (HTML, superuser-only). Polls the status JSON view every ~1s; renders a `<progress>` bar, matched / total / drift / pass counters, and a Cancel button. |
 | `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/status/` | JSON snapshot of a chunked clear job (superuser-only); 404s on unknown / expired ids. |
 | `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/cancel/` | POST-only cancel endpoint (superuser-only); flags `cancel_requested=1` and returns 202 with the latest snapshot. Cancel lands at the next chunk boundary. |
@@ -159,6 +161,8 @@ All configurable via `REDIS_ADMIN_*` Django settings; defaults shown.
 | `REDIS_ADMIN_CELERY_BROKER_SCAN_LIMIT` | `20_000` | Sample window used by the `celery_broker` frequency chart aggregator. The streaming clear (Clear queue → Clear all) intentionally is *not* bounded by this — it walks the full `LLEN(queue)` so a clear action always drains the entire queue regardless of the chart's sample size. |
 | `REDIS_ADMIN_MAX_DECODE_BYTES` | `4_096` | Per-value display truncation. |
 | `REDIS_ADMIN_DELETE_BATCH_SIZE` | `500` | Pipeline batch size for `DEL` / `LREM` / `SREM` / `HDEL`. |
+| `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT` | `200_000` | `LLEN(queue)` threshold above which the lazy `clear-by-filter/preview/` JSON endpoint stops trying to compute the count synchronously and instead spawns a `dry_run=True` chunked-clear background job. Below the threshold the synchronous walk + 60s cache keep the endpoint sub-second; above it the JS switches into polling the existing job-status hash. |
+| `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_CACHE_TTL_SECONDS` | `60` | TTL for the synchronous-mode preview count cache (cache Redis key `redis_admin:preview_count:<sha256(queue\|task\|repoid\|commitid)>`). Refresh / Back-Forward / multiple browser tabs return the cached count instantly; `?bust=1` on the preview endpoint skips the cache. |
 | `REDIS_ADMIN_CONNECTION_FACTORY` | unset | Dotted path to a callable returning a `redis.Redis`. Defaults to `shared.helpers.redis.get_redis_connection`. |
 | `REDIS_ADMIN_BROKER_CONNECTION_FACTORY` | unset | Dotted path for the Celery broker connection. Defaults to building a client from `services.celery_broker` (falls back to `services.redis_url` for single-Redis dev/enterprise). |
 
@@ -306,6 +310,70 @@ and the audit log captures the operation under
 For backward compatibility, the older `action=confirm` form
 shape (paired with `mode=all` / `mode=keep_one`) is aliased to
 the new actions so stale tabs and scripts keep working.
+
+### Lazy clear-by-filter preview
+
+The preview page used to call `streaming_celery_count` +
+materialise up to `CELERY_BROKER_DISPLAY_LIMIT` rows in the GET
+handler before painting anything. On a 1M-deep queue that's tens
+of seconds of blocking work in the gunicorn request thread before
+the operator sees a single byte. The preview now lays out in four
+tiers, each one taking a chunk out of the perceived render time:
+
+**Tier 1 — lazy preview load.** The GET handler renders the
+filter summary, typed-confirm form, and skeleton placeholders for
+the count + sample table in `< 200ms`, with no Redis scans. The
+submit buttons (`Dry-run` / `Clear all but first` / `Clear all`)
+start disabled. A separate JSON endpoint
+(`clear-by-filter/preview/`) computes the count + sample on
+demand; `celery_clear_by_filter_preview.js` fetches it on
+`DOMContentLoaded`, fills the count card, renders the sample, and
+unlocks the submit buttons.
+
+**Tier 2 — background count job for huge queues.** Above
+`REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT` (default
+200_000) the preview endpoint returns
+`{mode: "job", job_id, status_url}` and kicks off a `dry_run=True`
+chunked-clear job (the existing
+`start_celery_broker_clear_job` machinery — no new infrastructure).
+The JS then polls the status endpoint every ~1s; on
+`status=completed` it reads `matched` off the job hash as the
+match count and unlocks the buttons. The dry-run job's audit
+entry uses `mode="chunked-dry-run"`, so it slots into the same
+audit feed as a manual dry-run from the preview page itself. The
+sample table stays synchronous in both modes (LRANGE 0 N + parse
+is fast even on a 1M queue).
+
+**Tier 3 — short-lived count cache.** Synchronous-mode counts
+get stashed in cache Redis under
+`redis_admin:preview_count:<sha256(queue|task|repoid|commitid)>`
+with a `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_CACHE_TTL_SECONDS`
+TTL (default 60). Refresh / Back-Forward / opening the preview
+in a second tab hit the cache and return instantly with a
+`cached_at` field so the JS can render "Cached at …". The
+endpoint accepts `?bust=1` to skip the cache (a manual refresh-
+count button can use this; the orchestrator
+`resolve_clear_by_filter_preview_count` honours it). Cache writes
+are best-effort: a cache outage degrades to recomputing on every
+call, but never raises.
+
+**Tier 4 — skip-count escape hatch.** A muted-italic
+"Trust the filter, skip the count →" link sits next to the
+destructive submit buttons, visible from page-load. Clicking it
+hits `clear-by-filter/skip-count/?…`, which 302s back to
+`clear-by-filter/?…&count_skipped=1`. The GET handler reads the
+flag, suppresses the loader / count card, and renders the form
+with the destructive buttons unlocked from the start. The
+operator types the queue name → submits → the destructive POST
+spawns the same chunked-clear job as before, and the progress
+page surfaces the live count + matched counter as the clear runs.
+
+The four tiers stack: a deep queue with a warm cache hits Tier 3
+first, returning the cached count without re-walking; a deep
+queue with a cold cache and an inline-limit-busting depth hits
+Tier 2 and polls the job; a typical queue with a typical depth
+hits Tier 1 inline; and at any point the operator can fall back
+to Tier 4 if the count surface is broken or just too slow.
 
 ### Chunked clear jobs (background-thread variant)
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -1997,6 +1997,7 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         # so the GET handler stays Redis-free.
         match_count: int | None = None
         kept_index: int | None = None
+        count_failed = False
         if request.method == "POST" and action in valid_actions:
             try:
                 match_count, kept_index = streaming_celery_count(
@@ -2011,22 +2012,32 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
                     queue_name,
                 )
                 # Defensive fallback: skip the count-based safety
-                # checks rather than render a 500. The destructive
-                # paths still gate on the typed-confirmation, and
-                # `start_celery_broker_clear_job` re-snapshots
-                # `LLEN(queue)` itself so the progress page total
-                # is accurate.
-                match_count = 0
+                # checks rather than render a 500 *or* a misleading
+                # "nothing to clear" no-op redirect. A transient
+                # Redis blip during the count must not silently
+                # convert a legitimate destructive action into a
+                # neutral redirect — the operator typed-confirmed
+                # the queue name, that's the real safety gate. The
+                # destructive paths still re-snapshot the queue
+                # depth from `start_celery_broker_clear_job` so the
+                # progress page total is accurate.
+                count_failed = True
+                match_count = None
                 kept_index = None
 
-            if match_count == 0:
+            if not count_failed and match_count == 0:
                 messages.info(
                     request,
                     "No messages match the filter — nothing to clear.",
                 )
                 return HttpResponseRedirect(changelist_url)
 
-            if action == "clear_keep_one" and match_count <= 1:
+            if (
+                not count_failed
+                and action == "clear_keep_one"
+                and match_count is not None
+                and match_count <= 1
+            ):
                 # Single-message bucket: there's nothing to clear
                 # without removing the only in-flight message,
                 # which defeats the "keep first" semantic. The
@@ -2077,12 +2088,25 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
                         dry_run=True,
                         keep_one=keep_one,
                     )
-                    messages.info(
-                        request,
-                        f"Dry-run: would clear {result.count} of {match_count} "
-                        f"matching message(s) from {queue_name} (audit log "
-                        f"entry written; queue untouched).",
-                    )
+                    if match_count is None:
+                        # Count probe failed earlier; surface that
+                        # in the banner so the operator knows the
+                        # "of N" denominator is missing on purpose.
+                        messages.info(
+                            request,
+                            f"Dry-run: would clear {result.count} matching "
+                            f"message(s) from {queue_name} (count probe "
+                            f"failed; audit log entry written; queue "
+                            f"untouched).",
+                        )
+                    else:
+                        messages.info(
+                            request,
+                            f"Dry-run: would clear {result.count} of "
+                            f"{match_count} matching message(s) from "
+                            f"{queue_name} (audit log entry written; "
+                            f"queue untouched).",
+                        )
                 else:
                     # Destructive: fan out to a background thread so a
                     # 500k-deep queue clear never sits on the gunicorn

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -57,6 +57,7 @@ from .services import (
     _substitute_filter_any,
     celery_broker_clear,
     get_celery_broker_clear_job,
+    get_or_start_clear_by_filter_preview_job,
     redis_delete,
     request_cancel_celery_broker_clear_job,
     resolve_clear_by_filter_preview_count,
@@ -1830,6 +1831,40 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             *urls,
         ]
 
+    @staticmethod
+    def _build_clear_by_filter_querystring(
+        *,
+        queue_name: str,
+        task_name: str | None,
+        repoid: int | None,
+        commitid: str | None,
+        extras: dict[str, str] | None = None,
+    ) -> str:
+        """Single source of truth for the filter querystring the
+        clear-by-filter views hand each other.
+
+        `clear_by_filter_view` uses it twice (preview-endpoint URL
+        and skip-count URL); `clear_by_filter_skip_count_view` uses
+        it again with `extras={"count_skipped": "1"}`. The dict-
+        comprehension `if v != ""` filter is preserved so an unset
+        `task_name` doesn't bloat the URL with an empty key.
+
+        Centralising it prevents the four call sites from drifting
+        apart when the filter shape evolves (a future commit
+        tightening `commitid` length or adding a new narrower
+        would otherwise need touching every callsite).
+        """
+
+        items: dict[str, str] = {
+            "queue_name": queue_name,
+            "task_name": task_name or "",
+            "repoid": "" if repoid is None else str(repoid),
+            "commitid": commitid or "",
+        }
+        if extras:
+            items.update(extras)
+        return urlencode({k: v for k, v in items.items() if v != ""})
+
     def _parse_clear_by_filter_params(
         self, request: HttpRequest
     ) -> tuple[dict[str, Any], HttpResponseRedirect | None]:
@@ -2135,17 +2170,11 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         preview_url = reverse(
             f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_preview"
         )
-        preview_query = urlencode(
-            {
-                k: v
-                for k, v in {
-                    "queue_name": queue_name,
-                    "task_name": task_name,
-                    "repoid": "" if repoid is None else str(repoid),
-                    "commitid": commitid,
-                }.items()
-                if v != ""
-            }
+        preview_query = self._build_clear_by_filter_querystring(
+            queue_name=queue_name,
+            task_name=task_name,
+            repoid=repoid,
+            commitid=commitid,
         )
         preview_full_url = (
             f"{preview_url}?{preview_query}" if preview_query else preview_url
@@ -2158,17 +2187,11 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         skip_count_url = reverse(
             f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_skip_count"
         )
-        skip_count_query = urlencode(
-            {
-                k: v
-                for k, v in {
-                    "queue_name": queue_name,
-                    "task_name": task_name,
-                    "repoid": "" if repoid is None else str(repoid),
-                    "commitid": commitid,
-                }.items()
-                if v != ""
-            }
+        skip_count_query = self._build_clear_by_filter_querystring(
+            queue_name=queue_name,
+            task_name=task_name,
+            repoid=repoid,
+            commitid=commitid,
         )
         skip_count_full_url = (
             f"{skip_count_url}?{skip_count_query}"
@@ -2257,12 +2280,24 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
 
         bust_cache = (request.GET.get("bust") or "").strip() == "1"
 
-        sample_targets = self._materialise_sample_targets(
-            queue_name=queue_name,
-            task_name=task_name or None,
-            repoid=repoid,
-            commitid=commitid or None,
-        )
+        # Sample materialise is wrapped in try/except so a broker
+        # outage degrades to an empty sample table instead of
+        # bubbling Django's HTML 500 page out of a JSON endpoint.
+        # Mirrors the LLEN fallback below — both are best-effort
+        # decorations on the count payload, not the count itself.
+        try:
+            sample_targets = self._materialise_sample_targets(
+                queue_name=queue_name,
+                task_name=task_name or None,
+                repoid=repoid,
+                commitid=commitid or None,
+            )
+        except Exception:
+            log.exception(
+                "redis_admin.clear_by_filter_preview: sample materialise failed for %r",
+                queue_name,
+            )
+            sample_targets = []
         sample_payload = [
             {
                 "index_in_queue": t.index_in_queue,
@@ -2291,14 +2326,17 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         inline_limit = redis_admin_settings.CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT
         if queue_depth > inline_limit:
             opts = self.model._meta
-            job_id = start_celery_broker_clear_job(
+            # Dedup: refresh / multi-tab / JS retry must not spawn N
+            # parallel full-queue scans for the same filter. The
+            # helper returns the in-flight job_id when one is still
+            # running for this filter hash, else spawns a fresh
+            # `dry_run=True` job and caches its id under a short TTL.
+            job_id = get_or_start_clear_by_filter_preview_job(
                 queue_name,
                 user=request.user,
                 task_name=task_name or None,
                 repoid=repoid,
                 commitid=commitid or None,
-                keep_one=False,
-                dry_run=True,
             )
             status_url = reverse(
                 f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_status",
@@ -2402,20 +2440,12 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         preview_url = reverse(
             f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter"
         )
-        query = urlencode(
-            {
-                k: v
-                for k, v in {
-                    "queue_name": parsed["queue_name"],
-                    "task_name": parsed["task_name"],
-                    "repoid": (
-                        "" if parsed["repoid"] is None else str(parsed["repoid"])
-                    ),
-                    "commitid": parsed["commitid"],
-                    "count_skipped": "1",
-                }.items()
-                if v != ""
-            }
+        query = self._build_clear_by_filter_querystring(
+            queue_name=parsed["queue_name"],
+            task_name=parsed["task_name"],
+            repoid=parsed["repoid"],
+            commitid=parsed["commitid"],
+            extras={"count_skipped": "1"},
         )
         return HttpResponseRedirect(f"{preview_url}?{query}")
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -59,6 +59,7 @@ from .services import (
     get_celery_broker_clear_job,
     redis_delete,
     request_cancel_celery_broker_clear_job,
+    resolve_clear_by_filter_preview_count,
     start_celery_broker_clear_job,
     streaming_celery_count,
 )
@@ -1774,7 +1775,23 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             self.admin_site.admin_view(self.clear_by_filter_view),
             name=f"{opts.app_label}_{opts.model_name}_clear_by_filter",
         )
-        # Three new URLs for the chunked-clear background job: a
+        # Lazy preview JSON endpoint hit by the page's JS to fill in
+        # the count + sample once the skeleton has rendered. Two
+        # response modes (synchronous count vs. background job) are
+        # documented on `clear_by_filter_preview_view`.
+        clear_preview_url = path(
+            "clear-by-filter/preview/",
+            self.admin_site.admin_view(self.clear_by_filter_preview_view),
+            name=(f"{opts.app_label}_{opts.model_name}_clear_by_filter_preview"),
+        )
+        # Tier 4 escape hatch: re-renders the preview page with the
+        # count card hidden + destructive submit buttons unlocked.
+        clear_skip_count_url = path(
+            "clear-by-filter/skip-count/",
+            self.admin_site.admin_view(self.clear_by_filter_skip_count_view),
+            name=(f"{opts.app_label}_{opts.model_name}_clear_by_filter_skip_count"),
+        )
+        # Three URLs for the chunked-clear background job: a
         # progress page (HTML), a status JSON endpoint that the
         # progress page polls, and a cancel POST endpoint. All three
         # are routed under `clear-by-filter/job/<uuid:job_id>/...`
@@ -1804,12 +1821,83 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         # custom routes don't get swallowed as object_ids.
         return [
             clear_url,
+            clear_preview_url,
+            clear_skip_count_url,
             clear_progress_url,
             clear_status_url,
             clear_cancel_url,
             chart_fragment_url,
             *urls,
         ]
+
+    def _parse_clear_by_filter_params(
+        self, request: HttpRequest
+    ) -> tuple[dict[str, Any], HttpResponseRedirect | None]:
+        """Shared params extraction + validation for the clear-by-filter
+        family of views (`clear_by_filter_view`,
+        `clear_by_filter_preview_view`, `clear_by_filter_skip_count_view`).
+
+        Returns `(parsed, redirect)`. On a validation error `redirect`
+        is a redirect to the changelist with a flash message; on
+        success `redirect is None` and `parsed` carries
+        `{queue_name, task_name, repoid, commitid, changelist_url,
+         opts}`. This split lets the JSON preview endpoint surface the
+        same shape errors as a 400 response without duplicating the
+        validation rules across views.
+        """
+
+        params = request.POST if request.method == "POST" else request.GET
+        queue_name = (params.get("queue_name") or "").strip()
+        task_name = (params.get("task_name") or "").strip()
+        repoid_raw = (params.get("repoid") or "").strip()
+        commitid = (params.get("commitid") or "").strip()
+
+        opts = self.model._meta
+        changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+        if queue_name:
+            changelist_url = (
+                f"{changelist_url}?{urlencode({'queue_name__exact': queue_name})}"
+            )
+
+        if not queue_name:
+            messages.error(request, "queue_name is required for clear-by-filter")
+            return {}, HttpResponseRedirect(changelist_url)
+
+        repoid: int | None = None
+        if repoid_raw:
+            try:
+                repoid = int(repoid_raw)
+            except ValueError:
+                messages.error(
+                    request,
+                    f"repoid must be an integer; got {repoid_raw!r}",
+                )
+                return {}, HttpResponseRedirect(changelist_url)
+
+        # At least one narrowing filter beyond the queue is required —
+        # otherwise this view collapses into "clear the whole queue",
+        # which the M5 `clear_by_scope` flow already owns. Keeping
+        # the surfaces non-overlapping prevents two ways to do the
+        # same thing with subtly different audit-log shapes.
+        if repoid is None and not commitid and not task_name:
+            messages.error(
+                request,
+                "Refusing to clear: at least one of task_name, repoid, "
+                "or commitid must be set",
+            )
+            return {}, HttpResponseRedirect(changelist_url)
+
+        return (
+            {
+                "queue_name": queue_name,
+                "task_name": task_name,
+                "repoid": repoid,
+                "commitid": commitid,
+                "changelist_url": changelist_url,
+                "opts": opts,
+            },
+            None,
+        )
 
     def clear_by_filter_view(self, request: HttpRequest) -> HttpResponse:
         """Targeted clear by `(queue_name, task_name?, repoid?, commitid?)`.
@@ -1848,6 +1936,19 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         `services.celery_broker_clear`, which runs the LSET-tombstone
         path and writes the audit log entry under
         `scope="celery_broker_clear"`.
+
+        **GET path is fast.** Renders the form, filter summary, and
+        skeleton placeholders for the count + sample table; the JS
+        in `celery_clear_by_filter_preview.js` then fetches
+        `clear-by-filter/preview/?…` to fill them in. The previous
+        version did the streaming count + a queryset materialise
+        inside the GET handler, which on a 1M-deep queue was
+        dozens of seconds of blocking work in the gunicorn request
+        thread before the operator saw anything. The
+        `count_skipped` query string sets a flag for the
+        skip-count escape hatch (Tier 4) so the preview page
+        renders without the count card and the destructive submit
+        buttons are unlocked from page-load.
         """
 
         if not request.user.is_superuser:
@@ -1855,11 +1956,16 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
                 "redis_admin clear-by-filter is restricted to superusers"
             )
 
-        params = request.POST if request.method == "POST" else request.GET
-        queue_name = (params.get("queue_name") or "").strip()
-        task_name = (params.get("task_name") or "").strip()
-        repoid_raw = (params.get("repoid") or "").strip()
-        commitid = (params.get("commitid") or "").strip()
+        parsed, redirect = self._parse_clear_by_filter_params(request)
+        if redirect is not None:
+            return redirect
+        queue_name = parsed["queue_name"]
+        task_name = parsed["task_name"]
+        repoid = parsed["repoid"]
+        commitid = parsed["commitid"]
+        changelist_url = parsed["changelist_url"]
+        opts = parsed["opts"]
+
         action = (request.POST.get("action") or "").strip()
         # Backward-compat alias: the previous version of this view
         # used `action=confirm` paired with a `mode` form input. New
@@ -1869,130 +1975,13 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             legacy_mode = (request.POST.get("mode") or "").strip()
             action = "clear_keep_one" if legacy_mode == "keep_one" else "clear_all"
 
-        opts = self.model._meta
-        changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
-        if queue_name:
-            changelist_url = (
-                f"{changelist_url}?{urlencode({'queue_name__exact': queue_name})}"
-            )
-
-        if not queue_name:
-            messages.error(request, "queue_name is required for clear-by-filter")
-            return HttpResponseRedirect(changelist_url)
-
-        repoid: int | None = None
-        if repoid_raw:
-            try:
-                repoid = int(repoid_raw)
-            except ValueError:
-                messages.error(
-                    request,
-                    f"repoid must be an integer; got {repoid_raw!r}",
-                )
-                return HttpResponseRedirect(changelist_url)
-
-        # At least one narrowing filter beyond the queue is required —
-        # otherwise this view collapses into "clear the whole queue",
-        # which the M5 `clear_by_scope` flow already owns. Keeping
-        # the surfaces non-overlapping prevents two ways to do the
-        # same thing with subtly different audit-log shapes.
-        if repoid is None and not commitid and not task_name:
-            messages.error(
-                request,
-                "Refusing to clear: at least one of task_name, repoid, "
-                "or commitid must be set",
-            )
-            return HttpResponseRedirect(changelist_url)
-
-        queryset = self.model._default_manager.all().filter(
-            queue_name__exact=queue_name
-        )
-        if task_name:
-            queryset = queryset.filter(task_name__exact=task_name)
-        if repoid is not None:
-            queryset = queryset.filter(repoid=repoid)
-        if commitid:
-            queryset = queryset.filter(commitid__startswith=commitid)
-        # Cap-bounded sample for the preview table (cheap, in-memory).
-        # The queryset materialises the first `CELERY_BROKER_DISPLAY_LIMIT`
-        # messages, then filters; we trim further to keep the rendered
-        # table compact.
-        sample_targets = sorted(queryset, key=lambda row: row.index_in_queue or 0)[
-            :_CLEAR_BY_FILTER_SAMPLE_SIZE
-        ]
-
-        # `match_count` and `kept_index` come from a streaming pass
-        # over the full queue so the preview agrees with what the
-        # actual clear (also unbounded) would do. Going through the
-        # queryset would underreport whenever `LLEN(queue) >
-        # CELERY_BROKER_DISPLAY_LIMIT` (anything past the 2k materialise
-        # window).
-        try:
-            match_count, kept_index = streaming_celery_count(
-                queue_name,
-                task_name=task_name or None,
-                repoid=repoid,
-                commitid=commitid or None,
-            )
-        except Exception:
-            log.exception(
-                "redis_admin.clear_by_filter: streaming count failed for %r",
-                queue_name,
-            )
-            # Defensive fallback: degrade to the queryset count rather
-            # than render a 500. The operator at least sees something
-            # and can still hit "Clear all" — the streaming clear path
-            # has its own error handling.
-            match_count = len(sample_targets)
-            kept_index = sample_targets[0].index_in_queue if sample_targets else None
-        # Build a single synthetic target carrying the operator's
-        # *exact* filter (queue + task_name? + repoid? + commitid?)
-        # so `_celery_broker_clear` always derives the same
-        # `frozenset({(task_name or None, repoid, commitid or None)})`
-        # that `streaming_celery_count` walked the full queue with.
-        #
-        # Without this, the clear path inferred its filter set from
-        # `sample_targets` — the materialised window capped by
-        # `CELERY_BROKER_DISPLAY_LIMIT` (default 2_000). That had two
-        # silent-no-op modes:
-        #
-        # 1. All matches sit beyond the display window (e.g. a recent
-        #    burst on a queue with `LLEN > 2_000`): `sample_targets`
-        #    is empty, `by_queue_filters` becomes `{}`, the streaming
-        #    clear loop doesn't iterate, and the queue is never
-        #    touched even though `match_count > 0` from streaming.
-        # 2. Operator filtered by `repoid` only: each `sample_target`
-        #    contributes a *specific* `(task_name, repoid, commitid)`
-        #    triple, so the filter set excludes any task name not
-        #    represented in the first 2_000 messages — those messages
-        #    survive the clear.
-        #
-        # The synthetic target restores the streaming-clear semantic
-        # of "match every envelope whose `(task, repoid, commitid)`
-        # equals the operator's input." Per-message and bulk-select
-        # paths (`delete_model`, `clear_selected`, `delete_queryset`,
-        # `clear_dry_run`) still pass real materialised rows — those
-        # are intentionally index-driven, not filter-driven, so they
-        # don't go through this code path.
-        # `_FILTER_ANY` (not `None`) for unset slots so the
-        # streaming match treats them as wildcards. `None` would
-        # require an exact-equality match against `meta.task is
-        # None` / `meta.repoid is None` / `meta.commitid is None`,
-        # which the per-message paths legitimately rely on for
-        # tasks like `sync_repos` whose envelope leaves repoid /
-        # commitid as `None`.
-        task_any, repoid_any, commitid_any = _substitute_filter_any(
-            task_name, repoid, commitid
-        )
-        filter_target = CeleryBrokerQueue(
-            pk_token=f"{queue_name}#{kept_index if kept_index is not None else 'filter'}",
-            queue_name=queue_name,
-            index_in_queue=kept_index,
-            task_name=task_any,
-            repoid=repoid_any,
-            commitid=commitid_any,
-        )
-        matches = [filter_target]
+        # Tier 4 escape hatch: when the operator clicked "Skip count"
+        # the preview page renders without the count card and the
+        # destructive submit buttons unlock from page-load. The flag
+        # round-trips on every form rerender so a typed-confirmation
+        # error doesn't snap the count card back into view.
+        params = request.POST if request.method == "POST" else request.GET
+        count_skipped = (params.get("count_skipped") or "").strip() == "1"
 
         expected_confirm = queue_name
         typed_confirm = (request.POST.get("typed_confirm") or "").strip()
@@ -2001,11 +1990,35 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         destructive_actions = {"clear_keep_one", "clear_all"}
         valid_actions = destructive_actions | {"dry_run"}
 
-        # The chart-driven submit lands here with no `action` set
-        # (the chart's button just opens the preview page); fall
-        # through to the render path without invoking the service or
-        # writing a LogEntry.
+        # The destructive POST path needs `match_count` / `kept_index`
+        # for the safety checks (`match_count == 0` early-return,
+        # `clear_keep_one` single-match guard) and the dry-run banner.
+        # We compute it lazily — only on POST with a valid action —
+        # so the GET handler stays Redis-free.
+        match_count: int | None = None
+        kept_index: int | None = None
         if request.method == "POST" and action in valid_actions:
+            try:
+                match_count, kept_index = streaming_celery_count(
+                    queue_name,
+                    task_name=task_name or None,
+                    repoid=repoid,
+                    commitid=commitid or None,
+                )
+            except Exception:
+                log.exception(
+                    "redis_admin.clear_by_filter: streaming count failed for %r",
+                    queue_name,
+                )
+                # Defensive fallback: skip the count-based safety
+                # checks rather than render a 500. The destructive
+                # paths still gate on the typed-confirmation, and
+                # `start_celery_broker_clear_job` re-snapshots
+                # `LLEN(queue)` itself so the progress page total
+                # is accurate.
+                match_count = 0
+                kept_index = None
+
             if match_count == 0:
                 messages.info(
                     request,
@@ -2013,41 +2026,53 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
                 )
                 return HttpResponseRedirect(changelist_url)
 
-            if action == "clear_keep_one":
-                if match_count <= 1:
-                    # Single-message bucket: there's nothing to clear
-                    # without removing the only in-flight message,
-                    # which defeats the "keep first" semantic. The
-                    # preview page only renders this button for
-                    # buckets with match_count >= 2, but a hand-
-                    # crafted POST or a count change between render
-                    # and submit could still land here.
-                    messages.info(
-                        request,
-                        f"Nothing to clear: only {match_count} message(s) "
-                        f"match and 'clear all but first' would leave "
-                        f"them all in place.",
-                    )
-                    return HttpResponseRedirect(changelist_url)
-
-            targets = list(matches)
+            if action == "clear_keep_one" and match_count <= 1:
+                # Single-message bucket: there's nothing to clear
+                # without removing the only in-flight message,
+                # which defeats the "keep first" semantic. The
+                # preview page only renders this button for
+                # buckets with match_count >= 2, but a hand-
+                # crafted POST or a count change between render
+                # and submit could still land here.
+                messages.info(
+                    request,
+                    f"Nothing to clear: only {match_count} message(s) "
+                    f"match and 'clear all but first' would leave "
+                    f"them all in place.",
+                )
+                return HttpResponseRedirect(changelist_url)
 
             if action in destructive_actions and typed_confirm != expected_confirm:
                 confirm_error = f"Typed confirmation must equal {expected_confirm!r}"
             else:
                 dry_run = action == "dry_run"
                 keep_one = action == "clear_keep_one"
-                # Dry-run keeps the synchronous shape: the request
-                # already does the streaming-count walk above, so
-                # the dry-run service call is fast (no LSET/LREM)
-                # and the operator gets the audit-log entry +
-                # re-rendered preview in one shot. The destructive
-                # actions, by contrast, fan out to a background
-                # thread so a 500k-deep queue clear never sits on
-                # the gunicorn worker.
                 if dry_run:
+                    # Build a single synthetic target carrying the
+                    # operator's *exact* filter so
+                    # `_celery_broker_clear` always derives the
+                    # same `frozenset({(task_name or None, repoid,
+                    # commitid or None)})` that
+                    # `streaming_celery_count` walked the full
+                    # queue with. Substituting `_FILTER_ANY` (not
+                    # `None`) for unset slots so the streaming
+                    # match treats them as wildcards.
+                    task_any, repoid_any, commitid_any = _substitute_filter_any(
+                        task_name, repoid, commitid
+                    )
+                    filter_target = CeleryBrokerQueue(
+                        pk_token=(
+                            f"{queue_name}#"
+                            f"{kept_index if kept_index is not None else 'filter'}"
+                        ),
+                        queue_name=queue_name,
+                        index_in_queue=kept_index,
+                        task_name=task_any,
+                        repoid=repoid_any,
+                        commitid=commitid_any,
+                    )
                     result = celery_broker_clear(
-                        targets,
+                        [filter_target],
                         user=request.user,
                         dry_run=True,
                         keep_one=keep_one,
@@ -2059,6 +2084,10 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
                         f"entry written; queue untouched).",
                     )
                 else:
+                    # Destructive: fan out to a background thread so a
+                    # 500k-deep queue clear never sits on the gunicorn
+                    # worker. The progress page handles the polling +
+                    # cancel UX.
                     job_id = start_celery_broker_clear_job(
                         queue_name,
                         user=request.user,
@@ -2075,6 +2104,54 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
                     )
                     return HttpResponseRedirect(progress_url)
 
+        # URL the JS preview client hits to fetch the count + sample
+        # asynchronously. We resolve it server-side and pass it as a
+        # data attribute on the page root so the JS doesn't need to
+        # know URL names.
+        preview_url = reverse(
+            f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_preview"
+        )
+        preview_query = urlencode(
+            {
+                k: v
+                for k, v in {
+                    "queue_name": queue_name,
+                    "task_name": task_name,
+                    "repoid": "" if repoid is None else str(repoid),
+                    "commitid": commitid,
+                }.items()
+                if v != ""
+            }
+        )
+        preview_full_url = (
+            f"{preview_url}?{preview_query}" if preview_query else preview_url
+        )
+
+        # Skip-count link target (Tier 4): re-renders this same view
+        # with `count_skipped=1` flag set so the preview page comes
+        # back without the count card and with the destructive buttons
+        # unlocked from page-load.
+        skip_count_url = reverse(
+            f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_skip_count"
+        )
+        skip_count_query = urlencode(
+            {
+                k: v
+                for k, v in {
+                    "queue_name": queue_name,
+                    "task_name": task_name,
+                    "repoid": "" if repoid is None else str(repoid),
+                    "commitid": commitid,
+                }.items()
+                if v != ""
+            }
+        )
+        skip_count_full_url = (
+            f"{skip_count_url}?{skip_count_query}"
+            if skip_count_query
+            else skip_count_url
+        )
+
         ctx = {
             **self.admin_site.each_context(request),
             "title": f"Clear {queue_name} by filter",
@@ -2083,17 +2160,240 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             "task_name": task_name,
             "repoid": repoid,
             "commitid": commitid,
+            # `match_count` / `kept_index` are populated only on the
+            # destructive POST path; the GET render uses the skeleton
+            # placeholder until the JS fetches them. Templates fall
+            # back to the placeholder when these are `None`.
             "match_count": match_count,
             "kept_index": kept_index,
-            "sample_targets": sample_targets,
             "expected_confirm": expected_confirm,
             "typed_confirm": typed_confirm,
             "confirm_error": confirm_error,
             "changelist_url": changelist_url,
+            "preview_url": preview_full_url,
+            "skip_count_url": skip_count_full_url,
+            "count_skipped": count_skipped,
         }
         return render(
             request, "admin/redis_admin/celerybrokerqueue/clear_by_filter.html", ctx
         )
+
+    # ---- Lazy preview: JSON endpoint --------------------------------------
+    #
+    # The preview page renders a skeleton in <200ms; the JS then hits
+    # `clear-by-filter/preview/?…` to populate the count + sample
+    # table. Two response shapes:
+    #
+    # * `mode="synchronous"` — small queues. Body carries
+    #   `match_count`, `kept_index`, `sample`, `cached_at?`. The cache
+    #   layer (`resolve_clear_by_filter_preview_count`) covers
+    #   refresh / Back-Forward; `?bust=1` skips the cache so the
+    #   "refresh count" button can recompute.
+    # * `mode="job"` — deep queues (above
+    #   `CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT`). Body carries
+    #   `{job_id, status_url}`; the JS switches into polling mode and
+    #   reads `total_found` off the job hash on completion. The job
+    #   itself is a `dry_run=True` chunked clear, reusing the
+    #   existing `start_celery_broker_clear_job` machinery.
+    #
+    # The sample materialisation stays synchronous in *both* modes:
+    # it's bounded by `CELERY_BROKER_DISPLAY_LIMIT` (LRANGE 0 N-1 +
+    # parse), which is fast even on multi-million-deep queues. Only
+    # the count is escalated to job mode.
+
+    def clear_by_filter_preview_view(self, request: HttpRequest) -> JsonResponse:
+        """JSON preview endpoint for the lazy clear-by-filter page.
+
+        Same superuser guard + filter validation as
+        `clear_by_filter_view`. Returns a 400 on missing /
+        misshapen filters with a `{error, detail}` body so the
+        JS can surface it directly.
+        """
+
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-filter is restricted to superusers"
+            )
+
+        parsed, redirect = self._parse_clear_by_filter_params(request)
+        if redirect is not None:
+            # Re-pack the validation flash into a JSON 400 so the JS
+            # client can render it inline rather than following the
+            # changelist redirect we'd hand a browser GET.
+            stored = list(messages.get_messages(request))
+            detail = stored[-1].message if stored else "invalid filter"
+            return JsonResponse(
+                {"error": "invalid_filter", "detail": str(detail)},
+                status=400,
+            )
+        queue_name = parsed["queue_name"]
+        task_name = parsed["task_name"]
+        repoid = parsed["repoid"]
+        commitid = parsed["commitid"]
+
+        bust_cache = (request.GET.get("bust") or "").strip() == "1"
+
+        sample_targets = self._materialise_sample_targets(
+            queue_name=queue_name,
+            task_name=task_name or None,
+            repoid=repoid,
+            commitid=commitid or None,
+        )
+        sample_payload = [
+            {
+                "index_in_queue": t.index_in_queue,
+                "task_name": t.task_name or "",
+                "repoid": t.repoid,
+                "commitid": t.commitid or "",
+                "task_id": t.task_id or "",
+            }
+            for t in sample_targets
+        ]
+
+        # Threshold check: above the inline limit we hand the count
+        # off to a chunked dry-run job so the HTTP request returns
+        # immediately. `LLEN` itself is O(1), so the threshold
+        # check is free.
+        try:
+            broker = _conn.get_connection(kind="broker")
+            queue_depth = int(broker.llen(queue_name) or 0)
+        except Exception:
+            log.exception(
+                "redis_admin.clear_by_filter_preview: LLEN failed for %r",
+                queue_name,
+            )
+            queue_depth = 0
+
+        inline_limit = redis_admin_settings.CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT
+        if queue_depth > inline_limit:
+            opts = self.model._meta
+            job_id = start_celery_broker_clear_job(
+                queue_name,
+                user=request.user,
+                task_name=task_name or None,
+                repoid=repoid,
+                commitid=commitid or None,
+                keep_one=False,
+                dry_run=True,
+            )
+            status_url = reverse(
+                f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_status",
+                kwargs={"job_id": job_id},
+            )
+            return JsonResponse(
+                {
+                    "mode": "job",
+                    "job_id": job_id,
+                    "status_url": status_url,
+                    "queue_depth": queue_depth,
+                    "inline_limit": inline_limit,
+                    "sample": sample_payload,
+                }
+            )
+
+        try:
+            count_payload = resolve_clear_by_filter_preview_count(
+                queue_name,
+                task_name=task_name or None,
+                repoid=repoid,
+                commitid=commitid or None,
+                bust_cache=bust_cache,
+            )
+        except Exception:
+            log.exception(
+                "redis_admin.clear_by_filter_preview: count failed for %r",
+                queue_name,
+            )
+            return JsonResponse(
+                {"error": "count_failed", "detail": "streaming count raised"},
+                status=500,
+            )
+
+        body = {
+            "mode": "synchronous",
+            "match_count": count_payload["match_count"],
+            "kept_index": count_payload["kept_index"],
+            "queue_depth": queue_depth,
+            "inline_limit": inline_limit,
+            "sample": sample_payload,
+        }
+        if "cached_at" in count_payload and count_payload["cached_at"]:
+            body["cached_at"] = count_payload["cached_at"]
+        return JsonResponse(body)
+
+    def _materialise_sample_targets(
+        self,
+        *,
+        queue_name: str,
+        task_name: str | None,
+        repoid: int | None,
+        commitid: str | None,
+    ) -> list[CeleryBrokerQueue]:
+        """Materialise up to `_CLEAR_BY_FILTER_SAMPLE_SIZE` matching rows.
+
+        Bounded by `CELERY_BROKER_DISPLAY_LIMIT` upstream (the
+        queryset only walks the first N envelopes), so even on a
+        million-deep queue this is just an `LRANGE 0 N-1` + parse.
+        Returned rows are sorted by `index_in_queue` so the
+        preview table renders head-of-queue first, matching the
+        operator's "next message Celery would pop" mental model.
+        """
+
+        queryset = self.model._default_manager.all().filter(
+            queue_name__exact=queue_name
+        )
+        if task_name:
+            queryset = queryset.filter(task_name__exact=task_name)
+        if repoid is not None:
+            queryset = queryset.filter(repoid=repoid)
+        if commitid:
+            queryset = queryset.filter(commitid__startswith=commitid)
+        return sorted(queryset, key=lambda row: row.index_in_queue or 0)[
+            :_CLEAR_BY_FILTER_SAMPLE_SIZE
+        ]
+
+    def clear_by_filter_skip_count_view(self, request: HttpRequest) -> HttpResponse:
+        """Tier 4 escape hatch: route the operator straight to the
+        typed-confirm form without rendering the count card.
+
+        Re-validates the same filter combo as
+        `clear_by_filter_view` (so a hand-crafted skip-count URL
+        can't bypass the narrowing-filter requirement) and 302s
+        back to the preview page with `count_skipped=1` set, which
+        the GET handler reads to render the form without the count
+        skeleton and with the destructive submit buttons unlocked
+        from page-load.
+        """
+
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-filter is restricted to superusers"
+            )
+
+        parsed, redirect = self._parse_clear_by_filter_params(request)
+        if redirect is not None:
+            return redirect
+
+        opts = parsed["opts"]
+        preview_url = reverse(
+            f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter"
+        )
+        query = urlencode(
+            {
+                k: v
+                for k, v in {
+                    "queue_name": parsed["queue_name"],
+                    "task_name": parsed["task_name"],
+                    "repoid": (
+                        "" if parsed["repoid"] is None else str(parsed["repoid"])
+                    ),
+                    "commitid": parsed["commitid"],
+                    "count_skipped": "1",
+                }.items()
+                if v != ""
+            }
+        )
+        return HttpResponseRedirect(f"{preview_url}?{query}")
 
     # ---- Chunked-clear background-job views ------------------------------
     #

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -1681,3 +1681,130 @@ def resolve_clear_by_filter_preview_count(
         "match_count": int(match_count),
         "kept_index": kept_index,
     }
+
+
+# ---- Preview-mode dry-run job dedup ------------------------------------
+#
+# When `clear_by_filter_preview_view` escalates a deep-queue count to a
+# chunked background job (`queue_depth > CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT`)
+# it spawns a `start_celery_broker_clear_job(dry_run=True)` thread that
+# walks the entire queue. Without dedup, a page refresh / second tab /
+# JS retry kicks off another full-queue scan in parallel: O(N) Redis
+# reads multiplied by the number of accidental refreshes.
+#
+# Best-effort fix: cache the `job_id` under a short TTL keyed by the
+# filter hash. Subsequent calls within the window reuse the in-flight
+# id; cache outage falls through to always-spawn (no regression vs the
+# pre-PR behaviour).
+_CLEAR_BY_FILTER_PREVIEW_JOB_LOCK_PREFIX: str = "redis_admin:preview_job_lock"
+
+
+def _clear_by_filter_preview_job_lock_key(
+    queue_name: str,
+    *,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+) -> str:
+    """SHA-256 over the same canonical tuple as the count cache.
+
+    Hashing for the same two reasons as `_clear_by_filter_preview_cache_key`
+    (bounded length + multi-tenant isolation). Sharing the canonical
+    tuple shape with the count cache keeps the operator mental model
+    simple — same filter → same hash → either cached count or shared
+    in-flight job, never both at once.
+    """
+
+    canonical = "|".join(
+        [
+            queue_name,
+            task_name or "",
+            "" if repoid is None else str(repoid),
+            commitid or "",
+        ]
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"{_CLEAR_BY_FILTER_PREVIEW_JOB_LOCK_PREFIX}:{digest}"
+
+
+def get_or_start_clear_by_filter_preview_job(
+    queue_name: str,
+    *,
+    user,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+) -> str:
+    """Return an in-flight preview-mode `job_id` for this filter, or
+    spawn a new one and cache its id under a short TTL.
+
+    Best-effort dedup. Catches the common waste path — refresh /
+    multi-tab / JS retry kicking off N parallel full-queue scans
+    while the first is still walking — without becoming a strict
+    mutex (two simultaneous first-time requests can still race past
+    the cache miss and both spawn a job). Cache outage falls through
+    to the always-spawn path so the preview never returns a 500
+    because of a flaky lock.
+
+    Stale-id guard: if the cached `job_id` no longer resolves to a
+    live job hash (its 24h TTL elapsed, or a redis-cli operator
+    nuked the hash), we fall through to spawn a fresh job rather
+    than handing the JS a dead job_id.
+    """
+
+    cache_key = _clear_by_filter_preview_job_lock_key(
+        queue_name,
+        task_name=task_name,
+        repoid=repoid,
+        commitid=commitid,
+    )
+
+    cache: Any = None
+    try:
+        cache = _conn.get_connection(kind="default")
+    except Exception:  # pragma: no cover - cache outage at lookup
+        log.exception("redis_admin.preview_job_lock: connection failed; skipping dedup")
+
+    if cache is not None:
+        try:
+            existing = cache.get(cache_key)
+        except Exception:  # pragma: no cover - cache outage at GET
+            log.exception("redis_admin.preview_job_lock: GET failed; skipping dedup")
+            existing = None
+        if existing is not None:
+            cached_job_id = (
+                existing.decode("utf-8")
+                if isinstance(existing, bytes)
+                else str(existing)
+            )
+            if get_celery_broker_clear_job(cached_job_id) is not None:
+                return cached_job_id
+            # Stale cache entry — the job hash expired or was purged.
+            # Drop it so the next caller doesn't re-check repeatedly.
+            try:
+                cache.delete(cache_key)
+            except Exception:  # pragma: no cover - cache outage at DEL
+                log.exception(
+                    "redis_admin.preview_job_lock: DEL failed; skipping cleanup"
+                )
+
+    job_id = start_celery_broker_clear_job(
+        queue_name,
+        user=user,
+        task_name=task_name,
+        repoid=repoid,
+        commitid=commitid,
+        keep_one=False,
+        dry_run=True,
+    )
+
+    if cache is not None:
+        ttl = redis_admin_settings.CLEAR_BY_FILTER_PREVIEW_JOB_LOCK_TTL_SECONDS
+        if ttl > 0:
+            try:
+                cache.set(cache_key, job_id, ex=ttl)
+            except Exception:  # pragma: no cover - cache outage at SET
+                log.exception(
+                    "redis_admin.preview_job_lock: SET failed; skipping dedup"
+                )
+    return job_id

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -22,6 +22,7 @@ single chokepoint for:
 from __future__ import annotations
 
 import datetime as _dt
+import hashlib
 import json
 import logging
 import threading
@@ -1474,3 +1475,209 @@ def _run_celery_broker_clear_job_body(
         dry_run=dry_run,
         extra=extra,
     )
+
+
+# ---- Lazy clear-by-filter preview --------------------------------------
+#
+# The synchronous `clear_by_filter_view` GET handler used to call
+# `streaming_celery_count` + materialise up to `CELERY_BROKER_DISPLAY_LIMIT`
+# rows through the queryset before painting anything. On a 1M-deep queue
+# that's tens of seconds of blocking work in the gunicorn request thread.
+#
+# The new flow renders a skeleton page in <200ms and lets a JS-driven
+# JSON endpoint (`clear-by-filter/preview/`) compute the count + sample
+# on demand. This module owns the cache + orchestration helpers; the
+# view layer wires them to the HTTP surface.
+_CLEAR_BY_FILTER_PREVIEW_CACHE_PREFIX: str = "redis_admin:preview_count"
+
+
+def _clear_by_filter_preview_cache_key(
+    queue_name: str,
+    *,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+) -> str:
+    """SHA-256 over a canonical `queue|task|repoid|commitid` tuple.
+
+    Hashing has two purposes:
+
+    * **Bounded length.** Commit SHAs are 40 chars and operator
+      task names can be long Python dotted paths
+      (`app.tasks.upload_finalizer.UploadFinalizerTask` etc.); a
+      raw concat key can blow past the 64-byte target Redis key
+      width. Bringing it down to a fixed 64-char hex digest keeps
+      the cache slot uniform.
+    * **Multi-tenant isolation.** The hash makes accidental key
+      collisions across deployments / shards effectively
+      impossible without us having to spell out the full filter
+      tuple in the key (which would also leak filter shape into
+      `MONITOR` output).
+
+    We use `|` as the separator because none of the four inputs
+    can legitimately contain a pipe — queue names + task names are
+    ascii-identifiers, repoid is an int, commitid is hex. Any pipe
+    in the operator input would be rejected upstream by the
+    validation in `clear_by_filter_view`.
+    """
+
+    canonical = "|".join(
+        [
+            queue_name,
+            task_name or "",
+            "" if repoid is None else str(repoid),
+            commitid or "",
+        ]
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"{_CLEAR_BY_FILTER_PREVIEW_CACHE_PREFIX}:{digest}"
+
+
+def _clear_by_filter_preview_cache_get(
+    queue_name: str,
+    *,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+) -> dict[str, Any] | None:
+    """Read a cached `(match_count, kept_index, computed_at)` tuple.
+
+    Returns `None` on:
+
+    * cache miss (`GET` returns `None`),
+    * malformed payload (a future schema change writing a
+      different shape, or a redis-cli operator stamping garbage on
+      the key) — we degrade silently to a recompute,
+    * cache outage — same: silent degrade so a flaky cache redis
+      can't break the preview endpoint.
+
+    The view layer calls `_clear_by_filter_preview_cache_set` to
+    populate this on a synchronous-mode count completion.
+    """
+
+    try:
+        cache = _conn.get_connection(kind="default")
+    except Exception:  # pragma: no cover - cache outage at lookup
+        log.exception("redis_admin.preview_cache: connection failed; skipping cache")
+        return None
+
+    key = _clear_by_filter_preview_cache_key(
+        queue_name, task_name=task_name, repoid=repoid, commitid=commitid
+    )
+    try:
+        raw = cache.get(key)
+    except Exception:  # pragma: no cover - cache outage at GET
+        log.exception("redis_admin.preview_cache: GET failed; skipping cache")
+        return None
+    if raw is None:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", errors="replace")
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        log.warning("redis_admin.preview_cache: malformed cache entry at %s", key)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if "match_count" not in payload or "computed_at" not in payload:
+        return None
+    return payload
+
+
+def _clear_by_filter_preview_cache_set(
+    queue_name: str,
+    *,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+    match_count: int,
+    kept_index: int | None,
+) -> None:
+    """Write the synchronous-mode count to cache redis with the
+    configured TTL.
+
+    Best-effort: a failed write logs and returns; we never raise
+    out of the preview flow because of a cache miss-fire. The
+    operator just gets a recompute on the next call.
+    """
+
+    ttl = redis_admin_settings.CLEAR_BY_FILTER_PREVIEW_CACHE_TTL_SECONDS
+    if ttl <= 0:
+        return
+    try:
+        cache = _conn.get_connection(kind="default")
+    except Exception:  # pragma: no cover - cache outage at set
+        log.exception("redis_admin.preview_cache: connection failed; skipping cache")
+        return
+
+    key = _clear_by_filter_preview_cache_key(
+        queue_name, task_name=task_name, repoid=repoid, commitid=commitid
+    )
+    payload = {
+        "match_count": int(match_count),
+        "kept_index": kept_index,
+        "computed_at": _utc_now_iso(),
+    }
+    try:
+        cache.set(key, json.dumps(payload), ex=ttl)
+    except Exception:  # pragma: no cover - cache outage at set
+        log.exception("redis_admin.preview_cache: SET failed; skipping cache")
+
+
+def resolve_clear_by_filter_preview_count(
+    queue_name: str,
+    *,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+    bust_cache: bool = False,
+) -> dict[str, Any]:
+    """Cache-or-compute orchestrator for the preview endpoint.
+
+    Single chokepoint for the synchronous-mode count + cache logic
+    so the view layer doesn't have to know about cache key shape /
+    TTL / payload schema. Returns a dict shaped to fit the JSON
+    response directly:
+
+    * `match_count` — int, total messages matching the filter.
+    * `kept_index` — int | None, lowest `index_in_queue` matching
+      the filter (the message a `keep_one=True` clear would
+      preserve).
+    * `cached_at` — ISO 8601 UTC timestamp set when the cache was
+      written; absent for fresh recomputes.
+
+    The caller is responsible for the threshold check (deferring
+    deep queues to the chunked-job path) — this helper always
+    runs the synchronous walk on a miss.
+    """
+
+    if not bust_cache:
+        cached = _clear_by_filter_preview_cache_get(
+            queue_name, task_name=task_name, repoid=repoid, commitid=commitid
+        )
+        if cached is not None:
+            return {
+                "match_count": int(cached["match_count"]),
+                "kept_index": cached.get("kept_index"),
+                "cached_at": cached.get("computed_at"),
+            }
+
+    match_count, kept_index = streaming_celery_count(
+        queue_name,
+        task_name=task_name,
+        repoid=repoid,
+        commitid=commitid,
+    )
+    _clear_by_filter_preview_cache_set(
+        queue_name,
+        task_name=task_name,
+        repoid=repoid,
+        commitid=commitid,
+        match_count=match_count,
+        kept_index=kept_index,
+    )
+    return {
+        "match_count": int(match_count),
+        "kept_index": kept_index,
+    }

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -1491,14 +1491,21 @@ def _run_celery_broker_clear_job_body(
 _CLEAR_BY_FILTER_PREVIEW_CACHE_PREFIX: str = "redis_admin:preview_count"
 
 
-def _clear_by_filter_preview_cache_key(
+def _clear_by_filter_filter_digest(
     queue_name: str,
     *,
     task_name: str | None,
     repoid: int | None,
     commitid: str | None,
 ) -> str:
-    """SHA-256 over a canonical `queue|task|repoid|commitid` tuple.
+    """Stable SHA-256 hex digest of the canonical filter tuple.
+
+    Single chokepoint shared by the synchronous-mode count cache
+    (`_clear_by_filter_preview_cache_key`) and the deep-queue job
+    lock (`_clear_by_filter_preview_job_lock_key`) so the two key
+    families can never accidentally diverge in their hashing
+    logic — same filter tuple → same digest → either cached count
+    or shared in-flight job, never both at once.
 
     Hashing has two purposes:
 
@@ -1529,7 +1536,27 @@ def _clear_by_filter_preview_cache_key(
             commitid or "",
         ]
     )
-    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _clear_by_filter_preview_cache_key(
+    queue_name: str,
+    *,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+) -> str:
+    """Cache key for the synchronous-mode count cache. Body is the
+    shared `_clear_by_filter_filter_digest` so a future tweak to
+    the canonical-tuple shape lands in both key families at once.
+    """
+
+    digest = _clear_by_filter_filter_digest(
+        queue_name,
+        task_name=task_name,
+        repoid=repoid,
+        commitid=commitid,
+    )
     return f"{_CLEAR_BY_FILTER_PREVIEW_CACHE_PREFIX}:{digest}"
 
 
@@ -1706,24 +1733,17 @@ def _clear_by_filter_preview_job_lock_key(
     repoid: int | None,
     commitid: str | None,
 ) -> str:
-    """SHA-256 over the same canonical tuple as the count cache.
-
-    Hashing for the same two reasons as `_clear_by_filter_preview_cache_key`
-    (bounded length + multi-tenant isolation). Sharing the canonical
-    tuple shape with the count cache keeps the operator mental model
-    simple — same filter → same hash → either cached count or shared
-    in-flight job, never both at once.
+    """Cache key for the deep-queue dry-run job lock. Body is the
+    shared `_clear_by_filter_filter_digest` so the lock + count
+    cache index the same canonical tuple.
     """
 
-    canonical = "|".join(
-        [
-            queue_name,
-            task_name or "",
-            "" if repoid is None else str(repoid),
-            commitid or "",
-        ]
+    digest = _clear_by_filter_filter_digest(
+        queue_name,
+        task_name=task_name,
+        repoid=repoid,
+        commitid=commitid,
     )
-    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     return f"{_CLEAR_BY_FILTER_PREVIEW_JOB_LOCK_PREFIX}:{digest}"
 
 

--- a/apps/codecov-api/redis_admin/settings.py
+++ b/apps/codecov-api/redis_admin/settings.py
@@ -55,3 +55,29 @@ CELERY_BROKER_SCAN_LIMIT: int = getattr(
 # from blocking Redis with a single oversized MULTI when an operator clears
 # thousands of keys at once.
 DELETE_BATCH_SIZE: int = getattr(settings, "REDIS_ADMIN_DELETE_BATCH_SIZE", 500)
+
+# `LLEN(queue)` threshold above which the lazy `clear-by-filter/preview/`
+# endpoint stops trying to compute the count synchronously and instead
+# spawns a `dry_run=True` chunked-clear background job (the existing
+# `start_celery_broker_clear_job` machinery). At 200_000 the synchronous
+# walk is still tens of seconds on fakeredis and would routinely outlive
+# nginx / gunicorn `proxy_read_timeout` defaults; below it the inline
+# count keeps the page responsive without a job-hash round-trip.
+#
+# Kept above `CELERY_BROKER_SCAN_LIMIT` (20_000) because the chart
+# already covers the typical "deep but not pathological" regime; the
+# preview only needs job-mode escalation when the queue is truly
+# painful to walk synchronously.
+CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT: int = getattr(
+    settings, "REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT", 200_000
+)
+
+# TTL for the synchronous-mode preview count cache (cache Redis key:
+# `redis_admin:preview_count:<sha256(filter)>`). 60 seconds is short
+# enough that a refresh during an investigation reflects the current
+# queue depth (a cleared 1M-deep queue drops to zero in well under a
+# minute), and long enough that Back-Forward / refresh / hitting the
+# preview from two browser tabs feels instant.
+CLEAR_BY_FILTER_PREVIEW_CACHE_TTL_SECONDS: int = getattr(
+    settings, "REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_CACHE_TTL_SECONDS", 60
+)

--- a/apps/codecov-api/redis_admin/settings.py
+++ b/apps/codecov-api/redis_admin/settings.py
@@ -81,3 +81,16 @@ CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT: int = getattr(
 CLEAR_BY_FILTER_PREVIEW_CACHE_TTL_SECONDS: int = getattr(
     settings, "REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_CACHE_TTL_SECONDS", 60
 )
+
+# TTL for the preview-mode dry-run job lock (cache Redis key:
+# `redis_admin:preview_job_lock:<sha256(filter)>`). When the
+# preview endpoint escalates a deep-queue count to a chunked
+# background job (queue_depth > `CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT`),
+# subsequent calls within this window reuse the in-flight `job_id`
+# instead of spawning a duplicate full-queue scan. 5 minutes is
+# long enough that a refresh / multi-tab open during the same
+# investigation re-uses the job; short enough that a stale job
+# lock can't outlive a worker crash by more than a coffee break.
+CLEAR_BY_FILTER_PREVIEW_JOB_LOCK_TTL_SECONDS: int = getattr(
+    settings, "REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_JOB_LOCK_TTL_SECONDS", 300
+)

--- a/apps/codecov-api/redis_admin/static/redis_admin/css/celery_clear_by_filter_preview.css
+++ b/apps/codecov-api/redis_admin/static/redis_admin/css/celery_clear_by_filter_preview.css
@@ -1,0 +1,173 @@
+/* Loader / count / sample cards for the lazy clear-by-filter
+ * preview page. Mirrors the visual language of
+ * `celery_chart_fragment.css` (loader card with spinner) and
+ * `celery_clear_progress.css` (counters + progress bar) so the
+ * three preview/progress surfaces in the celery_broker admin
+ * read as one design family.
+ *
+ * Lives in an external file so the production CSP — `'self'` plus
+ * a single fixed sha256 hash for inline scripts — doesn't block
+ * inline <style>. See settings_base.py CSP_DEFAULT_SRC.
+ */
+
+.celery-clear-preview-hidden {
+  display: none !important;
+}
+
+.celery-clear-preview-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 8px;
+  margin: 16px 0;
+  padding: 28px 24px;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 6px;
+  background: var(--darkened-bg, #f8f8f8);
+  color: var(--body-fg, #333);
+  min-height: 120px;
+  box-sizing: border-box;
+}
+
+.celery-clear-preview-loader__spinner {
+  width: 36px;
+  height: 36px;
+  border: 4px solid var(--border-color, #ddd);
+  border-top-color: var(--primary, #417690);
+  border-radius: 50%;
+  animation: celery-clear-preview-spin 0.85s linear infinite;
+}
+
+.celery-clear-preview-loader__label {
+  margin: 6px 0 0 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+.celery-clear-preview-loader__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--body-quiet-color, #666);
+  max-width: 480px;
+  line-height: 1.4;
+}
+
+@keyframes celery-clear-preview-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .celery-clear-preview-loader__spinner {
+    animation: celery-clear-preview-pulse 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes celery-clear-preview-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.4; }
+}
+
+/* Resolved count card (synchronous-mode finish state). */
+.celery-clear-preview-count-card {
+  margin-top: 8px;
+}
+
+.celery-clear-preview-count-large {
+  font-size: 1.6em;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.celery-clear-preview-cached-note {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 0.8em;
+  color: var(--body-quiet-color, #666);
+}
+
+/* Job-mode progress card. Reuses the same visual language as
+ * `celery_clear_progress.css` — `<progress>` bar + a small set of
+ * counters — so the preview's "we're computing on a deep queue"
+ * surface matches the destructive-clear page the operator already
+ * knows. */
+.celery-clear-preview-job-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 20px;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 6px;
+  background: var(--darkened-bg, #f8f8f8);
+  margin: 16px 0;
+}
+
+.celery-clear-preview-job-bar {
+  flex: 1 1 auto;
+  height: 14px;
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 4px;
+  background: var(--darkened-bg, #f0f0f0);
+  overflow: hidden;
+  width: 100%;
+}
+.celery-clear-preview-job-bar::-webkit-progress-bar {
+  background: var(--darkened-bg, #f0f0f0);
+}
+.celery-clear-preview-job-bar::-webkit-progress-value {
+  background: var(--primary, #417690);
+  transition: width 0.4s ease-in-out;
+}
+.celery-clear-preview-job-bar::-moz-progress-bar {
+  background: var(--primary, #417690);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .celery-clear-preview-job-bar::-webkit-progress-value {
+    transition: none;
+  }
+}
+
+/* Inline error pill. Non-fatal — operator can still hit the
+ * skip-count link to proceed, so this card is paired visually with
+ * an "Skip count" call to action. */
+.celery-clear-preview-error-card {
+  margin: 16px 0;
+  padding: 12px 16px;
+  border: 1px solid var(--error-fg, #ba2121);
+  border-left-width: 4px;
+  border-radius: 4px;
+  background: var(--darkened-bg, #fdf3f3);
+  color: var(--body-fg, #333);
+}
+
+.celery-clear-preview-error {
+  margin: 0 0 6px 0;
+  color: var(--error-fg, #ba2121);
+  font-weight: 600;
+}
+
+/* Skip-count link. Visually subordinate (italic, muted) so it
+ * reads as the "trust the filter, skip ahead" escape hatch and
+ * doesn't compete with the destructive submit buttons. */
+.celery-clear-preview-skip-count {
+  display: inline-block;
+  margin-top: 6px;
+  font-style: italic;
+  font-size: 0.9em;
+  color: var(--body-quiet-color, #666);
+}
+
+.celery-clear-preview-skip-count:hover,
+.celery-clear-preview-skip-count:focus {
+  color: var(--link-fg, var(--primary, #417690));
+}
+
+.celery-clear-preview-skip-count-row {
+  margin-top: 8px;
+}

--- a/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_by_filter_preview.js
+++ b/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_by_filter_preview.js
@@ -195,11 +195,16 @@
       );
     }
 
-    // Hide the loader card, reveal the resolved count card, and
-    // render the sample. Empty match_count → don't unlock submits;
-    // the operator's only legitimate next action is to widen the
-    // filter or back out.
+    // Hide the loader + (if we came from job mode) the job card,
+    // reveal the resolved count card, and render the sample. Empty
+    // match_count → don't unlock submits; the operator's only
+    // legitimate next action is to widen the filter or back out.
+    // Tier 2 deep-queue path enters job mode by showing the job
+    // card; on terminal `completed` it now hands off to this
+    // function, so hide the now-stale progress card to avoid two
+    // overlapping result sections being visible at once.
     hide($('celery-clear-preview-loader'));
+    hide($('celery-clear-preview-job-card'));
     show($('celery-clear-preview-count-card'));
 
     if (payload.cached_at) {
@@ -222,7 +227,14 @@
   }
 
   function showError(message) {
+    // Hide the loader + (if we came from job mode) the job card so
+    // the error card replaces them rather than stacking alongside.
+    // Tier 2 deep-queue path's `cancelled` / `failed` terminal
+    // states funnel through here; without hiding the job card the
+    // operator would see the in-progress card and the error card
+    // at the same time.
     hide($('celery-clear-preview-loader'));
+    hide($('celery-clear-preview-job-card'));
     var errBox = $('celery-clear-preview-error');
     if (errBox) {
       errBox.textContent = message;

--- a/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_by_filter_preview.js
+++ b/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_by_filter_preview.js
@@ -82,9 +82,37 @@
     }
   }
 
-  function renderSampleTable(rootEl, sample) {
+  function renderSampleHeader(sampleLength, matchCount) {
+    // Mirror the pre-PR-907 dynamic heading: when the sample
+    // window is narrower than the full match set we surface
+    // "Showing first N of M matching message(s)" so the operator
+    // doesn't mistake the sample table for the complete match
+    // list. When the sample equals the count, drop the "of M" so
+    // the heading isn't redundant.
+    var headerEl = $('celery-clear-preview-sample-header');
+    if (!headerEl) return;
+    var resolvedCount = (typeof matchCount === 'number' ? matchCount : sampleLength) || 0;
+    if (sampleLength === 0) {
+      headerEl.textContent = 'Matching messages:';
+      return;
+    }
+    if (resolvedCount > sampleLength) {
+      headerEl.textContent = (
+        'Showing first ' + formatNumber(sampleLength) +
+        ' of ' + formatNumber(resolvedCount) +
+        ' matching message(s):'
+      );
+    } else {
+      headerEl.textContent = (
+        'The first ' + formatNumber(sampleLength) + ' matching message(s):'
+      );
+    }
+  }
+
+  function renderSampleTable(rootEl, sample, matchCount) {
     var tableContainer = $('celery-clear-preview-sample');
     if (!tableContainer) return;
+    renderSampleHeader((sample || []).length, matchCount);
     if (!sample || sample.length === 0) {
       tableContainer.innerHTML = '<p><em>No matching messages in the sample window.</em></p>';
       return;
@@ -189,7 +217,7 @@
     }
 
     show($('celery-clear-preview-form-area'));
-    renderSampleTable(rootEl, payload.sample || []);
+    renderSampleTable(rootEl, payload.sample || [], payload.match_count || 0);
     setSubmitButtonsEnabled(true);
   }
 

--- a/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_by_filter_preview.js
+++ b/apps/codecov-api/redis_admin/static/redis_admin/js/celery_clear_by_filter_preview.js
@@ -1,0 +1,360 @@
+// Lazy-loads the count + sample table for the clear-by-filter
+// preview page. The Django GET handler renders only the form +
+// skeleton placeholders so the page paints in <200ms even on
+// million-message queues; this script then fetches the JSON
+// preview endpoint and either:
+//
+//   * fills in the count + sample synchronously (small queues), or
+//   * polls the chunked-clear-job status endpoint (deep queues
+//     above REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT),
+//     reading `total_found` off the job hash on completion as the
+//     match count.
+//
+// Loaded as an external file (not inline) so the production CSP on
+// api-admin.codecov.io — `'self'` plus a single fixed sha256 hash
+// for inline scripts — does not block it. See settings_base.py
+// CSP_DEFAULT_SRC.
+//
+// Lifecycle:
+//   - On DOMContentLoaded, read the preview URL + skip-count URL +
+//     filter params from data attributes on
+//     `#celery-clear-by-filter-preview-root`.
+//   - If `data-count-skipped="1"` is set, leave the form alone (the
+//     server already rendered with the count card hidden + submit
+//     buttons unlocked) and exit.
+//   - Otherwise fetch the preview endpoint with same-origin creds.
+//   - mode=synchronous → fill count, render sample, unlock submits.
+//   - mode=job → switch to polling the job status endpoint; same
+//     backoff shape as celery_clear_progress.js. On completed, read
+//     `matched` (or `total_found`) as the count and unlock submits.
+//   - On error → show a non-fatal error pill with the skip-count
+//     escape link.
+(function () {
+  'use strict';
+
+  var POLL_INTERVAL_OK_MS = 1000;
+  var POLL_BACKOFF_STEPS_MS = [1000, 2000, 5000];
+  var POLL_BACKOFF_MAX_MS = 5000;
+  var TERMINAL_STATES = { completed: 1, cancelled: 1, failed: 1 };
+
+  function $(id) { return document.getElementById(id); }
+
+  function setText(id, value) {
+    var el = $(id);
+    if (el) el.textContent = value;
+  }
+
+  function show(el) {
+    if (el) el.classList.remove('celery-clear-preview-hidden');
+  }
+
+  function hide(el) {
+    if (el) el.classList.add('celery-clear-preview-hidden');
+  }
+
+  function escapeHtml(s) {
+    if (s === null || typeof s === 'undefined') return '';
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function formatNumber(n) {
+    if (typeof n !== 'number' || !isFinite(n)) return '0';
+    // Insert thin spaces / commas so a million-deep queue's count
+    // is readable. Falls back to a plain toString() in browsers
+    // missing Intl support.
+    if (typeof Intl !== 'undefined' && Intl.NumberFormat) {
+      return new Intl.NumberFormat().format(n);
+    }
+    return String(n);
+  }
+
+  function setSubmitButtonsEnabled(enabled) {
+    var buttons = document.querySelectorAll(
+      '.celery-clear-actions button[type="submit"]'
+    );
+    for (var i = 0; i < buttons.length; i += 1) {
+      buttons[i].disabled = !enabled;
+    }
+  }
+
+  function renderSampleTable(rootEl, sample) {
+    var tableContainer = $('celery-clear-preview-sample');
+    if (!tableContainer) return;
+    if (!sample || sample.length === 0) {
+      tableContainer.innerHTML = '<p><em>No matching messages in the sample window.</em></p>';
+      return;
+    }
+    var rows = [];
+    for (var i = 0; i < sample.length; i += 1) {
+      var row = sample[i];
+      var commitShort = row.commitid ? String(row.commitid).slice(0, 7) : '';
+      var taskShort = row.task_id ? String(row.task_id).slice(0, 8) : '';
+      rows.push(
+        '<tr>' +
+        '<td>' + escapeHtml(row.index_in_queue) + '</td>' +
+        '<td>' + escapeHtml(row.task_name || '—') + '</td>' +
+        '<td>' + (row.repoid === null || typeof row.repoid === 'undefined'
+          ? '—' : escapeHtml(row.repoid)) + '</td>' +
+        '<td>' + (commitShort
+          ? '<code title="' + escapeHtml(row.commitid) + '">' + escapeHtml(commitShort) + '</code>'
+          : '—') + '</td>' +
+        '<td>' + (taskShort
+          ? '<code title="' + escapeHtml(row.task_id) + '">' + escapeHtml(taskShort) + '</code>'
+          : '—') + '</td>' +
+        '</tr>'
+      );
+    }
+    tableContainer.innerHTML = (
+      '<table>' +
+      '<thead><tr>' +
+      '<th>Index</th><th>Task</th><th>repoid</th><th>commit</th><th>task id</th>' +
+      '</tr></thead>' +
+      '<tbody>' + rows.join('') + '</tbody>' +
+      '</table>'
+    );
+  }
+
+  function fillSynchronousResult(rootEl, payload) {
+    setText('celery-clear-preview-count', formatNumber(payload.match_count || 0));
+    var keptIndex = payload.kept_index;
+    var keptIndexEl = $('celery-clear-preview-kept-index-row');
+    if (keptIndexEl) {
+      if (typeof keptIndex === 'number' && payload.match_count >= 2) {
+        setText('celery-clear-preview-kept-index', String(keptIndex));
+        setText(
+          'celery-clear-preview-keep-one-remaining',
+          formatNumber((payload.match_count || 0) - 1)
+        );
+        setText(
+          'celery-clear-preview-keep-one-total',
+          formatNumber(payload.match_count || 0)
+        );
+        show(keptIndexEl);
+      } else {
+        hide(keptIndexEl);
+      }
+    }
+
+    // Update the per-button copy with the live count so the
+    // operator sees "Clear all (12,345 from notify)" instead of
+    // the placeholder. The keep-one button is hidden when count <=
+    // 1 because the action is a no-op in that case.
+    var keepOneBtn = $('celery-clear-preview-button-keep-one');
+    if (keepOneBtn) {
+      if ((payload.match_count || 0) >= 2) {
+        keepOneBtn.textContent = (
+          'Clear all but first (' +
+          formatNumber((payload.match_count || 0) - 1) + ' of ' +
+          formatNumber(payload.match_count || 0) + ' from ' +
+          (rootEl.dataset.queueName || '') + ')'
+        );
+        show(keepOneBtn);
+      } else {
+        hide(keepOneBtn);
+      }
+    }
+    var clearAllBtn = $('celery-clear-preview-button-clear-all');
+    if (clearAllBtn) {
+      clearAllBtn.textContent = (
+        'Clear all (' +
+        formatNumber(payload.match_count || 0) + ' from ' +
+        (rootEl.dataset.queueName || '') + ')'
+      );
+    }
+
+    // Hide the loader card, reveal the resolved count card, and
+    // render the sample. Empty match_count → don't unlock submits;
+    // the operator's only legitimate next action is to widen the
+    // filter or back out.
+    hide($('celery-clear-preview-loader'));
+    show($('celery-clear-preview-count-card'));
+
+    if (payload.cached_at) {
+      var cachedNote = $('celery-clear-preview-cached-note');
+      if (cachedNote) {
+        cachedNote.textContent = 'Cached at ' + payload.cached_at;
+        show(cachedNote);
+      }
+    }
+
+    if ((payload.match_count || 0) === 0) {
+      hide($('celery-clear-preview-form-area'));
+      show($('celery-clear-preview-empty'));
+      return;
+    }
+
+    show($('celery-clear-preview-form-area'));
+    renderSampleTable(rootEl, payload.sample || []);
+    setSubmitButtonsEnabled(true);
+  }
+
+  function showError(message) {
+    hide($('celery-clear-preview-loader'));
+    var errBox = $('celery-clear-preview-error');
+    if (errBox) {
+      errBox.textContent = message;
+      show(errBox);
+    }
+    show($('celery-clear-preview-error-card'));
+  }
+
+  function pollJob(rootEl, statusUrl) {
+    var backoffStep = 0;
+    var pollTimer = null;
+    var inFlight = false;
+
+    function scheduleNext(intervalMs) {
+      if (pollTimer) clearTimeout(pollTimer);
+      pollTimer = setTimeout(poll, intervalMs);
+    }
+
+    function poll() {
+      if (inFlight) return;
+      inFlight = true;
+      fetch(statusUrl, {
+        credentials: 'same-origin',
+        headers: { 'Accept': 'application/json' }
+      })
+        .then(function (r) {
+          if (!r.ok) {
+            throw new Error('status HTTP ' + r.status);
+          }
+          return r.json();
+        })
+        .then(function (snapshot) {
+          backoffStep = 0;
+          var status = snapshot.status || 'pending';
+          updateJobProgress(snapshot);
+          if (Object.prototype.hasOwnProperty.call(TERMINAL_STATES, status)) {
+            if (status === 'completed') {
+              // Total of envelopes the dry-run pass found. Falls
+              // back to `matched` because the existing chunked job
+              // hash exposes `matched` directly (the streaming
+              // counter HINCRBY'd per chunk); both equal `total_found`
+              // on a completed dry-run.
+              var matchCount = (
+                typeof snapshot.matched === 'number' ? snapshot.matched : 0
+              );
+              fillSynchronousResult(rootEl, {
+                match_count: matchCount,
+                // The chunked dry-run path doesn't surface kept_index
+                // through the job hash (the synchronous count walks
+                // the queue specifically to track it; the chunked
+                // worker only HINCRBYs deltas). We hide the kept-index
+                // row in job mode rather than show stale data.
+                kept_index: null,
+                sample: rootEl.__previewSample || [],
+              });
+            } else if (status === 'cancelled') {
+              showError('Count job was cancelled. Refresh to retry.');
+            } else {
+              showError(
+                'Count job failed' +
+                (snapshot.error ? ': ' + snapshot.error : '.') +
+                ' Refresh to retry.'
+              );
+            }
+            return;
+          }
+          // Surface live progress so the operator knows it's
+          // making forward progress on a deep queue.
+          scheduleNext(POLL_INTERVAL_OK_MS);
+        })
+        .catch(function () {
+          var step = backoffStep < POLL_BACKOFF_STEPS_MS.length
+            ? POLL_BACKOFF_STEPS_MS[backoffStep]
+            : POLL_BACKOFF_MAX_MS;
+          backoffStep += 1;
+          scheduleNext(step);
+        })
+        .then(function () { inFlight = false; });
+    }
+
+    poll();
+  }
+
+  function updateJobProgress(snapshot) {
+    var processed = snapshot.processed || 0;
+    var total = snapshot.total_estimated || 0;
+    setText('celery-clear-preview-job-processed', formatNumber(processed));
+    setText('celery-clear-preview-job-total', formatNumber(total));
+    setText('celery-clear-preview-job-status', snapshot.status || 'pending');
+    var bar = $('celery-clear-preview-job-bar');
+    if (bar) {
+      bar.value = processed;
+      bar.max = total > 0 ? total : 1;
+    }
+  }
+
+  function init() {
+    var root = $('celery-clear-by-filter-preview-root');
+    if (!root) return;
+
+    if (root.dataset.countSkipped === '1') {
+      // Tier 4: the operator chose to skip the count. Server
+      // rendered with the count card hidden + submits unlocked;
+      // nothing for us to do here.
+      return;
+    }
+
+    var previewUrl = root.dataset.previewUrl;
+    if (!previewUrl) return;
+
+    setSubmitButtonsEnabled(false);
+
+    fetch(previewUrl, {
+      credentials: 'same-origin',
+      headers: { 'Accept': 'application/json' }
+    })
+      .then(function (r) {
+        if (!r.ok) {
+          // Surface server-side validation / 5xx errors with the
+          // detail message for the operator. JSON body shape:
+          // {error, detail}.
+          return r.json().then(function (payload) {
+            throw new Error(
+              (payload && payload.detail) || 'preview HTTP ' + r.status
+            );
+          }, function () {
+            throw new Error('preview HTTP ' + r.status);
+          });
+        }
+        return r.json();
+      })
+      .then(function (payload) {
+        if (payload.mode === 'job') {
+          // Stash the synchronously-fetched sample (the preview
+          // endpoint runs `_materialise_sample_targets` even in
+          // job mode because LRANGE 0 N is fast) so we can render
+          // it once the job completes; the job hash itself only
+          // tracks counts, not envelope shapes.
+          root.__previewSample = payload.sample || [];
+          // Reveal the job-mode loader card + start polling.
+          hide($('celery-clear-preview-loader'));
+          show($('celery-clear-preview-job-card'));
+          pollJob(root, payload.status_url);
+          return;
+        }
+        // Synchronous mode: fill in directly.
+        fillSynchronousResult(root, payload);
+      })
+      .catch(function (err) {
+        showError(
+          (err && err.message)
+            ? err.message
+            : 'Could not load preview. Use the skip-count link below to proceed.'
+        );
+      });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/clear_by_filter.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/clear_by_filter.html
@@ -1,7 +1,16 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls %}
+{% load i18n admin_urls static %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+{# Tier 1: lazy preview JS / CSS. Loaded via {% static %} + defer so #}
+{# the script doesn't block the skeleton render and the production CSP #}
+{# (which forbids inline <script>) doesn't reject it. #}
+<link rel="stylesheet" href="{% static 'redis_admin/css/celery_clear_by_filter_preview.css' %}">
+<script src="{% static 'redis_admin/js/celery_clear_by_filter_preview.js' %}" defer></script>
+{% endblock %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">
@@ -13,6 +22,21 @@
 {% endblock %}
 
 {% block content %}
+{# Root container exposing filter params + preview / skip-count URLs #}
+{# to the lazy-preview JS via data attributes. The JS reads these on #}
+{# DOMContentLoaded; the page itself paints with skeleton placeholders #}
+{# in <200ms regardless of queue depth — the count + sample are #}
+{# fetched asynchronously from `clear_by_filter_preview_view`. #}
+<div id="celery-clear-by-filter-preview-root"
+     class="celery-clear-by-filter-preview"
+     data-preview-url="{{ preview_url }}"
+     data-skip-count-url="{{ skip_count_url }}"
+     data-queue-name="{{ queue_name }}"
+     data-task-name="{{ task_name }}"
+     data-repoid="{% if repoid is not None %}{{ repoid }}{% endif %}"
+     data-commitid="{{ commitid }}"
+     data-count-skipped="{% if count_skipped %}1{% else %}0{% endif %}">
+
 <div id="content-main">
 
   <p>
@@ -38,6 +62,7 @@
     {% if task_name %}<input type="hidden" name="task_name" value="{{ task_name }}">{% endif %}
     {% if repoid is not None %}<input type="hidden" name="repoid" value="{{ repoid }}">{% endif %}
     {% if commitid %}<input type="hidden" name="commitid" value="{{ commitid }}">{% endif %}
+    {% if count_skipped %}<input type="hidden" name="count_skipped" value="1">{% endif %}
 
     <fieldset class="module">
       <h2>Scope</h2>
@@ -51,49 +76,86 @@
         {% else %}
           <em>(any)</em>
         {% endif %}
-        {% if match_count >= 2 and kept_index is not None %}
+        <span id="celery-clear-preview-kept-index-row" class="celery-clear-preview-hidden">
           <br>"Clear all but first" would keep
-          <code>index={{ kept_index }}</code> (the lowest-index match,
-          i.e. the next message a Celery worker would pop) and clear
-          the remaining {{ match_count|add:"-1" }} of {{ match_count }}.
-        {% endif %}
+          <code>index=<span id="celery-clear-preview-kept-index">—</span></code>
+          (the lowest-index match, i.e. the next message a Celery
+          worker would pop) and clear the remaining
+          <span id="celery-clear-preview-keep-one-remaining">—</span>
+          of <span id="celery-clear-preview-keep-one-total">—</span>.
+        </span>
       </p>
     </fieldset>
 
-    <fieldset class="module">
-      <h2>Matched: {{ match_count }} message(s)</h2>
+    {# Tier 1: skeleton loader. Replaced by celery_clear_by_filter_preview.js #}
+    {# once the JSON preview endpoint comes back. Hidden when count_skipped=1 #}
+    {# (Tier 4 escape hatch). #}
+    {% if not count_skipped %}
+    <div id="celery-clear-preview-loader" class="celery-clear-preview-loader">
+      <div class="celery-clear-preview-loader__spinner" aria-hidden="true"></div>
+      <p class="celery-clear-preview-loader__label">Counting matches…</p>
+      <p class="celery-clear-preview-loader__hint">
+        Walking the queue to count messages matching the filter.
+        On deep queues this hands off to a background job and
+        polls for completion; either way the page itself is ready
+        and you can use the skip-count link below to proceed
+        without waiting.
+      </p>
+    </div>
+    {% endif %}
 
-      {% if match_count == 0 %}
+    {# Job-mode progress card: hidden until the preview JS detects #}
+    {# `mode=job` and switches into polling. #}
+    <div id="celery-clear-preview-job-card"
+         class="celery-clear-preview-job-card celery-clear-preview-hidden"
+         aria-live="polite">
+      <p>
+        Queue is large enough that we're computing the count in a
+        background dry-run job. You can wait for it to finish, or
+        skip the count entirely (the destructive action will get
+        the live count from its own progress page).
+      </p>
+      <progress id="celery-clear-preview-job-bar"
+                class="celery-clear-preview-job-bar"
+                value="0" max="1"></progress>
+      <p>
+        <strong>Status:</strong> <span id="celery-clear-preview-job-status">pending</span>
+        &middot;
+        Processed <span id="celery-clear-preview-job-processed">0</span>
+        of ~<span id="celery-clear-preview-job-total">0</span>
+      </p>
+    </div>
+
+    {# Resolved count card: shown once the synchronous-mode preview #}
+    {# returns or the job-mode poll terminates. The Tier 4 skip-count #}
+    {# render path also reaches the form region without ever showing #}
+    {# this card (the loader is suppressed by the {% if not count_skipped %} #}
+    {# above). #}
+    <fieldset id="celery-clear-preview-count-card"
+              class="module celery-clear-preview-count-card{% if not count_skipped %} celery-clear-preview-hidden{% endif %}">
+      <h2>
+        Matched:
+        <span id="celery-clear-preview-count" class="celery-clear-preview-count-large">
+          {% if count_skipped %}—{% else %}…{% endif %}
+        </span>
+        message(s)
+        <span id="celery-clear-preview-cached-note"
+              class="celery-clear-preview-cached-note celery-clear-preview-hidden"></span>
+      </h2>
+
+      <div id="celery-clear-preview-empty"
+           class="celery-clear-preview-hidden">
         <p><em>No celery_broker messages currently match this filter.</em></p>
-      {% else %}
-        <p>
-          The first {{ sample_targets|length }} matching message(s):
-        </p>
-        <table>
-          <thead>
-            <tr>
-              <th>Index</th>
-              <th>Task</th>
-              <th>repoid</th>
-              <th>commit</th>
-              <th>task id</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for t in sample_targets %}
-            <tr>
-              <td>{{ t.index_in_queue }}</td>
-              <td>{{ t.task_name|default:"—" }}</td>
-              <td>{{ t.repoid|default_if_none:"—" }}</td>
-              <td>{% if t.commitid %}<code>{{ t.commitid|slice:":7" }}</code>{% else %}—{% endif %}</td>
-              <td>{% if t.task_id %}<code>{{ t.task_id|slice:":8" }}</code>{% else %}—{% endif %}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-        {% if match_count > sample_targets|length %}
-          <p><em>Showing first {{ sample_targets|length }} of {{ match_count }} matching message(s).</em></p>
-        {% endif %}
+      </div>
+
+      <div id="celery-clear-preview-form-area"
+           class="{% if not count_skipped %}celery-clear-preview-hidden{% endif %}">
+        <p>The first 20 matching message(s):</p>
+        <div id="celery-clear-preview-sample">
+          {% if count_skipped %}
+            <p><em>Sample skipped (count was bypassed).</em></p>
+          {% endif %}
+        </div>
 
         <h3>Confirm and clear</h3>
         <div class="form-row{% if confirm_error %} errors{% endif %}">
@@ -109,42 +171,72 @@
         </div>
 
         {% comment %}
-        Three submit buttons share the form. Server-side dispatch on
-        the `action` value:
+        Three submit buttons share the form. They start disabled
+        and the JS unlocks them once the count comes back (Tier 1)
+        or once the count-skipped flag is set (Tier 4). Server-
+        side dispatch on the `action` value:
 
         * `dry_run` — neutral / `default` styling. Audited via
           `celery_broker_clear(dry_run=True)`; queue untouched.
-        * `clear_keep_one` — destructive (red text). Only rendered
-          when match_count >= 2. Clears every match EXCEPT the
-          lowest-index one; "drop duplicate retries but leave one
-          running."
+        * `clear_keep_one` — destructive (red text). Hidden when
+          match_count <= 1 (the JS toggles this once the count
+          comes back; Tier 4 leaves it visible since the count
+          isn't known).
         * `clear_all` — destructive (red text). Clears every match.
-
-        The two destructive buttons are stacked vertically and
-        anchored to the right edge so they read as a distinct "what
-        to do once you've confirmed" cluster, separated visually
-        both from the dry-run button on the left and from each
-        other.
         {% endcomment %}
         <div class="submit-row celery-clear-actions">
-          <button type="submit" name="action" value="dry_run" class="default">
+          <button type="submit" name="action" value="dry_run"
+                  class="default"
+                  {% if not count_skipped %}disabled{% endif %}>
             Dry-run (audit only, no mutations)
           </button>
           <div class="celery-destructive-actions">
-            {% if match_count >= 2 %}
-              <button type="submit" name="action" value="clear_keep_one"
-                      class="button celery-destructive-button celery-clear-keep-one">
-                Clear all but first ({{ match_count|add:"-1" }} of {{ match_count }} from {{ queue_name }})
-              </button>
-            {% endif %}
+            <button type="submit" name="action" value="clear_keep_one"
+                    id="celery-clear-preview-button-keep-one"
+                    class="button celery-destructive-button celery-clear-keep-one{% if not count_skipped %} celery-clear-preview-hidden{% endif %}"
+                    {% if not count_skipped %}disabled{% endif %}>
+              Clear all but first
+            </button>
             <button type="submit" name="action" value="clear_all"
-                    class="button celery-destructive-button celery-clear-all">
-              Clear all ({{ match_count }} from {{ queue_name }})
+                    id="celery-clear-preview-button-clear-all"
+                    class="button celery-destructive-button celery-clear-all"
+                    {% if not count_skipped %}disabled{% endif %}>
+              Clear all{% if count_skipped %} (count skipped){% endif %}
             </button>
           </div>
         </div>
-      {% endif %}
+
+        {% if count_skipped %}
+          <p class="help" style="margin-top: 0.5em;">
+            <em>Count was skipped — the destructive action's progress
+            page will show the live count once it starts.</em>
+          </p>
+        {% endif %}
+      </div>
     </fieldset>
+
+    {# Inline error pill, hidden by default; the JS toggles it on #}
+    {# fetch failure / job failure / cancel. The skip-count link #}
+    {# below stays visible from page-load so the operator always #}
+    {# has a way forward. #}
+    <div id="celery-clear-preview-error-card"
+         class="celery-clear-preview-error-card celery-clear-preview-hidden"
+         role="alert">
+      <p id="celery-clear-preview-error" class="celery-clear-preview-error"></p>
+      <p>
+        <a class="celery-clear-preview-skip-count" href="{{ skip_count_url }}">
+          Skip count and go straight to clear &rarr;
+        </a>
+      </p>
+    </div>
+
+    {% if not count_skipped %}
+    <p class="celery-clear-preview-skip-count-row">
+      <a class="celery-clear-preview-skip-count" href="{{ skip_count_url }}">
+        Trust the filter, skip the count &rarr;
+      </a>
+    </p>
+    {% endif %}
 
     <p>
       <a href="{{ changelist_url }}">&larr; back to {{ queue_name }} messages</a>
@@ -153,13 +245,15 @@
 
 </div>
 
+</div>
+{# Closes #celery-clear-by-filter-preview-root. #}
+
 <style>
-  /* Theme-safe styling: red TEXT (not red background) on the two
-     destructive buttons so they read as obviously dangerous while
-     staying readable on Django's light/dark admin themes. We
-     deliberately don't use Django admin's `deletelink` class here
-     because that swaps the background to red and the foreground to
-     white; the user spec for this surface is "red text". */
+  /* Theme-safe styling for the destructive submit buttons (red
+     text, not red background). Same colour shape as before
+     (PR #904) — kept in this template rather than moved to the
+     external CSS so the destructive-action styling lives next to
+     the markup that uses it. */
   .celery-clear-actions {
     display: flex;
     flex-wrap: wrap;
@@ -179,14 +273,15 @@
     color: var(--error-fg, #ba2121);
     font-weight: 600;
   }
-  .celery-destructive-button:hover,
-  .celery-destructive-button:focus {
+  .celery-destructive-button:hover:not(:disabled),
+  .celery-destructive-button:focus:not(:disabled) {
     color: var(--error-fg, #ba2121);
     text-decoration: underline;
   }
-  /* Vertical separator between the two destructive options so they
-     don't read as a single chunk; the gap+border combo keeps the
-     two visually distinct without needing extra DOM. */
+  .celery-destructive-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
   .celery-destructive-actions > .celery-clear-all {
     margin-top: 0.25em;
     border-top: 1px dashed var(--border-color, var(--hairline-color, #ccc));

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/clear_by_filter.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/clear_by_filter.html
@@ -150,7 +150,16 @@
 
       <div id="celery-clear-preview-form-area"
            class="{% if not count_skipped %}celery-clear-preview-hidden{% endif %}">
-        <p>The first 20 matching message(s):</p>
+        {# Heading text is JS-rewritten on the synchronous-mode #}
+        {# preview response so the rendered count tracks the   #}
+        {# actual sample length and the operator sees "Showing #}
+        {# first N of M matching message(s)" when the sample   #}
+        {# window is narrower than the match set. The fallback #}
+        {# "Matching messages" copy stays harmless if the JS   #}
+        {# preview never lands (e.g. the Tier 4 skip-count     #}
+        {# render path, where the sample is intentionally      #}
+        {# blank). #}
+        <p id="celery-clear-preview-sample-header">Matching messages:</p>
         <div id="celery-clear-preview-sample">
           {% if count_skipped %}
             <p><em>Sample skipped (count was bypassed).</em></p>

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
@@ -513,9 +513,18 @@ def test_clear_job_status_view_returns_json_for_running_job(patched_broker, supe
     assert payload["queue_name"] == queue
     assert payload["filter_repoid"] == "1"
     assert payload["dry_run"] is True
-    # ints stay ints in JSON, not stringified.
+    # ints stay ints in JSON, not stringified. `matched` is what
+    # the lazy-preview JS in `celery_clear_by_filter_preview.js`
+    # gates `match_count` on (`typeof snapshot.matched === 'number'`)
+    # — pin it explicitly so a future regression that drops the
+    # `_int(...)` cast in `_job_progress_context` lands here loudly
+    # instead of silently re-rendering "0 matching messages" on the
+    # operator's preview page.
     assert isinstance(payload["total_estimated"], int)
     assert isinstance(payload["processed"], int)
+    assert isinstance(payload["matched"], int)
+    assert isinstance(payload["drifted"], int)
+    assert isinstance(payload["passes_run"], int)
 
 
 def test_clear_job_cancel_view_requires_post(patched_broker, superuser):

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -1266,9 +1266,14 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
     def test_chart_open_renders_preview_with_three_actions(self):
         # The chart's "Clear queue" button POSTs the bucket's scope
         # without an `action` value; the view should land on the
-        # preview page rather than mutating anything. The preview
-        # page must render all three submit buttons (dry-run,
-        # clear-all-but-first, clear-all) when match_count >= 2.
+        # preview page rather than mutating anything. With the
+        # lazy preview (PR #907) the page renders a skeleton in
+        # <200ms and the JS in `celery_clear_by_filter_preview.js`
+        # fetches the count + sample asynchronously, so this
+        # render path no longer touches Redis. All three submit
+        # buttons must still ship in the rendered HTML (the JS
+        # toggles `clear_keep_one`'s visibility based on the
+        # JSON preview's `match_count`).
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
 
@@ -1283,7 +1288,11 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
 
         assert response.status_code == 200
         body = response.content.decode("utf-8", errors="replace")
-        assert "Matched: 2 message(s)" in body
+        # Skeleton placeholders + data attributes are the contract
+        # the JS preview client reads on DOMContentLoaded.
+        assert "celery-clear-by-filter-preview-root" in body
+        assert "celery-clear-preview-loader" in body
+        assert "Counting matches" in body
         # All three action buttons are wired up via distinct
         # `action` values — assert on the form-input markers, not
         # on the visible labels, so a future copy tweak doesn't
@@ -1314,7 +1323,11 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
 
         assert response.status_code == 200
         body = response.content.decode("utf-8", errors="replace")
-        assert "Matched: 2 message(s)" in body
+        # The dry-run banner is surfaced via the Django messages
+        # framework (rendered by `admin/base.html`'s `{% block
+        # messages %}`) so the operator sees the matched count
+        # without depending on the JS preview round-trip.
+        assert "would clear 2 of 2 matching message(s)" in body
         # Dry-run did not pop the queue.
         assert self.redis.llen("celery") == 3
 
@@ -1526,16 +1539,27 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
 
         assert response.status_code == 200
         body = response.content.decode("utf-8", errors="replace")
-        # Dry-run re-renders the preview (200, no redirect) and the
-        # full match set survives in the queue.
-        assert "Matched: 3" in body
+        # Dry-run re-renders the preview (200, no redirect) with
+        # the matched count surfaced as a Django messages flash.
+        # The full match set survives in the queue.
+        assert "would clear 3 of 3 matching message(s)" in body
         assert self.redis.llen("celery") == 3
 
-    def test_clear_keep_one_button_hidden_when_only_one_match(self):
-        # Single-match preview: the destructive "Clear all but
-        # first" button must not render — there's only one message
-        # and the keep-first semantic would clear nothing. The
-        # "Clear all" button still shows.
+    def test_clear_keep_one_button_starts_hidden_in_skeleton_render(self):
+        # The lazy preview (PR #907) always server-renders all
+        # three buttons in the skeleton — visibility for the
+        # `clear_keep_one` button is JS-driven on the count
+        # response (the JS hides it when match_count <= 1). Pin
+        # the server-rendered shape: the keep-one button ships
+        # with the `celery-clear-preview-hidden` CSS class so
+        # the skeleton paint never flashes a button the JS
+        # would have hidden anyway. Server-side `not in body`
+        # assertions on the keep-one button no longer apply —
+        # the single-match-hides-keep-one invariant is now
+        # tested over the JSON preview endpoint in
+        # `test_clear_by_filter_preview.py`, plus the runtime
+        # POST guard in `test_clear_keep_one_is_noop_when_only_
+        # one_match` below.
         self._push(
             task="app.tasks.notify.NotifyTask",
             kwargs={"repoid": 1, "commitid": "aaaa"},
@@ -1553,10 +1577,14 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
 
         assert response.status_code == 200
         body = response.content.decode("utf-8", errors="replace")
-        assert "Matched: 1 message(s)" in body
         assert 'name="action" value="dry_run"' in body
         assert 'name="action" value="clear_all"' in body
-        assert 'name="action" value="clear_keep_one"' not in body
+        assert 'name="action" value="clear_keep_one"' in body
+        # Skeleton render: the keep-one submit button starts
+        # hidden until the JS reads `match_count` off the JSON
+        # preview and decides whether to surface it.
+        assert "celery-clear-preview-button-keep-one" in body
+        assert "celery-clear-keep-one celery-clear-preview-hidden" in body
 
     def test_clear_keep_one_is_noop_when_only_one_match(self):
         # Single-message bucket: `action=clear_keep_one` would have

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -1654,13 +1654,22 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
 
         # Must NOT bounce back to the changelist with a "nothing to
         # clear" flash. The destructive path is allowed to proceed
-        # (the background job page does the real depth snapshot).
+        # and lands on the background-job progress page (URL pattern
+        # `clear-by-filter/job/<uuid>/` per `get_urls`), which does
+        # the real `LLEN(queue)` snapshot itself.
         assert response.status_code in (302, 303)
         location = response["Location"]
-        assert "/clear-by-filter/progress/" in location, (
-            f"expected redirect to the progress page after a typed-"
-            f"confirmed clear_all even when the count probe failed; "
-            f"got Location={location!r}"
+        assert "/clear-by-filter/job/" in location, (
+            f"expected redirect to the background-job progress page "
+            f"after a typed-confirmed clear_all even when the count "
+            f"probe failed; got Location={location!r}"
+        )
+        # And specifically NOT the "nothing to clear" no-op redirect
+        # back to the queue's changelist that the original (buggy)
+        # commit produced (which would land on a `?queue_name__exact=…`
+        # URL with no `clear-by-filter/job/` segment).
+        assert "/clear-by-filter/job/" in location and "queue_name__exact" not in (
+            location
         )
 
     def test_dry_run_surfaces_count_failed_banner_when_count_raises(self):

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -26,6 +26,7 @@ import base64
 import json
 from types import SimpleNamespace
 from typing import Any
+from unittest import mock
 
 import fakeredis
 import pytest
@@ -1620,6 +1621,81 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
         assert len(remaining) == 1
         envelope = json.loads(remaining[0])
         assert envelope["headers"]["id"] == "only-one"
+
+    def test_clear_all_proceeds_when_count_probe_raises(self):
+        # Bugbot caught: when `streaming_celery_count` raised, the
+        # original lazy-preview commit fell back to `match_count =
+        # 0`, which then triggered the very next `match_count == 0`
+        # safety check and silently 302'd to "nothing to clear" —
+        # converting a typed-confirmed destructive action into a
+        # misleading no-op redirect on a transient Redis blip.
+        # The fix: skip the count-based safety checks entirely when
+        # the count probe fails, since the typed-confirmation is
+        # the real safety gate (and the background job re-snapshots
+        # `LLEN(queue)` itself).
+        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
+        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
+
+        with mock.patch(
+            "redis_admin.admin.streaming_celery_count",
+            side_effect=RuntimeError("simulated redis blip"),
+        ):
+            response = self.client.post(
+                "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+                {
+                    "queue_name": "celery",
+                    "repoid": "1",
+                    "commitid": "aaaa",
+                    "action": "clear_all",
+                    "typed_confirm": "celery",
+                },
+                follow=False,
+            )
+
+        # Must NOT bounce back to the changelist with a "nothing to
+        # clear" flash. The destructive path is allowed to proceed
+        # (the background job page does the real depth snapshot).
+        assert response.status_code in (302, 303)
+        location = response["Location"]
+        assert "/clear-by-filter/progress/" in location, (
+            f"expected redirect to the progress page after a typed-"
+            f"confirmed clear_all even when the count probe failed; "
+            f"got Location={location!r}"
+        )
+
+    def test_dry_run_surfaces_count_failed_banner_when_count_raises(self):
+        # When the count probe raises, the dry-run path still runs
+        # (the dry-run itself walks the queue with the real filter
+        # and is the source of truth for `result.count`). The
+        # banner just drops the misleading "of N" denominator and
+        # surfaces that the count probe failed so the operator
+        # knows why the matched-total is missing.
+        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
+        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
+
+        with mock.patch(
+            "redis_admin.admin.streaming_celery_count",
+            side_effect=RuntimeError("simulated redis blip"),
+        ):
+            response = self.client.post(
+                "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+                {
+                    "queue_name": "celery",
+                    "repoid": "1",
+                    "commitid": "aaaa",
+                    "action": "dry_run",
+                },
+                follow=False,
+            )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        # The "of {match_count}" denominator is suppressed and the
+        # banner explicitly says the count probe failed.
+        assert "would clear 2 matching message(s)" in body
+        assert "count probe failed" in body
+        # Dry-run still doesn't mutate the queue.
+        assert self.redis.llen("celery") == 2
 
     def test_legacy_confirm_action_still_clears_all(self):
         # Backward-compat shim: the previous version of this view

--- a/apps/codecov-api/redis_admin/tests/test_clear_by_filter_preview.py
+++ b/apps/codecov-api/redis_admin/tests/test_clear_by_filter_preview.py
@@ -1,0 +1,554 @@
+"""Coverage for the lazy clear-by-filter preview machinery.
+
+The previous synchronous GET path called `streaming_celery_count`
++ materialised up to `CELERY_BROKER_DISPLAY_LIMIT` rows before
+painting anything; on a 1M-deep queue that's tens of seconds of
+blocking work in the gunicorn request thread. This file pins the
+four-tier replacement:
+
+* **Tier 1**: lazy preview — GET handler renders the form +
+  skeleton in <200ms, no Redis scans.
+* **Tier 2**: background count job for queues above
+  `CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT`.
+* **Tier 3**: 60s synchronous-mode count cache with `?bust=1`
+  override.
+* **Tier 4**: skip-count escape hatch.
+
+All tests run under `-m 'not django_db'`. The audit-log
+integration for the job-mode dry-run lives in
+`test_celery_broker_clear_job.py` and is exercised by CI's
+`@pytest.mark.django_db` job.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+import fakeredis
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.core.exceptions import PermissionDenied
+from django.test import RequestFactory
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin import services as redis_admin_services
+from redis_admin import settings as redis_admin_settings
+from redis_admin.admin import CeleryBrokerQueueAdmin
+from redis_admin.models import CeleryBrokerQueue
+from redis_admin.tests.test_celery_broker_clear_job import (
+    _push_envelopes,
+    _wait_for_job,
+)
+
+
+@pytest.fixture
+def patched_broker(monkeypatch) -> fakeredis.FakeStrictRedis:
+    """Single fakeredis backing both the cache (`kind="default"`,
+    where the count cache + job hash live) and the broker
+    (`kind="broker"`). Mirrors the fixture in
+    `test_celery_broker_clear_job.py` so push + count cohabit
+    one in-memory server.
+    """
+
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(
+        redis_admin_conn, "get_connection", lambda kind="default": server
+    )
+    return server
+
+
+@pytest.fixture
+def superuser():
+    """A `SimpleNamespace` superuser stand-in. The view-layer
+    permission checks read `is_superuser`; the audit-log writes
+    only need `id` / `pk`.
+    """
+
+    return SimpleNamespace(
+        id=42,
+        pk=42,
+        is_superuser=True,
+        is_staff=True,
+        is_active=True,
+        is_authenticated=True,
+        is_anonymous=False,
+        username="testop",
+    )
+
+
+@pytest.fixture
+def staff_only_user():
+    """A staff user without superuser. Used to pin the 403 gate."""
+
+    return SimpleNamespace(
+        id=43,
+        pk=43,
+        is_superuser=False,
+        is_staff=True,
+        is_active=True,
+        is_authenticated=True,
+        is_anonymous=False,
+        username="staffop",
+    )
+
+
+def _admin_instance() -> CeleryBrokerQueueAdmin:
+    return CeleryBrokerQueueAdmin(model=CeleryBrokerQueue, admin_site=AdminSite())
+
+
+def _attach_messages(request) -> None:
+    """Pin the standard `RequestFactory` boilerplate for views that
+    call `messages.error(...)` or `messages.info(...)` so the bare
+    request doesn't blow up on a missing storage backend.
+    """
+
+    request.session = {}
+    request._messages = FallbackStorage(request)
+
+
+# ---- Tier 1: lazy preview --------------------------------------------------
+
+
+def test_preview_endpoint_returns_synchronous_count_for_small_queue(
+    patched_broker, superuser
+):
+    """Below the inline-limit threshold the endpoint computes the
+    count synchronously and returns the sample inline. Pins the
+    JSON response shape the JS client unmarshals (`mode`,
+    `match_count`, `kept_index`, `sample`).
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=100, repoid=42)
+
+    rf = RequestFactory()
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": queue, "repoid": "42"},
+    )
+    request.user = superuser
+
+    admin_instance = _admin_instance()
+    response = admin_instance.clear_by_filter_preview_view(request)
+
+    assert response.status_code == 200
+    payload = json.loads(response.content)
+    assert payload["mode"] == "synchronous"
+    assert payload["match_count"] == 100
+    # _CLEAR_BY_FILTER_SAMPLE_SIZE is 20 in admin.py; pin via the
+    # fact that we pushed 100 messages and the table caps at 20.
+    assert len(payload["sample"]) == 20
+    sample_row = payload["sample"][0]
+    assert sample_row["repoid"] == 42
+    assert "task_name" in sample_row
+    assert "index_in_queue" in sample_row
+    # `kept_index` is the lowest index_in_queue match; for our push
+    # pattern that's 0 (the first message we pushed).
+    assert payload["kept_index"] == 0
+
+
+def test_preview_endpoint_uses_cache_on_second_call(patched_broker, superuser):
+    """Tier 3: the second call returns the cached count instead of
+    re-walking the queue. Asserted by counting calls into the
+    monkeypatched `streaming_celery_count`.
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=10, repoid=1)
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    call_counter = {"n": 0}
+    real_count = redis_admin_services.streaming_celery_count
+
+    def _counting_count(*args, **kwargs):
+        call_counter["n"] += 1
+        return real_count(*args, **kwargs)
+
+    with mock.patch.object(
+        redis_admin_services, "streaming_celery_count", _counting_count
+    ):
+        for _ in range(2):
+            request = rf.get(
+                "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+                data={"queue_name": queue, "repoid": "1"},
+            )
+            request.user = superuser
+            response = admin_instance.clear_by_filter_preview_view(request)
+            assert response.status_code == 200
+
+    # First call walks the queue; second call hits the cache. If
+    # this drifts (someone disables the cache or moves it out of
+    # the orchestrator), the assertion shouts about it.
+    assert call_counter["n"] == 1
+    payload = json.loads(response.content)
+    assert payload["match_count"] == 10
+    # Second call advertises that it came from cache so the JS can
+    # surface "Cached at …" in the UI.
+    assert "cached_at" in payload
+
+
+def test_preview_endpoint_bust_param_skips_cache(patched_broker, superuser):
+    """Tier 3: `?bust=1` forces a recompute. Pins the manual
+    refresh-count button against future cache-layer refactors.
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=5, repoid=1)
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    call_counter = {"n": 0}
+    real_count = redis_admin_services.streaming_celery_count
+
+    def _counting_count(*args, **kwargs):
+        call_counter["n"] += 1
+        return real_count(*args, **kwargs)
+
+    with mock.patch.object(
+        redis_admin_services, "streaming_celery_count", _counting_count
+    ):
+        # First call populates the cache.
+        request = rf.get(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+            data={"queue_name": queue, "repoid": "1"},
+        )
+        request.user = superuser
+        admin_instance.clear_by_filter_preview_view(request)
+        assert call_counter["n"] == 1
+
+        # Bust forces a recompute even though the cache is warm.
+        request = rf.get(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+            data={"queue_name": queue, "repoid": "1", "bust": "1"},
+        )
+        request.user = superuser
+        admin_instance.clear_by_filter_preview_view(request)
+        assert call_counter["n"] == 2
+
+
+def test_preview_endpoint_returns_job_mode_for_deep_queue(
+    patched_broker, superuser, monkeypatch
+):
+    """Tier 2: above the inline-limit threshold the endpoint hands
+    the count off to a `dry_run=True` chunked job and returns
+    `{mode: "job", job_id, status_url}` instead. We lower the
+    threshold under test rather than push 200_000 envelopes (which
+    would be slow even on fakeredis).
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=50, repoid=1)
+
+    monkeypatch.setattr(
+        redis_admin_settings, "CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT", 10
+    )
+
+    rf = RequestFactory()
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": queue, "repoid": "1"},
+    )
+    request.user = superuser
+
+    admin_instance = _admin_instance()
+    response = admin_instance.clear_by_filter_preview_view(request)
+
+    assert response.status_code == 200
+    payload = json.loads(response.content)
+    assert payload["mode"] == "job"
+    # job_id is a UUID string (start_celery_broker_clear_job uses
+    # `str(uuid.uuid4())`); parse round-trips assert that.
+    parsed = uuid.UUID(payload["job_id"])
+    assert str(parsed) == payload["job_id"]
+    assert payload["status_url"].endswith(f"/job/{payload['job_id']}/status/")
+    # Sample still rendered synchronously even in job mode (LRANGE
+    # 0 N is fast); operator gets a head-of-queue preview to scan
+    # while the count job runs.
+    assert isinstance(payload["sample"], list)
+    # Wait for the worker thread to drain so subsequent tests don't
+    # see a leaked daemon thread.
+    _wait_for_job(payload["job_id"], timeout=10.0)
+
+
+def test_preview_endpoint_inline_limit_setting_overrides_threshold(
+    patched_broker, superuser, monkeypatch
+):
+    """Tier 2: the threshold is overridable through the Django
+    setting `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT`.
+    We pin the same `n=20` push to flip from synchronous to job
+    mode when the threshold drops below the queue depth.
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=20, repoid=1)
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    # With the default high threshold (200_000) → synchronous.
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": queue, "repoid": "1"},
+    )
+    request.user = superuser
+    response = admin_instance.clear_by_filter_preview_view(request)
+    assert json.loads(response.content)["mode"] == "synchronous"
+
+    # Lower the threshold below the queue depth → job mode.
+    monkeypatch.setattr(redis_admin_settings, "CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT", 5)
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": queue, "repoid": "1"},
+    )
+    request.user = superuser
+    response = admin_instance.clear_by_filter_preview_view(request)
+    payload = json.loads(response.content)
+    assert payload["mode"] == "job"
+    _wait_for_job(payload["job_id"], timeout=10.0)
+
+
+def test_preview_endpoint_validates_required_filters(patched_broker, superuser):
+    """Empty `queue_name` and "queue_name only with no narrowing
+    filter" both 400 with a JSON error body so the JS surfaces
+    the inline error pill rather than following a redirect.
+    """
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    # Empty queue_name.
+    request = rf.get("/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/")
+    request.user = superuser
+    _attach_messages(request)
+    response = admin_instance.clear_by_filter_preview_view(request)
+    assert response.status_code == 400
+    payload = json.loads(response.content)
+    assert payload["error"] == "invalid_filter"
+    assert "queue_name" in payload["detail"]
+
+    # queue_name set, but no task / repoid / commitid → still 400.
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": "notify"},
+    )
+    request.user = superuser
+    _attach_messages(request)
+    response = admin_instance.clear_by_filter_preview_view(request)
+    assert response.status_code == 400
+    payload = json.loads(response.content)
+    assert payload["error"] == "invalid_filter"
+    assert (
+        "task_name" in payload["detail"]
+        or "repoid" in payload["detail"]
+        or "commitid" in payload["detail"]
+    )
+
+
+def test_preview_endpoint_requires_superuser(
+    patched_broker, superuser, staff_only_user
+):
+    """Anonymous + staff-but-not-superuser hit the same `PermissionDenied`
+    as `clear_by_filter_view`. Pins the gate against a future
+    refactor that splits permissions per view.
+    """
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    # Staff-only user (is_superuser=False) is refused.
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": "notify", "repoid": "1"},
+    )
+    request.user = staff_only_user
+    with pytest.raises(PermissionDenied):
+        admin_instance.clear_by_filter_preview_view(request)
+
+    # Anonymous user is refused.
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": "notify", "repoid": "1"},
+    )
+    request.user = SimpleNamespace(
+        is_superuser=False,
+        is_staff=False,
+        is_active=False,
+        is_authenticated=False,
+    )
+    with pytest.raises(PermissionDenied):
+        admin_instance.clear_by_filter_preview_view(request)
+
+    # Superuser sails through.
+    _push_envelopes(patched_broker, "notify", n=2, repoid=1)
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": "notify", "repoid": "1"},
+    )
+    request.user = superuser
+    response = admin_instance.clear_by_filter_preview_view(request)
+    assert response.status_code == 200
+
+
+def test_clear_by_filter_get_renders_skeleton_without_redis_scans(
+    patched_broker, superuser
+):
+    """Tier 1 invariant: the GET handler renders a 200 even when
+    every Redis-touching helper raises. Pins that the slimmed
+    handler no longer calls `streaming_celery_count` or
+    materialises the queryset on the GET path.
+    """
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("GET handler should not call streaming_celery_count")
+
+    def _boom_queryset(*args, **kwargs):
+        raise AssertionError("GET handler should not materialise the queryset")
+
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+        data={"queue_name": "notify", "repoid": "1"},
+    )
+    request.user = superuser
+    _attach_messages(request)
+
+    with (
+        mock.patch("redis_admin.admin.streaming_celery_count", _boom),
+        mock.patch.object(
+            CeleryBrokerQueueAdmin, "_materialise_sample_targets", _boom_queryset
+        ),
+    ):
+        response = admin_instance.clear_by_filter_view(request)
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    # Skeleton placeholders + data attributes survive the slim
+    # render path.
+    assert "celery-clear-by-filter-preview-root" in body
+    assert "data-preview-url" in body
+    assert "celery-clear-preview-loader" in body
+    # Submit buttons start disabled until the JS unlocks them.
+    assert "disabled" in body
+
+
+# ---- Tier 4: skip-count escape hatch ---------------------------------------
+
+
+def test_skip_count_view_redirects_to_clear_form_with_count_skipped_flag(
+    patched_broker, superuser
+):
+    """The skip-count link 302s back to `clear_by_filter_view`
+    with `count_skipped=1` set so the GET handler renders the
+    form without the count card and with the destructive submit
+    buttons unlocked.
+    """
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/skip-count/",
+        data={"queue_name": "notify", "repoid": "1"},
+    )
+    request.user = superuser
+    _attach_messages(request)
+    response = admin_instance.clear_by_filter_skip_count_view(request)
+
+    assert response.status_code == 302
+    location = response["Location"]
+    assert "clear-by-filter/" in location
+    assert "count_skipped=1" in location
+    assert "queue_name=notify" in location
+    assert "repoid=1" in location
+
+
+def test_skip_count_view_validates_filters(patched_broker, superuser):
+    """Skip-count re-validates the same filter combo. A hand-
+    crafted skip-count URL without a narrowing filter still
+    bounces the operator back to the changelist with a flash.
+    """
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/skip-count/",
+        data={"queue_name": "notify"},  # no narrowing filter
+    )
+    request.user = superuser
+    _attach_messages(request)
+    response = admin_instance.clear_by_filter_skip_count_view(request)
+    # Validation flash → redirect to the changelist (the pattern
+    # used by `clear_by_filter_view`).
+    assert response.status_code == 302
+    assert "count_skipped=1" not in response["Location"]
+
+
+def test_clear_by_filter_get_with_count_skipped_renders_form_without_loader(
+    patched_broker, superuser
+):
+    """When `count_skipped=1` is set the GET handler suppresses
+    the loader card + count card and unlocks the submit buttons
+    from page-load. Pins the Tier 4 render shape.
+    """
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+        data={
+            "queue_name": "notify",
+            "repoid": "1",
+            "count_skipped": "1",
+        },
+    )
+    request.user = superuser
+    _attach_messages(request)
+
+    response = admin_instance.clear_by_filter_view(request)
+    assert response.status_code == 200
+    body = response.content.decode()
+    # Loader card is suppressed (the {% if not count_skipped %}
+    # block doesn't emit it).
+    assert "Counting matches…" not in body
+    # The skip-count flag round-trips on the form so a typed-
+    # confirmation error doesn't snap the loader back into view.
+    assert 'name="count_skipped"' in body
+    # Submit buttons are NOT disabled in the count-skipped render.
+    assert " disabled>" not in body and " disabled " not in body
+
+
+# ---- Filter validation parity ---------------------------------------------
+
+
+def test_preview_endpoint_repoid_must_be_integer(patched_broker, superuser):
+    """`repoid` validation matches `clear_by_filter_view` — non-
+    integer input → 400. Lifts a parity invariant out of the
+    shared `_parse_clear_by_filter_params` helper so a future
+    rewrite that divorces them gets a loud test failure.
+    """
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": "notify", "repoid": "not-a-number"},
+    )
+    request.user = superuser
+    _attach_messages(request)
+    response = admin_instance.clear_by_filter_preview_view(request)
+    assert response.status_code == 400
+    payload = json.loads(response.content)
+    assert payload["error"] == "invalid_filter"
+    assert "repoid" in payload["detail"]

--- a/apps/codecov-api/redis_admin/tests/test_clear_by_filter_preview.py
+++ b/apps/codecov-api/redis_admin/tests/test_clear_by_filter_preview.py
@@ -39,6 +39,7 @@ from redis_admin import services as redis_admin_services
 from redis_admin import settings as redis_admin_settings
 from redis_admin.admin import CeleryBrokerQueueAdmin
 from redis_admin.models import CeleryBrokerQueue
+from redis_admin.services import _job_key
 from redis_admin.tests.test_celery_broker_clear_job import (
     _push_envelopes,
     _wait_for_job,
@@ -312,6 +313,173 @@ def test_preview_endpoint_inline_limit_setting_overrides_threshold(
     payload = json.loads(response.content)
     assert payload["mode"] == "job"
     _wait_for_job(payload["job_id"], timeout=10.0)
+
+
+def test_preview_endpoint_dedups_job_for_same_filter_within_lock_ttl(
+    patched_broker, superuser, monkeypatch
+):
+    """Bugbot caught: the deep-queue path used to call
+    `start_celery_broker_clear_job` unconditionally on every preview
+    request, so a page refresh / second tab / JS retry kicked off N
+    parallel full-queue scans for the same filter. The dedup helper
+    caches the in-flight `job_id` under a short TTL keyed by the
+    filter hash; subsequent calls within the window must reuse it.
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=50, repoid=1)
+    monkeypatch.setattr(
+        redis_admin_settings, "CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT", 10
+    )
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    spawn_calls = {"n": 0}
+    real_start = redis_admin_services.start_celery_broker_clear_job
+
+    def _counting_start(*args, **kwargs):
+        spawn_calls["n"] += 1
+        return real_start(*args, **kwargs)
+
+    monkeypatch.setattr(
+        redis_admin_services, "start_celery_broker_clear_job", _counting_start
+    )
+
+    def _make_request():
+        request = rf.get(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+            data={"queue_name": queue, "repoid": "1"},
+        )
+        request.user = superuser
+        return request
+
+    first = admin_instance.clear_by_filter_preview_view(_make_request())
+    assert first.status_code == 200
+    first_payload = json.loads(first.content)
+    assert first_payload["mode"] == "job"
+    first_job_id = first_payload["job_id"]
+    uuid.UUID(first_job_id)  # well-formed
+    assert spawn_calls["n"] == 1
+
+    # Second call for the same filter — must reuse the in-flight
+    # job rather than spawn a new one.
+    second = admin_instance.clear_by_filter_preview_view(_make_request())
+    assert second.status_code == 200
+    second_payload = json.loads(second.content)
+    assert second_payload["mode"] == "job"
+    assert second_payload["job_id"] == first_job_id, (
+        f"expected dedup helper to return the in-flight job_id "
+        f"({first_job_id}); got a new job_id ({second_payload['job_id']})"
+    )
+    assert spawn_calls["n"] == 1, (
+        f"expected `start_celery_broker_clear_job` to be called exactly once "
+        f"across two preview requests for the same filter; got {spawn_calls['n']}"
+    )
+
+    # Different filter → fresh spawn (the lock is keyed on the
+    # full filter tuple, not just the queue name).
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": queue, "repoid": "999"},
+    )
+    request.user = superuser
+    third = admin_instance.clear_by_filter_preview_view(request)
+    assert third.status_code == 200
+    third_payload = json.loads(third.content)
+    assert third_payload["mode"] == "job"
+    assert third_payload["job_id"] != first_job_id
+    assert spawn_calls["n"] == 2
+
+    _wait_for_job(first_job_id, timeout=10.0)
+    _wait_for_job(third_payload["job_id"], timeout=10.0)
+
+
+def test_preview_endpoint_dedup_falls_through_when_cached_job_is_stale(
+    patched_broker, superuser, monkeypatch
+):
+    """Stale-id guard: if the cached `job_id` no longer resolves to
+    a live job hash (its 24h TTL elapsed, or a redis-cli operator
+    nuked the hash) the helper must spawn a fresh job rather than
+    hand the JS a dead `job_id`.
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=50, repoid=1)
+    monkeypatch.setattr(
+        redis_admin_settings, "CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT", 10
+    )
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": queue, "repoid": "1"},
+    )
+    request.user = superuser
+    first = admin_instance.clear_by_filter_preview_view(request)
+    first_job_id = json.loads(first.content)["job_id"]
+    _wait_for_job(first_job_id, timeout=10.0)
+
+    # Simulate the job-hash TTL elapsing (or an operator deleting
+    # it via redis-cli) while the dedup lock entry survives —
+    # second call must see the stale lock, fall through, and
+    # spawn a fresh job.
+    patched_broker.delete(_job_key(first_job_id))
+
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": queue, "repoid": "1"},
+    )
+    request.user = superuser
+    second = admin_instance.clear_by_filter_preview_view(request)
+    second_payload = json.loads(second.content)
+    assert second_payload["job_id"] != first_job_id, (
+        f"expected stale-job-hash detection to spawn a fresh job_id; "
+        f"got the dead first_job_id={first_job_id}"
+    )
+    _wait_for_job(second_payload["job_id"], timeout=10.0)
+
+
+def test_preview_endpoint_returns_empty_sample_when_materialise_raises(
+    patched_broker, superuser
+):
+    """Bugbot caught: `_materialise_sample_targets` was unwrapped,
+    so a broker outage during sample lookup raised through to
+    Django's HTML 500 page from a JSON endpoint. The fix wraps it
+    in try/except so a flaky sample lookup degrades to an empty
+    sample table while the count payload still ships.
+    """
+
+    queue = "notify"
+    _push_envelopes(patched_broker, queue, n=5, repoid=1)
+
+    rf = RequestFactory()
+    admin_instance = _admin_instance()
+
+    request = rf.get(
+        "/admin/redis_admin/celerybrokerqueue/clear-by-filter/preview/",
+        data={"queue_name": queue, "repoid": "1"},
+    )
+    request.user = superuser
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated broker outage during LRANGE")
+
+    with mock.patch.object(
+        CeleryBrokerQueueAdmin, "_materialise_sample_targets", _boom
+    ):
+        response = admin_instance.clear_by_filter_preview_view(request)
+
+    assert response.status_code == 200
+    payload = json.loads(response.content)
+    # JSON endpoint contract preserved — no HTML 500 leak.
+    assert response["Content-Type"].startswith("application/json")
+    # Count still computed; sample degrades to empty list.
+    assert payload["mode"] == "synchronous"
+    assert payload["match_count"] == 5
+    assert payload["sample"] == []
 
 
 def test_preview_endpoint_validates_required_filters(patched_broker, superuser):


### PR DESCRIPTION
## Summary

Makes the `/admin/redis_admin/celerybrokerqueue/clear-by-filter/` preview page render instantly even on million-message queues. The previous synchronous GET path called `streaming_celery_count` (full `LLEN(queue)` walk) + materialised up to `CELERY_BROKER_DISPLAY_LIMIT` messages from the queryset before painting anything; on a 1M-deep queue that's 30s+ of blocking work in the request thread.

Four tiers, layered:

1. **Lazy preview load.** GET handler now renders only the filter summary + skeleton placeholders in `< 200ms`. A new JSON endpoint (`clear-by-filter/preview/?queue_name=…`) runs the count + sample on demand. JS fills them in once they arrive; submit buttons start disabled and unlock on count completion.
2. **Background count job for huge queues.** Above `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT` (default 200k), the preview endpoint kicks off a `dry_run=True` chunked-clear-job and returns `{job_id, status_url}` instead of the count. JS polls the existing clear-job status hash; on `status=completed` it reads `matched` as the match count. **Reuses #904 machinery** (`start_celery_broker_clear_job`, `clear_by_filter_status_view`) — no new audit modes, no new infrastructure.
3. **60s count cache.** Synchronous-mode counts are cached in cache Redis under `redis_admin:preview_count:<sha256(queue|task|repoid|commitid)>` with a `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_CACHE_TTL_SECONDS` TTL (default 60). Refresh / Back-Forward returns the cached count instantly with a `cached_at` field. `?bust=1` skips the cache.
4. **Skip-count escape hatch.** Muted-italic "Trust the filter, skip the count →" link on the preview, visible from page-load. Routes through a tiny `clear-by-filter/skip-count/` view that 302s back to the preview page with `count_skipped=1` set; the GET handler then suppresses the count card and unlocks the submit buttons.

The four tiers stack: a deep queue with a warm cache hits Tier 3 first; a deep queue with a cold cache + inline-limit-busting depth hits Tier 2 and polls; a typical queue hits Tier 1 inline; the operator can fall back to Tier 4 at any point if the count surface is broken or just too slow.

## Test plan

- [x] **Tier 1**: `test_clear_by_filter_get_renders_skeleton_without_redis_scans` — `streaming_celery_count` and queryset materialisation both monkeypatched to raise; GET still renders 200 with skeleton placeholders + data attrs + disabled submit buttons.
- [x] **Tier 1**: `test_preview_endpoint_returns_synchronous_count_for_small_queue` — pushes 100 envelopes, hits the endpoint, asserts `mode="synchronous"`, `match_count=100`, sample length 20.
- [x] **Tier 2**: `test_preview_endpoint_returns_job_mode_for_deep_queue` — lowers the threshold under test, asserts `mode="job"` with a UUID-shaped `job_id` and a `status_url` ending in `/job/<uuid>/status/`.
- [x] **Tier 2**: `test_preview_endpoint_inline_limit_setting_overrides_threshold` — same push pattern flips from synchronous → job mode when the setting drops below the queue depth.
- [x] **Tier 3**: `test_preview_endpoint_uses_cache_on_second_call` — monkeypatches `streaming_celery_count` with a counter; second call doesn't re-walk the queue and the response advertises `cached_at`.
- [x] **Tier 3**: `test_preview_endpoint_bust_param_skips_cache` — `?bust=1` forces a recompute even when the cache is warm.
- [x] **Tier 4**: `test_skip_count_view_redirects_to_clear_form_with_count_skipped_flag` — pins the 302 location format.
- [x] **Tier 4**: `test_clear_by_filter_get_with_count_skipped_renders_form_without_loader` — the GET handler suppresses the loader card and unlocks submit buttons when `count_skipped=1` is set.
- [x] Validation parity: `test_preview_endpoint_validates_required_filters`, `test_preview_endpoint_repoid_must_be_integer`, `test_skip_count_view_validates_filters` — same invariants as `clear_by_filter_view`, surfaced as JSON 400 on the preview endpoint.
- [x] Auth: `test_preview_endpoint_requires_superuser` — staff-only and anonymous users both `PermissionDenied`; superuser sails through.
- [ ] Audit-log integration for the job-mode dry-run path lives in `test_celery_broker_clear_job.py`'s existing chunked-mode audit test (the preview endpoint just calls `start_celery_broker_clear_job(..., dry_run=True)`, which is the path that test already covers). Not duplicated here. Verified in CI's `@pytest.mark.django_db` job.

Sandbox results: **189 passed, 30 deselected, 90 errors** in `redis_admin/tests/` (errors are all the documented "could not translate host name 'postgres'" failures for `@pytest.mark.django_db` tests — same shape as on `main`; the +12 new tests all pass and bump the green count from 177 → 189).

```
RUN_ENV=TESTING DJANGO_SETTINGS_MODULE=codecov.settings_test uv run pytest \
    -m 'not django_db' redis_admin/tests/test_clear_by_filter_preview.py -v
============================== 12 passed in 1.63s ==============================
```

## Settings introduced

| Setting | Default | Purpose |
|---|---|---|
| `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_INLINE_LIMIT` | `200_000` | `LLEN(queue)` threshold above which the preview endpoint switches to background-job mode. |
| `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_CACHE_TTL_SECONDS` | `60` | TTL for the synchronous-mode count cache. |

## Files

```
 apps/codecov-api/redis_admin/README.md             |  70 ++-
 apps/codecov-api/redis_admin/admin.py              | 624 +++++++++++++++------
 apps/codecov-api/redis_admin/services.py           | 207 +++++++
 apps/codecov-api/redis_admin/settings.py           |  26 +
 .../css/celery_clear_by_filter_preview.css         | 173 ++++++
 .../js/celery_clear_by_filter_preview.js           | 360 ++++++++++++
 .../celerybrokerqueue/clear_by_filter.html         | 237 +++++---
 .../tests/test_clear_by_filter_preview.py          | 554 ++++++++++++++++++
 8 files changed, 2017 insertions(+), 234 deletions(-)
```

## Notes for review

- The new JS / CSS load via `{% static %}` + `defer` from `clear_by_filter.html`, with no inline `<script>` — same CSP-compatible pattern as `celery_clear_progress.{js,css}` from #904.
- `_parse_clear_by_filter_params` is the single chokepoint for filter validation; both the HTML and JSON entrypoints route through it so a future filter rule (e.g. tightening `commitid` length) lands in one place.
- Job-mode response carries the synchronously-fetched sample (`LRANGE 0 N` is fast even on million-message queues), so the preview table renders immediately even while the count job is still running.
- The destructive POST path still computes `match_count` synchronously for the safety checks (`match_count == 0` early-return, `clear_keep_one` single-match guard) and the dry-run banner. That's intentional: those checks need the live count, and `start_celery_broker_clear_job` itself re-snapshots `LLEN(queue)` so the progress page total isn't tied to the preview's count.
- No conflict with #906 (already merged).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches superuser-only admin flows that can trigger destructive queue-clears, and adds new JSON/job orchestration + caching that could affect operator UX and Redis load if incorrect.
> 
> **Overview**
> **Speeds up the `celerybrokerqueue/clear-by-filter/` preview** by removing synchronous Redis scans from the GET handler and replacing them with a skeleton page populated by new lazy-preview JS.
> 
> Adds a superuser-only `clear-by-filter/preview/` JSON endpoint that returns either an inline count (with a short-lived Redis cache and `?bust=1`) or a `dry_run` chunked-job id for deep queues (with job-id deduping), plus a `clear-by-filter/skip-count/` escape hatch that unlocks destructive actions without waiting for counts. Updates the template/UI accordingly, introduces new settings knobs for thresholds/TTLs, and adds/adjusts tests to pin the new response shapes and failure-mode behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 308ea620801d1b74d079e78513b96eff448845d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->