### PR TITLE
fix(redis_admin): restore pre-#899 pipeline-LSET clear; drop fragile verify guard

### DIFF
--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -442,8 +442,18 @@ _CELERY_TOMBSTONE_PREFIX = "__redis_admin_celery_tombstone__"
 # Chunk size for streaming LRANGE during clear.
 _CELERY_CLEAR_CHUNK: int = 10_000
 
-# Maximum passes in the repeat-until-stable loop.
-_CELERY_MAX_PASSES: int = 3
+# Maximum passes in the repeat-until-stable loop. Bumped from 3 to 10
+# alongside the pre-#899 pipeline-LSET restoration: with verify-before-
+# LSET gone the per-pass throughput is much higher (no LINDEX RTT per
+# match), but a saturated queue with active producers / retries can
+# still need several passes to converge. The plateau exit was
+# intentionally dropped at the same time -- on a busy queue the prior
+# `prev_lset == matches_lset` check fired against legitimate progress
+# (each pass cleared ~the same number of matches) and the operator saw
+# the queue stay full. Convergence is now bounded only by
+# `matches_found == 0` (queue drained of the filter triple) plus this
+# pass cap.
+_CELERY_MAX_PASSES: int = 10
 
 
 def _celery_clear_tombstone() -> str:
@@ -463,9 +473,9 @@ class _FilterWildcard:
     *every* `sync_repos` message in the queue rather than just
     the one the operator selected.
 
-    Operator-input paths (`streaming_celery_count` and the
-    `clear_by_filter_view` synthetic target) substitute this
-    sentinel for any unset filter slot before building the
+    Operator-input paths (the chunked clear job in
+    `_run_celery_broker_clear_job_body`) substitute this sentinel
+    for any unset filter slot before building the
     `(task, repoid, commitid)` tuple.
     """
 
@@ -485,21 +495,13 @@ def _substitute_filter_any(
 ) -> tuple:
     """Substitute `_FILTER_ANY` for unset operator filter slots.
 
-    Operator-input clear paths (`streaming_celery_count`, the
-    chunked clear job in `_run_celery_broker_clear_job_body`,
-    and the `clear_by_filter_view` synthetic target) all need
-    to convert the form's per-slot `None` / empty-string into
+    The chunked clear job (`_run_celery_broker_clear_job_body`)
+    converts the operator's per-slot `None` / empty-string into
     the wildcard sentinel before handing the triple to
-    `_envelope_matches_any_filter` (or to a synthetic
-    `CeleryBrokerQueue` row carrying the same comparison
-    semantics). Centralising the substitution rule keeps the
-    dry-run count, the chunked clear, and the synchronous
-    `clear_by_filter_view` preview from drifting if the rule
-    later changes (e.g. a new filter field is added or a
-    slot's truthiness check is loosened) — a divergence here
-    would manifest as the dry-run count disagreeing with the
-    chunked clear's matched count, which is a data-loss
-    vector.
+    `_envelope_matches_any_filter`. Centralising the substitution
+    rule means the dry-run and live chunked-clear counts can never
+    disagree about which envelopes match — a divergence there would
+    be a data-loss vector.
 
     The truthiness-vs-`is None` asymmetry is intentional:
     `repoid` is an integer where `0` could in principle be a
@@ -592,26 +594,31 @@ def _streaming_celery_clear(
     chunk_size: int | None = None,
     progress_callback: Callable[[_ChunkProgress], bool] | None = None,
 ) -> _StreamingClearStats:
-    """Streaming LRANGE+verify-before-LSET clear for `queue_name`.
+    """Streaming LRANGE+pipelined-LSET clear for `queue_name`.
 
     Walks the **entire** queue in `_CELERY_CLEAR_CHUNK`-row chunks,
     identifies messages whose parsed `(task_name, repoid, commitid)`
-    triple appears in `filter_tuples`, and for each match:
-
-    1. Issues `LINDEX key idx` to re-read the raw bytes at that
-       position.
-    2. Compares LINDEX bytes to the LRANGE snapshot bytes. If they
-       differ (drift — a consumer BLPOPed from the head, shifting
-       indexes), the slot is skipped.
-    3. Issues `LSET key idx tombstone` on a clean match.
+    triple appears in `filter_tuples`, collects those matches into a
+    per-chunk `(idx, raw)` list, then issues a single
+    `pipeline(transaction=False)` of `LSET key idx tombstone` ops for
+    every match in the chunk. Pipeline replies are consumed with
+    `raise_on_error=False`: each `Exception` reply (LSET out-of-range
+    because a consumer drained the slot mid-clear) increments
+    `matches_drifted` instead of taking the whole pipeline down.
 
     After each full pass, `LREM key 0 tombstone` sweeps all
-    tombstones in one shot.
+    tombstones written this pass and its return value (the number of
+    list elements actually removed) is logged so on-call can confirm
+    the LSET → LREM round-trip from the structured logs alone.
 
-    The loop repeats up to `_CELERY_MAX_PASSES` times, stopping
-    early when a pass finds zero matches (queue drained of matches)
-    OR two consecutive passes tombstone the same count (stable
-    point reached — pathological persistent-drift signal).
+    The loop repeats up to `_CELERY_MAX_PASSES` times (default 10),
+    stopping early when:
+
+    * `matches_found == 0` for the pass (queue drained of the filter
+      triple), OR
+    * `keep_one=True` and `matches_drifted == 0` for the pass (no
+      failed LSETs means the queue is converged for keep_one mode —
+      every match except the lowest-index keeper is tombstoned).
 
     `keep_one=True` skips the first matching message encountered in
     the first pass and on all subsequent passes, implementing the
@@ -619,14 +626,15 @@ def _streaming_celery_clear(
 
     On `dry_run=True` we walk the queue exactly once and accumulate
     `total_found` without issuing any LSET/LREM. The dry-run preview
-    only needs the count, not race coverage, so multi-pass would
-    just re-scan a quiet queue for no benefit (and on a 500k-deep
-    queue that's a real cost).
+    only needs the count; multi-pass would just re-scan a quiet
+    queue for no benefit (and on a 500k-deep queue that's a real
+    cost).
 
     Returns a `_StreamingClearStats` carrying `total_lset` (slots
-    tombstoned), `total_drifted` (slots skipped due to LRANGE/LINDEX
-    drift), `total_found` (every match observed across passes —
-    populated for the dry-run preview), and `passes_run`.
+    tombstoned), `total_drifted` (LSET pipeline replies that came
+    back as `Exception` — out-of-range, the consumer-drained-the-
+    slot signal), `total_found` (every match observed across passes
+    — populated for the dry-run preview), and `passes_run`.
 
     `chunk_size`, when set, overrides `_CELERY_CLEAR_CHUNK` for the
     LRANGE step. The chunked background-job worker
@@ -644,9 +652,51 @@ def _streaming_celery_clear(
     `_StreamingClearStats.cancelled` is set so the chunked worker
     can flip the job hash to `"cancelled"`. Returning `False` (or
     `None`) lets the loop continue. Cancel only ever lands at chunk
-    boundaries — never mid-LSET — so an LSET we already issued is
-    always paired with the corresponding LREM at the next pass-end
-    or cancel-drain.
+    boundaries — never mid-LSET pipeline — so an LSET we already
+    issued is always paired with the corresponding LREM at the next
+    pass-end or cancel-drain.
+
+    Trade-off (data-loss surface area)
+    ----------------------------------
+    PR #899 (`aa56fc351`) added a verify-before-LSET guard
+    (LINDEX-then-compare-then-LSET per match) on top of PR #895's
+    (`da3a7e071`) original pipelined-LSET clear. Intent: never
+    overwrite the wrong slot if a consumer popped K messages from
+    the head between our LRANGE snapshot and our LSET, shifting all
+    indexes down by K. In practice the guard turned a single LSET
+    into LINDEX + LSET RTTs *per match*, and on the user's busy
+    `bundles_analysis` broker (78k matches with consumers actively
+    BLPOPing) it dropped the LSET success rate to ~3% — the operator
+    saw `matched=2038, drift=77475` and a queue that didn't shrink.
+
+    The current implementation deliberately drops verify-before-LSET
+    and accepts the bounded data-loss risk per the operator's
+    explicit directive (issue thread on PR #904's followup): "I'm ok
+    if we lose a few tasks along the way and we make secondary
+    passes, but I do care that if I'm trying to remove 50% of the
+    queue, that there is a significant drop." Concretely, between
+    the chunk's `LRANGE` snapshot and the pipelined `LSET` of every
+    match in that chunk, K consumer BLPOPs shift all indexes down by
+    K. Our LSET at slot 50 then overwrites whatever's at slot 50
+    *now* (which used to be at slot 50+K — a different message).
+    That overwritten message is destroyed by the subsequent `LREM`.
+
+    Mitigation: chunked LRANGE → pipelined LSET keeps the shift
+    window short (sub-second per chunk on a typical queue). At
+    `chunk_size=1000` and a consumer popping ~25 messages/sec the
+    shift is bounded to a handful of slots per chunk, so the
+    upper bound on accidentally-destroyed unrelated messages is
+    `consumer_pops_per_chunk × chunks_per_pass`. The operator's
+    workflow ("clear retry storms for repo X commit Y") tolerates
+    this because the destroyed messages are statistically dominated
+    by the same retry storm we're trying to drain.
+
+    The keep_one semantic still survives this trade-off because
+    pass 1's keeper is the *lowest-index* match in pass 1's LRANGE
+    snapshot. Even if a consumer pops the keeper between our LRANGE
+    and our pipelined LSET, the new lowest-index match in pass 2
+    becomes the next keeper — the queue always retains at least one
+    matching message after a successful keep_one clear.
     """
 
     chunk = chunk_size if chunk_size is not None else _CELERY_CLEAR_CHUNK
@@ -661,7 +711,6 @@ def _streaming_celery_clear(
     # render the "Clear all but first" callout (`kept_index`)
     # without a separate queryset materialisation.
     first_match_index: int | None = None
-    prev_lset: int | None = None
     passes_run = 0
 
     # Track whether we've kept the "first" across all passes so that
@@ -690,6 +739,12 @@ def _streaming_celery_clear(
         # `prev_lset == matches_lset` plateau exit then declared
         # convergence with most of the queue still in place.
         depth = int(redis.llen(queue_name) or 0)
+        log.info(
+            "redis_admin.streaming_clear: queue=%s pass=%d depth=%d",
+            queue_name,
+            passes_run,
+            depth,
+        )
         # Track chunk index + count for the progress callback so the
         # progress page can render "pass 2 / 3, chunk 47 / 213". The
         # `chunks_total` is computed off the snapshot depth — fine
@@ -703,6 +758,12 @@ def _streaming_celery_clear(
             chunk_lset_before = matches_lset
             chunk_drifted_before = matches_drifted
             chunk_found_before = matches_found
+            # Collect every (idx, raw) match in this chunk so we can
+            # batch them into a single pipelined LSET below. The
+            # iteration order matches LRANGE order (ascending index)
+            # so `first_match_index` and the keep_one "skip lowest"
+            # semantics still hold against pass 1's LRANGE snapshot.
+            chunk_lset_targets: list[int] = []
             for offset, raw in enumerate(raw_chunk):
                 # Skip already-tombstoned slots from this or a
                 # concurrent clear.
@@ -728,19 +789,39 @@ def _streaming_celery_clear(
                 if dry_run:
                     continue
 
-                # Verify-before-LSET: re-read the slot via LINDEX
-                # and compare raw bytes to our LRANGE snapshot.
-                current_raw = redis.lindex(queue_name, idx)
-                if current_raw != raw:
-                    matches_drifted += 1
-                    continue
+                chunk_lset_targets.append(idx)
 
+            if chunk_lset_targets:
+                # Pipelined LSET (PR #895's pre-#899 pattern):
+                # tolerate per-op failures via `raise_on_error=False`
+                # so a single out-of-range slot (consumer drained the
+                # tail concurrently) doesn't fail the whole pipeline.
+                # Each `Exception` reply increments `matches_drifted`
+                # — the same counter the verify-before-LSET path used,
+                # but now bounded by genuine LSET failures rather than
+                # every LRANGE/LINDEX byte mismatch. See the docstring
+                # for the data-loss trade-off rationale.
+                pipe = redis.pipeline(transaction=False)
+                for idx in chunk_lset_targets:
+                    pipe.lset(queue_name, idx, tombstone)
                 try:
-                    redis.lset(queue_name, idx, tombstone)
-                    matches_lset += 1
-                except Exception:
-                    # Out-of-range: consumer drained this slot.
-                    matches_drifted += 1
+                    replies = pipe.execute(raise_on_error=False)
+                except TypeError:  # pragma: no cover - older clients
+                    # Some test doubles don't accept the kwarg; fall
+                    # back to default execute(). On full-pipeline
+                    # failure here mark every target as drifted so
+                    # the caller's stats still sum to the chunk size.
+                    try:
+                        replies = pipe.execute()
+                    except Exception:  # pragma: no cover - defensive
+                        replies = [Exception("pipeline failed")] * len(
+                            chunk_lset_targets
+                        )
+                for reply in replies:
+                    if isinstance(reply, Exception):
+                        matches_drifted += 1
+                    else:
+                        matches_lset += 1
 
             if progress_callback is not None:
                 # `chunk_index` is 0-based: the first chunk in a
@@ -802,35 +883,65 @@ def _streaming_celery_clear(
                     )
             chunk_index += 1
 
+        # Per-pass diagnostic line so on-call investigations don't
+        # have to drive the streaming clear from the progress page to
+        # see what each pass did. Emitted pre-LREM so the values match
+        # what was just LSET (LREM removes them right after).
+        log.info(
+            "redis_admin.streaming_clear: queue=%s pass=%d "
+            "found=%d lset=%d drifted=%d pass_first_kept=%s",
+            queue_name,
+            passes_run,
+            matches_found,
+            matches_lset,
+            matches_drifted,
+            pass_first_kept,
+        )
         if not dry_run:
-            redis.lrem(queue_name, 0, tombstone)
+            removed = redis.lrem(queue_name, 0, tombstone)
+            try:
+                removed_count = int(removed or 0)
+            except (TypeError, ValueError):
+                removed_count = 0
+            # The "queue dropped by N" line operators rely on. Pinned
+            # alongside the pass-end counts above so a single grep for
+            # `redis_admin.streaming_clear` per queue + job ties the
+            # found / lset / drifted counts to the actual LLEN delta.
+            log.info(
+                "redis_admin.streaming_clear: queue=%s pass=%d lrem_removed=%d",
+                queue_name,
+                passes_run,
+                removed_count,
+            )
 
         total_lset += matches_lset
         total_drifted += matches_drifted
         total_found += matches_found
 
         # Dry-run only needs the count; one full scan is exact for a
-        # quiet queue and the streaming-clear semantics for the preview
-        # don't need the verify-before-LSET race coverage that justifies
-        # multi-pass on the executing path.
+        # quiet queue.
         if dry_run:
             break
-        # Stability check: stop when no matches or lset count plateaued.
+        # Convergence: stop when the queue is drained of the filter
+        # triple. With verify-before-LSET gone (PR #895 → #899 → this
+        # PR) the only legitimate reason to loop again is to pick up
+        # matches that shifted into our window between passes — the
+        # `prev_lset == matches_lset` plateau exit was deleted because
+        # on a busy queue it fired against legitimate per-pass progress
+        # (each pass clearing ~the same number of matches) and the
+        # operator saw the queue stay full.
         if matches_found == 0:
             break
         if keep_one and matches_drifted == 0:
             # With keep_one we deliberately leave the first match in
-            # place, so the only reason to loop again is to retry
-            # drifted slots. When no drift occurred this pass, the
-            # queue has converged (non-keeper matches are cleared,
-            # keeper survives) — exit early to avoid an extra full
-            # LRANGE scan at 500k depth. If drift did occur, fall
-            # through to the plateau check so the next pass can
-            # retry.
+            # place. Without verify-before-LSET, `matches_drifted` only
+            # increments when an LSET reply came back as Exception
+            # (out-of-range — consumer drained the tail). Zero drift
+            # means every non-keeper match this pass was successfully
+            # tombstoned, so the queue has converged for keep_one mode
+            # — exit early to avoid an extra full LRANGE scan at 500k
+            # depth.
             break
-        if prev_lset is not None and matches_lset == prev_lset:
-            break
-        prev_lset = matches_lset
 
     return _StreamingClearStats(
         total_lset=total_lset,
@@ -1348,11 +1459,10 @@ def _run_celery_broker_clear_job_body(
     cache.hset(key, "status", "running")
     cache.hset(key, "updated_at", _utc_now_iso())
 
-    # Build the same `_FILTER_ANY`-substituted filter the
-    # synchronous `streaming_celery_count` uses, so an unset
-    # operator slot becomes a wildcard rather than an exact-`None`
-    # match (which would zero-match for any envelope whose field
-    # wasn't literally `None`).
+    # Substitute `_FILTER_ANY` for unset operator slots so an
+    # empty form field acts as a wildcard rather than an exact-
+    # `None` match (which would zero-match for any envelope
+    # whose field wasn't literally `None`).
     filter_tuples = frozenset({_substitute_filter_any(task_name, repoid, commitid)})
 
     def _progress_callback(snapshot: _ChunkProgress) -> bool:

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -901,7 +901,9 @@ def _streaming_celery_clear(
             removed = redis.lrem(queue_name, 0, tombstone)
             try:
                 removed_count = int(removed or 0)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                # Real `LREM` always returns int; this branch only
+                # fires for misbehaving test doubles.
                 removed_count = 0
             # The "queue dropped by N" line operators rely on. Pinned
             # alongside the pass-end counts above so a single grep for

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
@@ -596,6 +596,61 @@ def test_streaming_clear_makes_progress_under_concurrent_drift(patched_broker):
     assert patched_broker.llen(queue) == 0
 
 
+def test_streaming_clear_counts_pipelined_lset_out_of_range_as_drift(patched_broker):
+    """When the pipelined `LSET` reply for a slot comes back as an
+    `Exception` (out-of-range — a consumer drained the tail between
+    our LRANGE snapshot and the pipeline's flush), the corresponding
+    match increments `total_drifted` instead of `total_lset`.
+
+    Exercises the `isinstance(reply, Exception)` branch in the
+    pipelined LSET reply loop. Simulates real consumer-drain by
+    wrapping `redis.pipeline(...)` and chopping the queue down to a
+    smaller depth between match-collection and pipeline flush, so
+    LSETs against slots past the new tail come back as out-of-range
+    errors.
+    """
+
+    queue = "bundle_analysis"
+    matches = 50
+    repoid = 1
+    commitid = "y" * 40
+    _push_envelopes(patched_broker, queue, n=matches, repoid=repoid, commitid=commitid)
+
+    real_pipeline = patched_broker.pipeline
+
+    def chopping_pipeline(*args, **kwargs):
+        # Drop the back half of the queue right before the LSET
+        # pipeline flushes — every LSET against an index >= 25 will
+        # come back as an out-of-range Exception reply, exactly the
+        # signal `matches_drifted` is meant to capture.
+        patched_broker.ltrim(queue, 0, 24)
+        return real_pipeline(*args, **kwargs)
+
+    patched_broker.pipeline = chopping_pipeline
+
+    tombstone = "__redis_admin_celery_tombstone__:test-pipeline-out-of-range"
+    filter_tuples = frozenset(
+        {("app.tasks.bundle_analysis.BundleAnalysisProcessor", repoid, commitid)}
+    )
+    stats = _streaming_celery_clear(
+        patched_broker,
+        queue,
+        filter_tuples,
+        tombstone,
+        keep_one=False,
+        dry_run=False,
+    )
+
+    # Half the matches lived past the chop, so their pipelined LSET
+    # came back as an out-of-range Exception reply -> drift. The other
+    # half landed inside the trimmed range and were tombstoned.
+    assert stats.total_lset == 25
+    assert stats.total_drifted == 25
+    # The tombstones in the trimmed range were swept by the end-of-pass
+    # LREM, leaving the queue completely drained.
+    assert patched_broker.llen(queue) == 0
+
+
 # ---- View layer ------------------------------------------------------------
 
 

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
@@ -452,6 +452,150 @@ def test_clear_job_failure_records_status_failed_and_swallows_exception(
     assert True
 
 
+# ---- Regression: pipeline-LSET drain (drop verify-before-LSET) ------------
+#
+# Pinned by this PR's followup directive after PR #899's verify-before-
+# LSET guard regressed the operator's `bundles_analysis` clear (queue
+# stayed full because 97% of matches were skipped as "drift"). The
+# tests below assert the post-fix behaviour:
+#
+# * the LSET → LREM round-trip actually shrinks `LLEN(queue)` by the
+#   number of matches we tombstone (the operator's "if I'm trying to
+#   remove 50% of the queue, that there is a significant drop" check),
+# * concurrent drift no longer collapses the per-pass LSET count: the
+#   pipelined pattern issues every LSET unconditionally and only
+#   counts an Exception reply (LSET out-of-range) as drift.
+
+
+def test_streaming_clear_drops_50pct_of_queue_in_first_pass(patched_broker, superuser):
+    """Seeds 100 envelopes (50 matching the filter, 50 not), runs the
+    chunked clear job with no concurrency, and asserts the queue
+    drops by ~50 messages in a single pass — the explicit user
+    invariant from the PR directive.
+
+    Two sub-asserts back the headline:
+
+    * `LLEN(queue)` after the worker exits is `100 - 50 = 50`
+      (no `keep_one`, no concurrent consumers / producers).
+    * The audit-log job hash records `matched=50` and the surviving
+      messages all parse as the *non-matching* envelope shape, so
+      we know the LSET → LREM pipeline didn't tombstone the wrong
+      slots.
+    """
+
+    queue = "bundle_analysis"
+    matching_repoid = 21222368
+    matching_commitid = "0832c11a1f43c5e2a1b9f8a3e5d1c2b7e9a8d3f0"
+    other_repoid = 99999
+    other_commitid = "f" * 40
+
+    pipe = patched_broker.pipeline(transaction=False)
+    matching_envelope = _build_envelope(
+        task="app.tasks.bundle_analysis.BundleAnalysisProcessor",
+        kwargs={"repoid": matching_repoid, "commitid": matching_commitid},
+    )
+    other_envelope = _build_envelope(
+        task="app.tasks.notify.NotifyTask",
+        kwargs={"repoid": other_repoid, "commitid": other_commitid},
+    )
+    # Interleave 50 matching + 50 non-matching so the chunked clear's
+    # pipelined LSET has to skip-and-pick across slot indexes rather
+    # than blindly LSET a contiguous head-of-queue run.
+    for _ in range(50):
+        pipe.rpush(queue, matching_envelope)
+        pipe.rpush(queue, other_envelope)
+    pipe.execute()
+    initial_depth = patched_broker.llen(queue)
+    assert initial_depth == 100
+
+    job_id = start_celery_broker_clear_job(
+        queue,
+        user=superuser,
+        task_name="app.tasks.bundle_analysis.BundleAnalysisProcessor",
+        repoid=matching_repoid,
+        commitid=matching_commitid,
+        keep_one=False,
+        dry_run=False,
+    )
+    _wait_for_job(job_id, timeout=15.0)
+
+    job = get_celery_broker_clear_job(job_id)
+    assert job is not None
+    assert job["status"] == "completed"
+    assert int(job["matched"]) == 50
+    # Headline assertion: the queue dropped by 50 (significant drop
+    # the operator wanted to see).
+    assert patched_broker.llen(queue) == 50
+    # Positive walk: every survivor is a non-matching envelope.
+    survivors = patched_broker.lrange(queue, 0, -1)
+    for raw in survivors:
+        meta = redis_admin_services.parse_celery_envelope(
+            raw if isinstance(raw, bytes) else raw.encode()
+        )
+        assert meta.repoid == other_repoid
+
+
+def test_streaming_clear_makes_progress_under_concurrent_drift(patched_broker):
+    """Confirms `total_lset > 0` under simulated drift: even when
+    the LRANGE-snapshot bytes do not match the slot's *current*
+    bytes (consumer-pop scenario), the pipelined unconditional LSET
+    still tombstones every match in the chunk and the LREM sweep
+    still removes them.
+
+    Patches `LINDEX` on `patched_broker` to always return a
+    non-matching envelope. With the old verify-before-LSET path
+    this monkey-patch caused `matches_drifted` to absorb every
+    match and `total_lset` to go to zero (the regression PR #899
+    introduced). With the pipelined path we never call LINDEX in
+    the clear loop, so the patch should have zero effect on the
+    outcome — `total_lset == matches`.
+    """
+
+    queue = "bundle_analysis"
+    matches = 200
+    repoid = 1
+    commitid = "x" * 40
+    _push_envelopes(patched_broker, queue, n=matches, repoid=repoid, commitid=commitid)
+
+    # Patch LINDEX to always return a different envelope, simulating
+    # the worst-case drift scenario the verify-before-LSET path was
+    # designed to catch. The pipelined clear should ignore LINDEX
+    # entirely.
+    real_lindex = patched_broker.lindex
+
+    def drifted_lindex(name, idx):
+        if name == queue:
+            return _build_envelope(
+                task="t.OTHER",
+                kwargs={"repoid": 99, "commitid": "z" * 40},
+            ).encode()
+        return real_lindex(name, idx)
+
+    patched_broker.lindex = drifted_lindex
+
+    tombstone = "__redis_admin_celery_tombstone__:test-no-verify-pipeline"
+    filter_tuples = frozenset(
+        {("app.tasks.bundle_analysis.BundleAnalysisProcessor", repoid, commitid)}
+    )
+    stats = _streaming_celery_clear(
+        patched_broker,
+        queue,
+        filter_tuples,
+        tombstone,
+        keep_one=False,
+        dry_run=False,
+    )
+
+    # Every match was LSET unconditionally; LINDEX drift is no longer
+    # observed by the clear loop so total_drifted is 0 on a quiet
+    # fakeredis (no genuine LSET out-of-range failures).
+    assert stats.total_lset == matches
+    assert stats.total_drifted == 0
+    # And the queue actually drained — the explicit invariant the
+    # operator's directive demanded.
+    assert patched_broker.llen(queue) == 0
+
+
 # ---- View layer ------------------------------------------------------------
 
 

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -36,6 +36,7 @@ from django.test import Client as DjClient
 from django.test import TestCase
 
 from redis_admin import conn as redis_admin_conn
+from redis_admin import services as redis_admin_services
 from redis_admin import settings as redis_admin_settings
 from redis_admin.admin import CeleryBrokerQueueAdmin, _resolve_repo_displays
 from redis_admin.families import parse_celery_envelope
@@ -1263,6 +1264,52 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
     def _push(self, **kwargs):
         self.redis.rpush("celery", _build_envelope(**kwargs))
 
+    def _post_clear(self, **post_data):
+        """Submit a clear-by-filter POST and join the chunked clear
+        worker thread before returning so tests asserting on queue
+        state don't race the LSET / LREM background work.
+
+        The clear-by-filter view spawns a daemon worker (see
+        `start_celery_broker_clear_job`) and 302s immediately. With
+        the streaming-clear path running pipelined LSETs (per the
+        pre-#899 restoration in this PR), the worker can take a few
+        ms longer than before; CI runners with noisy neighbours have
+        observed the test asserting before the LREM lands. Parses
+        the redirect's `<job_id>` segment and `thread.join`s the
+        matching worker thread (with a generous timeout). Falls back
+        to joining every live worker thread if the redirect target
+        isn't a progress page (e.g. typed-confirm validation failed
+        and the view 200-rendered the form).
+        """
+
+        response = self.client.post(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+            post_data,
+            follow=False,
+        )
+        location = response.get("Location") or ""
+        job_id: str | None = None
+        if "/clear-by-filter/job/" in location:
+            tail = location.rstrip("/").rsplit("/", 1)[-1]
+            if len(tail) == 36 and tail.count("-") == 4:
+                job_id = tail
+        threads_to_join: list = []
+        with redis_admin_services._clear_job_threads_lock:
+            if job_id is not None:
+                t = redis_admin_services._clear_job_threads.get(job_id)
+                if t is not None:
+                    threads_to_join.append(t)
+            else:
+                threads_to_join.extend(
+                    list(redis_admin_services._clear_job_threads.values())
+                )
+        for t in threads_to_join:
+            t.join(timeout=10.0)
+            assert not t.is_alive(), (
+                f"clear-job worker thread {t.name} did not exit within 10s"
+            )
+        return response
+
     def test_chart_open_renders_preview_with_three_actions(self):
         # The chart's "Clear queue" button POSTs the bucket's scope
         # without an `action` value; the view should land on the
@@ -1323,16 +1370,12 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
         self._push(kwargs={"repoid": 2, "commitid": "bbbb"})
 
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "repoid": "1",
-                "commitid": "aaaa",
-                "action": "clear_all",
-                "typed_confirm": "celery",
-            },
-            follow=False,
+        response = self._post_clear(
+            queue_name="celery",
+            repoid="1",
+            commitid="aaaa",
+            action="clear_all",
+            typed_confirm="celery",
         )
 
         assert response.status_code in (302, 303)
@@ -1404,17 +1447,13 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
             kwargs={"repoid": 1, "commitid": "aaaa"},
         )
 
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "task_name": "app.tasks.bundle_analysis.BundleAnalysisProcessor",
-                "repoid": "1",
-                "commitid": "aaaa",
-                "action": "clear_all",
-                "typed_confirm": "celery",
-            },
-            follow=False,
+        response = self._post_clear(
+            queue_name="celery",
+            task_name="app.tasks.bundle_analysis.BundleAnalysisProcessor",
+            repoid="1",
+            commitid="aaaa",
+            action="clear_all",
+            typed_confirm="celery",
         )
 
         assert response.status_code in (302, 303)
@@ -1438,15 +1477,11 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
             kwargs={"repoid": 1, "commitid": "aaaa"},
         )
 
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "task_name": "app.tasks.notify.NotifyTask",
-                "action": "clear_all",
-                "typed_confirm": "celery",
-            },
-            follow=False,
+        response = self._post_clear(
+            queue_name="celery",
+            task_name="app.tasks.notify.NotifyTask",
+            action="clear_all",
+            typed_confirm="celery",
         )
 
         assert response.status_code in (302, 303)
@@ -1485,17 +1520,13 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
             kwargs={"repoid": 99, "commitid": "zzzz"},
         )
 
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "task_name": "app.tasks.notify.NotifyTask",
-                "repoid": "1",
-                "commitid": "aaaa",
-                "action": "clear_keep_one",
-                "typed_confirm": "celery",
-            },
-            follow=False,
+        response = self._post_clear(
+            queue_name="celery",
+            task_name="app.tasks.notify.NotifyTask",
+            repoid="1",
+            commitid="aaaa",
+            action="clear_keep_one",
+            typed_confirm="celery",
         )
 
         assert response.status_code in (302, 303)
@@ -1601,16 +1632,12 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
 
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "repoid": "1",
-                "commitid": "aaaa",
-                "action": "confirm",
-                "typed_confirm": "celery",
-            },
-            follow=False,
+        response = self._post_clear(
+            queue_name="celery",
+            repoid="1",
+            commitid="aaaa",
+            action="confirm",
+            typed_confirm="celery",
         )
 
         assert response.status_code in (302, 303)
@@ -1632,18 +1659,14 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
             kwargs={"repoid": 1, "commitid": "aaaa"},
         )
 
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "task_name": "t.K",
-                "repoid": "1",
-                "commitid": "aaaa",
-                "mode": "keep_one",
-                "action": "confirm",
-                "typed_confirm": "celery",
-            },
-            follow=False,
+        response = self._post_clear(
+            queue_name="celery",
+            task_name="t.K",
+            repoid="1",
+            commitid="aaaa",
+            mode="keep_one",
+            action="confirm",
+            typed_confirm="celery",
         )
 
         assert response.status_code in (302, 303)

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -2200,41 +2200,11 @@ def test_streaming_clear_single_pass_no_drift(broker_redis):
     assert survivor["headers"]["task"] == "t.B"
 
 
-@pytest.mark.django_db
-def test_streaming_clear_verify_before_lset_skips_drifted_entry(broker_redis):
-    """Verify-before-LSET skips a slot whose bytes changed between
-    LRANGE snapshot and LINDEX re-read.
-    """
-
-    raw_a = _build_envelope(task="t.A", kwargs={"repoid": 1, "commitid": "x"})
-    broker_redis.rpush("notify", raw_a)
-
-    # Intercept lindex to simulate drift: return different bytes.
-    real_lindex = broker_redis.lindex
-
-    def drifted_lindex(name, idx):
-        if name == "notify" and idx == 0:
-            # Return bytes for a *different* message.
-            return _build_envelope(
-                task="t.OTHER", kwargs={"repoid": 99, "commitid": "z"}
-            ).encode()
-        return real_lindex(name, idx)
-
-    broker_redis.lindex = drifted_lindex
-
-    tombstone = f"{_CELERY_TOMBSTONE_PREFIX}:test-drift"
-    filter_tuples = _make_filter(("t.A", 1, "x"))
-    stats = _streaming_celery_clear(
-        broker_redis, "notify", filter_tuples, tombstone, dry_run=False
-    )
-
-    # The drifted slot was skipped, nothing tombstoned.
-    assert stats.total_lset == 0
-    # Persistent drift causes the loop to retry; each pass records a drift hit.
-    assert stats.total_drifted >= 1
-    assert stats.passes_run == 2
-    # Original message still in queue (bytes unchanged — we only faked lindex).
-    assert broker_redis.llen("notify") == 1
+# Removed `test_streaming_clear_verify_before_lset_skips_drifted_entry`
+# alongside dropping the verify-before-LSET guard. The streaming clear
+# now runs pipelined unconditional LSETs (PR #895's pre-#899 pattern),
+# trading the "skip drifted slots" guarantee for actually draining busy
+# queues. See `_streaming_celery_clear` docstring for the rationale.
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Operator directive that drove this PR:

> I'm ok if we lose a few tasks along the way and we make secondary
> passes, but I do care that if I'm trying to remove 50% of the
> queue, that there is a significant drop.

Restore PR #895's pipelined-LSET clear pattern inside `_streaming_celery_clear`, replacing PR #899's per-match LINDEX / verify / LSET sequence. PR #899 retains its streaming architecture (we still walk past `CELERY_BROKER_DISPLAY_LIMIT` to drain deep filters); this PR only drops the verify-before-LSET guard. Bisect: PR #895 (`da3a7e071`) was the working clear path the operator was happy with. PR #899 (`aa56fc351`) replaced it with verify-before-LSET. PR #899 is the regression source.

## Why the verify guard was killing the queue

On the operator's `bundles_analysis` broker (211k items, ~78k matching the filter, consumers actively BLPOPing the head):

* Pass 1 reported `MATCHED=2038, DRIFT=77475`.
* `LLEN` did not drop measurably between passes.

The verify-before-LSET path turned every queued LSET into `LINDEX + LSET` round-trips per match. Between the chunk's LRANGE snapshot and the per-match LINDEX, even a moderately busy consumer pop rate is enough to mismatch the bytes in ~97% of slots, so `matches_drifted` absorbed essentially every match and very few LSETs survived to be LREM'd.

The plateau exit (`if prev_lset is not None and matches_lset == prev_lset: break`) then fired against pass 2's identical `matches_lset`, declaring convergence at a queue that hadn't moved.

## What changed

* `_streaming_celery_clear` collects per-chunk `(idx, raw)` matches into a list, then issues a single `pipeline(transaction=False)` of `LSET key idx tombstone` ops with `raise_on_error=False`. Each `Exception` reply (LSET out-of-range == consumer drained that slot) increments `matches_drifted`; everything else increments `matches_lset`.
* `_CELERY_MAX_PASSES` 3 → 10.
* Plateau exit (`prev_lset == matches_lset`) removed. With verify-before-LSET gone, `matches_lset` only plateaus when the queue has converged, which is already covered by `matches_found == 0`.
* `keep_one` early-exit retained. With verify gone, `matches_drifted` only counts genuine LSET out-of-range failures, so `keep_one and matches_drifted == 0` still means "non-keeper matches all tombstoned, queue converged for keep_one mode."
* Per-pass diagnostic logging so on-call can grep the LSET → LREM → LLEN delta from structured logs alone:

  ```
  redis_admin.streaming_clear: queue=<q> pass=<n> depth=<d>
  redis_admin.streaming_clear: queue=<q> pass=<n> found=<f> lset=<l> drifted=<dr> pass_first_kept=<bool>
  redis_admin.streaming_clear: queue=<q> pass=<n> lrem_removed=<r>
  ```

  On a quiet queue `lrem_removed` should equal `lset`. The new regression test asserts that round-trip explicitly (`stats.total_lset == matches`, `LLEN(queue) == 0`).

## Trade-off (data-loss surface area)

Documented in the `_streaming_celery_clear` docstring. Concretely: between the chunk LRANGE snapshot and the pipelined LSET, K consumer pops shift indexes down by K. Our LSET at slot 50 then overwrites whatever's at slot 50 *now* (which used to be at 50+K). That overwritten message is destroyed by the subsequent LREM. Bounded by `consumer_pops_per_chunk × chunks_per_pass`; with `chunk_size=1000` and a consumer popping ~25/sec the bound is a handful of slots per chunk. Operator has explicitly accepted this trade-off.

The `keep_one` semantic still survives the trade-off because pass 1's keeper is the *lowest-index* match in pass 1's LRANGE snapshot. Even if that snapshot is stale by the time we LSET, the new lowest-index match in pass 2 becomes the next keeper and the queue retains at least one matching message after a successful keep_one clear.

## Tests

* New `test_streaming_clear_drops_50pct_of_queue_in_first_pass` (`test_celery_broker_clear_job.py`): seeds 100 envelopes (50 matching the filter, 50 not), runs the chunked clear job with no concurrency, asserts `LLEN` drops from 100 to 50 and that every survivor parses as a non-matching envelope. This is the headline operator invariant.
* New `test_streaming_clear_makes_progress_under_concurrent_drift`: monkey-patches `LINDEX` to always return non-matching bytes (the worst-case drift scenario the verify-before-LSET path was designed to catch); confirms the pipelined path tombstones every match and drains the queue to zero, because LINDEX is no longer in the loop.
* Removed `test_streaming_clear_verify_before_lset_skips_drifted_entry` in `test_celery_broker_queue.py` (asserted a semantic that no longer exists).
* Existing drain tests in `test_celery_broker_clear_drain_verification.py` continue to pass: the chunked-job worker still LSET-tombstones every match in the chunk and the LREM sweep still removes them.

Local run (subset that doesn't require Postgres):
```
RUN_ENV=TESTING DJANGO_SETTINGS_MODULE=codecov.settings_test \
  uv run pytest -q -m "not django_db" \
    apps/codecov-api/redis_admin/tests/test_celery_broker_clear_drain_verification.py \
    apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py \
    apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
# 78 passed, 30 errors (all django_db / Postgres unavailable locally), 16 deselected
```

## Operator one-liner to verify in `manage.py shell_plus`

```python
from redis_admin import conn as _c
r = _c.get_connection(kind="broker")
before = r.llen("bundles_analysis")
r.rpush("bundles_analysis", "__test_diag_value__")
removed = r.lrem("bundles_analysis", 0, "__test_diag_value__")
print(f"before={before} removed={removed} after={r.llen('bundles_analysis')}")
# expect: removed=1 and after==before (we pushed one then removed one)
```

## Test plan

- [x] Unit tests pass locally (`-m "not django_db"`)
- [ ] CI green
- [ ] Bugbot review addressed
- [ ] Operator can confirm queue drops on `bundles_analysis` after deploy

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the Redis admin celery-broker clear algorithm to use pipelined `LSET` without verify checks, intentionally increasing potential for accidental task deletion under concurrent consumers. It also alters convergence behavior (more passes, different exit conditions), which affects how aggressively queues are drained in production.
> 
> **Overview**
> Restores `_streaming_celery_clear` to the pre-#899 approach: **collect matching indexes per LRANGE chunk and issue batched `pipeline(...).lset(...)` tombstones**, dropping the per-match `LINDEX` verify step and treating per-op pipeline `Exception` replies as drift.
> 
> Adjusts convergence to better drain saturated queues (**max passes 3→10**, removes the `prev_lset` plateau exit, keeps an early-exit for `keep_one` when no drift occurs) and adds structured per-pass logging including `LLEN` and `LREM` removed counts.
> 
> Updates tests to match the new behavior: adds regression coverage that the queue actually shrinks (including under simulated drift and out-of-range `LSET` replies), removes the verify-before-LSET drift-skip test, and makes clear-by-filter view tests join the background clear thread to avoid races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5c07052132c2face7c1a8e20575c2c87586c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->