### PR TITLE
perf(redis_admin): drop clear-by-filter preview load; reuse chart numbers

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -40,7 +40,7 @@ accidentally surfaces them under `RedisQueue`.
 | `/admin/redis_admin/redisqueueitem/<token>/change/` | Inspect a single item |
 | `/admin/redis_admin/celerybrokerqueue/` | **Celery summary** — one row per known celery_broker queue with current `LLEN` and a drill-in link |
 | `/admin/redis_admin/celerybrokerqueue/?queue_name__exact=<queue>` | **Celery drill-down** — messages inside a celery broker queue with structured task / repoid / commitid columns, a `(repoid, commitid)` frequency chart, and per-message clear |
-| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/` | Preview + clear messages in `<queue>` matching a `(task_name?, repoid?, commitid?)` filter (POST-only, superuser-only). Wired up by the frequency chart's per-row "Clear queue" button; the preview page exposes three explicit actions (dry-run, clear all but first, clear all). Destructive actions spawn a chunked background job and 302 to the progress page. |
+| `/admin/redis_admin/celerybrokerqueue/clear-by-filter/` | Confirmation page for clearing messages in `<queue>` matching a `(task_name?, repoid?, commitid?)` filter (superuser-only). GET renders the form synchronously with **no Redis I/O** — the per-row "Clear queue" form on the frequency chart passes the bucket count + queue depth as URL params (`bucket_count`, `bucket_pct`, `total_visible`, `total_depth`) so the page can show an "approximately N messages" callout without a count-walk. POST exposes three explicit actions (dry-run, clear all but first, clear all); each spawns a chunked background job and 302s to the progress page below. |
 | `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/` | Progress page for a chunked clear job (HTML, superuser-only). Polls the status JSON view every ~1s; renders a `<progress>` bar, matched / total / drift / pass counters, and a Cancel button. |
 | `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/status/` | JSON snapshot of a chunked clear job (superuser-only); 404s on unknown / expired ids. |
 | `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/cancel/` | POST-only cancel endpoint (superuser-only); flags `cancel_requested=1` and returns 202 with the latest snapshot. Cancel lands at the next chunk boundary. |
@@ -249,13 +249,16 @@ commitid asc)` for a stable order across reloads. Each row shows
   hover)
 - the bucket's `count` and percentage share of the visible window
 - a single per-bucket **Clear queue…** button (superuser-only).
-  Clicking it POSTs the bucket's
+  Clicking it submits the bucket's
   `(queue, task_name, repoid, commitid)` to `clear-by-filter/`
-  and lands on the preview page, where the operator picks one of
-  three explicit actions (dry-run / clear all but first / clear
-  all). The chart row itself is intentionally non-destructive —
-  no count in the label, no `deletelink` styling — because the
-  click only opens a page; the destructive choice is made there.
+  along with the bucket's count + the chart's queue depth as
+  hidden hints, and lands on the confirmation page, where the
+  operator picks one of three explicit actions (dry-run / clear
+  all but first / clear all). The confirmation page renders
+  synchronously from those hints with no Redis I/O. The chart
+  row itself is intentionally non-destructive — no count in the
+  label, no `deletelink` styling — because the click only opens
+  a page; the destructive choice is made there.
 
 Grouping by `task_name` matters on shared queues like the default
 `celery` queue where multiple task classes coexist — without it,
@@ -270,37 +273,64 @@ operators know the share is over the visible window.
 
 ### `clear-by-filter/` (chart-driven targeted clear)
 
-`POST /admin/redis_admin/celerybrokerqueue/clear-by-filter/` —
+`/admin/redis_admin/celerybrokerqueue/clear-by-filter/` —
 superuser-only. Required form fields: `queue_name`, plus at
 least one of `task_name` / `repoid` / `commitid` (refusing the
 empty-narrowing case keeps the surface from overlapping
 `clear-by-scope/`).
 
-The chart's per-row button POSTs without an `action`, which
-lands on a preview page listing the matched messages. The
-preview page then exposes three explicit submit buttons; the
-view dispatches on the form's `action` value:
+**GET (confirmation page) is fully synchronous and makes zero
+Redis calls.** Earlier iterations rendered a count + sample
+preview by streaming the queue at request time, which made the
+page take seconds to first byte on deep queues. The chart
+already knows the bucket count and the queue depth (it computed
+both to render its own row), so the per-row "Clear queue" form
+on the frequency chart now carries those numbers forward as
+URL params:
 
-- `action=dry_run` — neutral / `default`-styled button. Audited
-  via `celery_broker_clear(dry_run=True)`; queue untouched.
-  Re-renders the preview with an info banner. No
-  typed-confirmation required.
-- `action=clear_keep_one` — destructive (red text). Only
-  rendered when `match_count >= 2`. Clears every match EXCEPT
-  the one with the lowest `index_in_queue` (the next message a
-  Celery worker would pop), so a single representative stays in
-  flight. Intent: "drop the duplicate retries but leave one
-  running."
-- `action=clear_all` — destructive (red text). Clears every
-  matching message; the broadest of the three.
+| Hidden field | Value |
+|---|---|
+| `bucket_count` | `bucket.count` (matches inside the chart's `LRANGE` window) |
+| `bucket_pct` | `bucket.pct` (already pre-computed) |
+| `total_visible` | `chart.total_visible` (effective `CELERY_BROKER_SCAN_LIMIT`) |
+| `total_depth` | `chart.total_depth` (real `LLEN(queue)` at chart-render time) |
+
+The view extrapolates via `count ≈ bucket_count / total_visible
+* total_depth` and renders an "approximately N messages (~Y% of
+queue at depth Z)" callout. When any param is missing or
+malformed (operator hand-crafted the URL, or arrived via a
+non-chart link), the callout falls back to "Approximate count
+not available — the chunked clear will compute the exact match
+count as it scans." The form's three submit buttons remain
+unchanged either way; the chunked worker does its own counting
+during the scan so the approximate display is never a
+load-bearing input to the destructive operation.
+
+POST dispatches on the form's `action` value; **all three
+actions** spawn a chunked background job and 302 to the
+progress page (no synchronous destructive path):
+
+- `action=dry_run` — neutral / `default`-styled button. Spawns
+  the chunked worker with `dry_run=True`; queue untouched. The
+  audit `LogEntry` lands under `mode=chunked-dry-run` at job
+  completion. No typed-confirmation required.
+- `action=clear_keep_one` — destructive (red text). Spawns the
+  chunked worker with `dry_run=False`, `keep_one=True`. Clears
+  every match EXCEPT the one with the lowest `index_in_queue`
+  (the next message a Celery worker would pop), so a single
+  representative stays in flight. Intent: "drop the duplicate
+  retries but leave one running." Typed-confirmation required.
+- `action=clear_all` — destructive (red text). Spawns the
+  chunked worker with `dry_run=False`, `keep_one=False`; clears
+  every matching message. Typed-confirmation required.
 
 Both destructive buttons gate on the same typed-confirmation
 field (re-type the queue name); they share a common
 `celery-destructive-button` class that paints the text red and
 keeps them visually distinct from the dry-run button on the
-left. Server-side, both ultimately funnel through
-`services.celery_broker_clear`, so the LSET-tombstone path runs
-and the audit log captures the operation under
+left. The chunked worker funnels through
+`services._streaming_celery_clear`, so the LSET-tombstone path
+runs and the audit log captures the operation under
 `scope="celery_broker_clear"`.
 
 For backward compatibility, the older `action=confirm` form

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -54,22 +54,48 @@ from .queryset import (
 )
 from .services import (
     _CELERY_CLEAR_JOB_TERMINAL_STATES,
-    _substitute_filter_any,
     celery_broker_clear,
     get_celery_broker_clear_job,
     redis_delete,
     request_cancel_celery_broker_clear_job,
     start_celery_broker_clear_job,
-    streaming_celery_count,
 )
 
 log = logging.getLogger(__name__)
 
-# Cap on the rows we render in the clear-by-filter preview
-# table. Decoupled from `CELERY_BROKER_DISPLAY_LIMIT` because
-# the preview page only needs a representative slice; the real
-# `match_count` comes from the streaming counter.
-_CLEAR_BY_FILTER_SAMPLE_SIZE: int = 20
+
+def _coerce_int(value: str | None) -> int | None:
+    """Best-effort `int(value)` for query-string display hints.
+
+    Returns `None` when `value` is `None` / empty / non-numeric. Used by
+    `clear_by_filter_view` to ingest the chart-supplied count hints
+    (`bucket_count`, `total_visible`, `total_depth`) without ever
+    raising on a hand-edited URL — the GET path falls back to
+    "Approximate count not available" when any hint is missing or
+    malformed, never a 500.
+    """
+
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_float(value: str | None) -> float | None:
+    """Best-effort `float(value)` for query-string display hints.
+
+    Mirrors `_coerce_int` for `bucket_pct` (the chart serialises it
+    as a fractional percentage like `36.4`); same fallback semantics.
+    """
+
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 # ---- Inline items preview (rendered on the queue change page) --------------
 #
@@ -1815,27 +1841,25 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         """Targeted clear by `(queue_name, task_name?, repoid?, commitid?)`.
 
         Reached from the frequency chart's per-row "Clear queue"
-        button (see `_frequency_chart.html`). The chart submits the
-        bucket's `task_name` / `repoid` / `commitid` and lands on a
+        button (see `_frequency_chart.html`). The chart GETs this
+        URL with the bucket's `task_name` / `repoid` / `commitid`
+        plus four display-only count hints (`bucket_count`,
+        `bucket_pct`, `total_visible`, `total_depth`) and lands on a
         preview page; the operator then picks one of three explicit
         actions:
 
-        * `action=dry_run` — audited dry-run via
-          `services.celery_broker_clear(dry_run=True)`. Leaves the
-          queue untouched but writes a `LogEntry` so we have a paper
-          trail for "what would have happened?". Re-renders the
-          preview with an info banner.
+        * `action=dry_run` — counts matches without mutating. Spawns
+          a chunked background-job worker (`dry_run=True`) and 302s
+          to the progress page; the worker writes a `LogEntry` on
+          completion so we have a paper trail for "what would have
+          happened?".
         * `action=clear_keep_one` — clear every match EXCEPT the one
-          with the lowest `index_in_queue`. The queryset materialises
-          via `LRANGE 0 N-1` so `matches[0]` is the head-of-queue (the
-          next message a Celery worker would pop); dropping it from
-          the deletion set leaves a single representative in flight.
-          Typical workflow: "drop the duplicate retries but leave one
-          running so something still completes." Refused for
-          single-match buckets where it would have to clear nothing.
+          with the lowest `index_in_queue` (the next message a
+          Celery worker would pop). Leaves a single representative
+          in flight. Typical workflow: "drop the duplicate retries
+          but leave one running so something still completes."
         * `action=clear_all` — clear every matching message. The
-          broadest of the three; equivalent to the old
-          `mode=all` semantic.
+          broadest of the three.
 
         The two destructive actions both gate on a typed-confirmation
         check (operator must re-type the queue name). Filtering by
@@ -1844,10 +1868,36 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         messages for repo X commit Y" would silently drop unrelated
         tasks routed through the same queue.
 
-        Both POSTs ultimately funnel through
-        `services.celery_broker_clear`, which runs the LSET-tombstone
-        path and writes the audit log entry under
-        `scope="celery_broker_clear"`.
+        ## Zero-Redis-I/O GET render
+
+        The GET render is intentionally Redis-free: no `LLEN`, no
+        `LRANGE`, no streaming-count walk, no queryset materialise.
+        The chart already knows the bucket count and queue depth
+        from its `LRANGE 0 CELERY_BROKER_SCAN_LIMIT-1` snapshot, so
+        we reuse those four hints to compute an approximate
+        "will tombstone ~X messages (~Y% of the queue at depth Z)"
+        callout in pure Python:
+
+            count ≈ bucket_count / total_visible * total_depth
+
+        Operators confirm based on the (queue, task, repoid, commit)
+        filter — which is identity-defining — not on a precise
+        count, so the approximate is sufficient. The previous
+        implementation called a streaming counter here, which held
+        the gunicorn worker for many seconds on a 200–500k-deep
+        queue; the chunked background-job worker still computes the
+        exact count as it scans, so the audit log stays precise.
+
+        When any of the four hints is missing (operator hand-crafted
+        the URL, or arrived via a non-chart link), the callout falls
+        back to "Approximate count not available" and the destructive
+        actions still work — the chunked worker reports the exact
+        match count from its own walk.
+
+        Both destructive POSTs and the dry-run POST funnel through
+        `services.start_celery_broker_clear_job`, which spawns a
+        chunked worker and returns immediately; the audit log entry
+        lands at job completion under `scope="celery_broker_clear"`.
         """
 
         if not request.user.is_superuser:
@@ -1904,96 +1954,6 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             )
             return HttpResponseRedirect(changelist_url)
 
-        queryset = self.model._default_manager.all().filter(
-            queue_name__exact=queue_name
-        )
-        if task_name:
-            queryset = queryset.filter(task_name__exact=task_name)
-        if repoid is not None:
-            queryset = queryset.filter(repoid=repoid)
-        if commitid:
-            queryset = queryset.filter(commitid__startswith=commitid)
-        # Cap-bounded sample for the preview table (cheap, in-memory).
-        # The queryset materialises the first `CELERY_BROKER_DISPLAY_LIMIT`
-        # messages, then filters; we trim further to keep the rendered
-        # table compact.
-        sample_targets = sorted(queryset, key=lambda row: row.index_in_queue or 0)[
-            :_CLEAR_BY_FILTER_SAMPLE_SIZE
-        ]
-
-        # `match_count` and `kept_index` come from a streaming pass
-        # over the full queue so the preview agrees with what the
-        # actual clear (also unbounded) would do. Going through the
-        # queryset would underreport whenever `LLEN(queue) >
-        # CELERY_BROKER_DISPLAY_LIMIT` (anything past the 2k materialise
-        # window).
-        try:
-            match_count, kept_index = streaming_celery_count(
-                queue_name,
-                task_name=task_name or None,
-                repoid=repoid,
-                commitid=commitid or None,
-            )
-        except Exception:
-            log.exception(
-                "redis_admin.clear_by_filter: streaming count failed for %r",
-                queue_name,
-            )
-            # Defensive fallback: degrade to the queryset count rather
-            # than render a 500. The operator at least sees something
-            # and can still hit "Clear all" — the streaming clear path
-            # has its own error handling.
-            match_count = len(sample_targets)
-            kept_index = sample_targets[0].index_in_queue if sample_targets else None
-        # Build a single synthetic target carrying the operator's
-        # *exact* filter (queue + task_name? + repoid? + commitid?)
-        # so `_celery_broker_clear` always derives the same
-        # `frozenset({(task_name or None, repoid, commitid or None)})`
-        # that `streaming_celery_count` walked the full queue with.
-        #
-        # Without this, the clear path inferred its filter set from
-        # `sample_targets` — the materialised window capped by
-        # `CELERY_BROKER_DISPLAY_LIMIT` (default 2_000). That had two
-        # silent-no-op modes:
-        #
-        # 1. All matches sit beyond the display window (e.g. a recent
-        #    burst on a queue with `LLEN > 2_000`): `sample_targets`
-        #    is empty, `by_queue_filters` becomes `{}`, the streaming
-        #    clear loop doesn't iterate, and the queue is never
-        #    touched even though `match_count > 0` from streaming.
-        # 2. Operator filtered by `repoid` only: each `sample_target`
-        #    contributes a *specific* `(task_name, repoid, commitid)`
-        #    triple, so the filter set excludes any task name not
-        #    represented in the first 2_000 messages — those messages
-        #    survive the clear.
-        #
-        # The synthetic target restores the streaming-clear semantic
-        # of "match every envelope whose `(task, repoid, commitid)`
-        # equals the operator's input." Per-message and bulk-select
-        # paths (`delete_model`, `clear_selected`, `delete_queryset`,
-        # `clear_dry_run`) still pass real materialised rows — those
-        # are intentionally index-driven, not filter-driven, so they
-        # don't go through this code path.
-        # `_FILTER_ANY` (not `None`) for unset slots so the
-        # streaming match treats them as wildcards. `None` would
-        # require an exact-equality match against `meta.task is
-        # None` / `meta.repoid is None` / `meta.commitid is None`,
-        # which the per-message paths legitimately rely on for
-        # tasks like `sync_repos` whose envelope leaves repoid /
-        # commitid as `None`.
-        task_any, repoid_any, commitid_any = _substitute_filter_any(
-            task_name, repoid, commitid
-        )
-        filter_target = CeleryBrokerQueue(
-            pk_token=f"{queue_name}#{kept_index if kept_index is not None else 'filter'}",
-            queue_name=queue_name,
-            index_in_queue=kept_index,
-            task_name=task_any,
-            repoid=repoid_any,
-            commitid=commitid_any,
-        )
-        matches = [filter_target]
-
         expected_confirm = queue_name
         typed_confirm = (request.POST.get("typed_confirm") or "").strip()
         confirm_error: str | None = None
@@ -2001,79 +1961,74 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         destructive_actions = {"clear_keep_one", "clear_all"}
         valid_actions = destructive_actions | {"dry_run"}
 
-        # The chart-driven submit lands here with no `action` set
-        # (the chart's button just opens the preview page); fall
-        # through to the render path without invoking the service or
-        # writing a LogEntry.
+        # POST handler: all three actions fan out to the chunked
+        # background-job worker. Dry-run shares the same path so the
+        # request thread never has to count matches up front — the
+        # worker counts as it walks and writes the LogEntry on
+        # completion. The chart-driven submit is a GET (no `action`
+        # set) and falls through to the render path below.
         if request.method == "POST" and action in valid_actions:
-            if match_count == 0:
-                messages.info(
-                    request,
-                    "No messages match the filter — nothing to clear.",
-                )
-                return HttpResponseRedirect(changelist_url)
-
-            if action == "clear_keep_one":
-                if match_count <= 1:
-                    # Single-message bucket: there's nothing to clear
-                    # without removing the only in-flight message,
-                    # which defeats the "keep first" semantic. The
-                    # preview page only renders this button for
-                    # buckets with match_count >= 2, but a hand-
-                    # crafted POST or a count change between render
-                    # and submit could still land here.
-                    messages.info(
-                        request,
-                        f"Nothing to clear: only {match_count} message(s) "
-                        f"match and 'clear all but first' would leave "
-                        f"them all in place.",
-                    )
-                    return HttpResponseRedirect(changelist_url)
-
-            targets = list(matches)
-
             if action in destructive_actions and typed_confirm != expected_confirm:
                 confirm_error = f"Typed confirmation must equal {expected_confirm!r}"
             else:
                 dry_run = action == "dry_run"
                 keep_one = action == "clear_keep_one"
-                # Dry-run keeps the synchronous shape: the request
-                # already does the streaming-count walk above, so
-                # the dry-run service call is fast (no LSET/LREM)
-                # and the operator gets the audit-log entry +
-                # re-rendered preview in one shot. The destructive
-                # actions, by contrast, fan out to a background
-                # thread so a 500k-deep queue clear never sits on
-                # the gunicorn worker.
-                if dry_run:
-                    result = celery_broker_clear(
-                        targets,
-                        user=request.user,
-                        dry_run=True,
-                        keep_one=keep_one,
-                    )
-                    messages.info(
-                        request,
-                        f"Dry-run: would clear {result.count} of {match_count} "
-                        f"matching message(s) from {queue_name} (audit log "
-                        f"entry written; queue untouched).",
-                    )
-                else:
-                    job_id = start_celery_broker_clear_job(
-                        queue_name,
-                        user=request.user,
-                        task_name=task_name or None,
-                        repoid=repoid,
-                        commitid=commitid or None,
-                        keep_one=keep_one,
-                        dry_run=False,
-                    )
-                    progress_url = reverse(
-                        f"admin:{opts.app_label}_{opts.model_name}"
-                        "_clear_by_filter_progress",
-                        kwargs={"job_id": job_id},
-                    )
-                    return HttpResponseRedirect(progress_url)
+                job_id = start_celery_broker_clear_job(
+                    queue_name,
+                    user=request.user,
+                    task_name=task_name or None,
+                    repoid=repoid,
+                    commitid=commitid or None,
+                    keep_one=keep_one,
+                    dry_run=dry_run,
+                )
+                progress_url = reverse(
+                    f"admin:{opts.app_label}_{opts.model_name}"
+                    "_clear_by_filter_progress",
+                    kwargs={"job_id": job_id},
+                )
+                return HttpResponseRedirect(progress_url)
+
+        # GET (or POST with bad confirm): render synchronously from the
+        # chart-supplied display hints. ZERO Redis calls in this path —
+        # every value below comes from URL params, the request, or the
+        # opts model meta.
+        bucket_count = _coerce_int(params.get("bucket_count"))
+        total_visible = _coerce_int(params.get("total_visible"))
+        total_depth = _coerce_int(params.get("total_depth"))
+        bucket_pct = _coerce_float(params.get("bucket_pct"))
+        approx: dict[str, Any] | None = None
+        # Truthiness on `total_visible > 0` and `total_depth` doubles
+        # as a divide-by-zero guard: an empty / depth-zero queue
+        # couldn't have produced a chart bucket in the first place,
+        # so missing or zero values imply the URL was hand-crafted
+        # and the operator should see the "not available" fallback
+        # rather than a 500.
+        if (
+            bucket_count is not None
+            and total_visible is not None
+            and total_visible > 0
+            and total_depth
+        ):
+            approx = {
+                "count": round(bucket_count / total_visible * total_depth),
+                "pct": bucket_pct,
+                "depth": total_depth,
+            }
+
+        # Resolve a Repository-admin link for `repoid` so the filter
+        # row matches the chart's repo cell (which renders the same
+        # link via `_resolve_repo_displays`). Best-effort: if the
+        # repo isn't in the DB or the admin URL is unreachable, the
+        # template falls back to the bare integer.
+        repo_change_url: str | None = None
+        if repoid is not None:
+            try:
+                repo_change_url = reverse(
+                    "admin:core_repository_change", args=[repoid]
+                )
+            except NoReverseMatch:  # pragma: no cover - admin always registered
+                repo_change_url = None
 
         ctx = {
             **self.admin_site.each_context(request),
@@ -2082,10 +2037,9 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             "queue_name": queue_name,
             "task_name": task_name,
             "repoid": repoid,
+            "repo_change_url": repo_change_url,
             "commitid": commitid,
-            "match_count": match_count,
-            "kept_index": kept_index,
-            "sample_targets": sample_targets,
+            "approx": approx,
             "expected_confirm": expected_confirm,
             "typed_confirm": typed_confirm,
             "confirm_error": confirm_error,

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -97,6 +97,7 @@ def _coerce_float(value: str | None) -> float | None:
     except (TypeError, ValueError):
         return None
 
+
 # ---- Inline items preview (rendered on the queue change page) --------------
 #
 # Showing the items "below" the readonly field block on the change page
@@ -2024,9 +2025,7 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
         repo_change_url: str | None = None
         if repoid is not None:
             try:
-                repo_change_url = reverse(
-                    "admin:core_repository_change", args=[repoid]
-                )
+                repo_change_url = reverse("admin:core_repository_change", args=[repoid])
             except NoReverseMatch:  # pragma: no cover - admin always registered
                 repo_change_url = None
 

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -463,9 +463,9 @@ class _FilterWildcard:
     *every* `sync_repos` message in the queue rather than just
     the one the operator selected.
 
-    Operator-input paths (`streaming_celery_count` and the
-    `clear_by_filter_view` synthetic target) substitute this
-    sentinel for any unset filter slot before building the
+    Operator-input paths (the chunked clear job in
+    `_run_celery_broker_clear_job_body`) substitute this sentinel
+    for any unset filter slot before building the
     `(task, repoid, commitid)` tuple.
     """
 
@@ -485,21 +485,15 @@ def _substitute_filter_any(
 ) -> tuple:
     """Substitute `_FILTER_ANY` for unset operator filter slots.
 
-    Operator-input clear paths (`streaming_celery_count`, the
-    chunked clear job in `_run_celery_broker_clear_job_body`,
-    and the `clear_by_filter_view` synthetic target) all need
-    to convert the form's per-slot `None` / empty-string into
+    The chunked clear job (`_run_celery_broker_clear_job_body`)
+    converts the operator's per-slot `None` / empty-string into
     the wildcard sentinel before handing the triple to
-    `_envelope_matches_any_filter` (or to a synthetic
-    `CeleryBrokerQueue` row carrying the same comparison
-    semantics). Centralising the substitution rule keeps the
-    dry-run count, the chunked clear, and the synchronous
-    `clear_by_filter_view` preview from drifting if the rule
-    later changes (e.g. a new filter field is added or a
-    slot's truthiness check is loosened) — a divergence here
-    would manifest as the dry-run count disagreeing with the
-    chunked clear's matched count, which is a data-loss
-    vector.
+    `_envelope_matches_any_filter`. Centralising the substitution
+    rule keeps the dry-run pass, the keep-one pass, and the
+    live clear pass from drifting if the rule later changes
+    (e.g. a new filter field is added or a slot's truthiness
+    check is loosened) — a divergence there would be a
+    data-loss vector.
 
     The truthiness-vs-`is None` asymmetry is intentional:
     `repoid` is an integer where `0` could in principle be a
@@ -840,51 +834,6 @@ def _streaming_celery_clear(
         passes_run=passes_run,
         cancelled=cancelled,
     )
-
-
-def streaming_celery_count(
-    queue_name: str,
-    *,
-    task_name: str | None = None,
-    repoid: int | None = None,
-    commitid: str | None = None,
-) -> tuple[int, int | None]:
-    """Streaming `(match_count, lowest_index_match)` for the
-    `(queue_name, task_name?, repoid?, commitid?)` filter.
-
-    Walks the full `LLEN(queue)` so the returned count agrees
-    with what `celery_broker_clear` would actually tombstone.
-    Used by `clear_by_filter_view` to render the preview page;
-    the queryset path is bounded by `CELERY_BROKER_DISPLAY_LIMIT`
-    and would underreport on deep queues.
-
-    The filter compares envelope tuples by exact equality. The
-    admin view passes `commitid` straight from the chart row
-    (full 40-char hash), so this matches the
-    `queryset.filter(commitid__startswith=...)` path the
-    changelist uses for full-length input. Partial-prefix
-    commits (rare; only reachable via manual URL editing) will
-    count as zero — that's a documented limitation; the user
-    can still browse via the changelist filters.
-    """
-
-    redis = _conn.get_connection(kind="broker")
-    # Substitute `_FILTER_ANY` (not `None`) for unset slots so the
-    # streaming match treats them as wildcards. `None` would mean
-    # "match only envelopes whose corresponding field is literally
-    # `None`" which would zero-out the count for any operator
-    # input that didn't pin every slot of the triple.
-    filter_tuples = frozenset({_substitute_filter_any(task_name, repoid, commitid)})
-    tombstone = _celery_clear_tombstone()
-    stats = _streaming_celery_clear(
-        redis,
-        queue_name,
-        filter_tuples,
-        tombstone,
-        keep_one=False,
-        dry_run=True,
-    )
-    return stats.total_found, stats.first_match_index
 
 
 def celery_broker_clear(
@@ -1348,11 +1297,10 @@ def _run_celery_broker_clear_job_body(
     cache.hset(key, "status", "running")
     cache.hset(key, "updated_at", _utc_now_iso())
 
-    # Build the same `_FILTER_ANY`-substituted filter the
-    # synchronous `streaming_celery_count` uses, so an unset
-    # operator slot becomes a wildcard rather than an exact-`None`
-    # match (which would zero-match for any envelope whose field
-    # wasn't literally `None`).
+    # Substitute `_FILTER_ANY` (not `None`) for unset operator
+    # slots so an empty form field acts as a wildcard rather than
+    # an exact-`None` match (which would zero-match for any
+    # envelope whose field wasn't literally `None`).
     filter_tuples = frozenset({_substitute_filter_any(task_name, repoid, commitid)})
 
     def _progress_callback(snapshot: _ChunkProgress) -> bool:

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/_frequency_chart.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/_frequency_chart.html
@@ -20,10 +20,14 @@ Shape:
   column on `RedisQueueAdmin`, so the chart's repo cell matches
   what operators see elsewhere.
 * `chart.clear_by_filter_url` — base URL for the row-level
-  "Clear queue" form action; we POST to it with `task_name` /
-  `repoid` / `commitid` / `csrfmiddlewaretoken`. The POST opens
-  the preview page where the operator picks dry-run, clear-all-
-  but-first, or clear-all.
+  "Clear queue" form action; we GET it with `task_name` /
+  `repoid` / `commitid` plus four display-only count hints
+  (`bucket_count` / `bucket_pct` / `total_visible` /
+  `total_depth`) so the preview page can render an approximate
+  "will tombstone ~X messages (~Y%)" callout without any Redis
+  call. The preview page itself exposes dry-run / clear-all-
+  but-first / clear-all as POST submits; those fan out to the
+  chunked background-job worker which does its own counting.
 * `chart.can_clear` — boolean toggling the visibility of the
   "Clear queue" buttons (superuser-only; staff users see read-
   only percentages).
@@ -96,21 +100,30 @@ Shape:
           {% if chart.can_clear %}
             <td class="celery-actions">
               {% comment %}
-              Single "Clear queue" button per row. POSTing the bucket's
-              hidden scope fields (queue/task/repoid/commitid) opens
-              the `clear_by_filter` preview page, where the operator
-              picks one of three explicit actions:
+              Single "Clear queue" button per row. The form GETs the
+              `clear_by_filter` preview page rather than POSTing,
+              because the four `bucket_*` / `total_*` hints below are
+              display-only (non-secret, idempotent, bookmarkable) and
+              the preview page itself does ZERO Redis I/O on the GET
+              render. It reuses the chart's already-computed bucket
+              count and queue depth to render an approximate "will
+              tombstone ~X messages (~Y% of the queue at depth Z)"
+              callout instantly, instead of firing a multi-second
+              streaming-count walk per click. Operators confirm
+              based on the (queue, task, repoid, commitid) filter —
+              which is identity-defining — not on a precise count,
+              so the approximate is sufficient.
 
-              1. dry-run (audited, leaves the queue untouched)
-              2. clear all but first (red text, destructive)
-              3. clear all (red text, destructive)
+              On the preview page, the operator picks one of three
+              explicit actions (dry-run / clear all but first / clear
+              all); all three are POSTs that fan out to the chunked
+              background-job worker.
 
-              Keeping the chart row neutral — neither `deletelink` nor
-              a count in the label — communicates "this opens a page",
-              not "this clears N messages right now".
+              Keeping the chart row neutral — neither `deletelink`
+              nor a count in the label — communicates "this opens a
+              page", not "this clears N messages right now".
               {% endcomment %}
-              <form method="post" action="{{ chart.clear_by_filter_url }}" class="celery-action-form">
-                {% csrf_token %}
+              <form method="get" action="{{ chart.clear_by_filter_url }}" class="celery-action-form">
                 <input type="hidden" name="queue_name" value="{{ chart.queue_name }}">
                 {% if bucket.task_name %}
                   <input type="hidden" name="task_name" value="{{ bucket.task_name }}">
@@ -121,6 +134,10 @@ Shape:
                 {% if bucket.commitid %}
                   <input type="hidden" name="commitid" value="{{ bucket.commitid }}">
                 {% endif %}
+                <input type="hidden" name="bucket_count" value="{{ bucket.count }}">
+                <input type="hidden" name="bucket_pct" value="{{ bucket.pct }}">
+                <input type="hidden" name="total_depth" value="{{ chart.total_depth }}">
+                <input type="hidden" name="total_visible" value="{{ chart.total_visible }}">
                 <button type="submit" class="button celery-clear-queue-btn">
                   Clear queue&hellip;
                 </button>

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/clear_by_filter.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/celerybrokerqueue/clear_by_filter.html
@@ -25,12 +25,93 @@
   </p>
   <p>
     Three actions are available below. <strong>Dry-run</strong> is the
-    safe first move — it writes a <code>LogEntry</code> under
+    safe first move &mdash; it writes a <code>LogEntry</code> under
     <code>scope=&quot;celery_broker_clear&quot;</code> but leaves the
     queue untouched. The two destructive actions both gate on the
     typed-confirmation field; both also write the same audit log
-    entry on success.
+    entry on success. All three fan out to a chunked background-job
+    worker that streams the queue and reports exact match counts as
+    it scans &mdash; this preview page itself does no Redis I/O.
   </p>
+
+  {# ---- Filter rows: queue, task, repoid (linked), commit (truncated) ---- #}
+  <fieldset class="module">
+    <h2>Filter</h2>
+    <table class="celery-clear-filter">
+      <tr>
+        <th scope="row">Queue</th>
+        <td><code>{{ queue_name }}</code></td>
+      </tr>
+      <tr>
+        <th scope="row">Task</th>
+        <td>
+          {% if task_name %}<code>{{ task_name }}</code>{% else %}<em>(any)</em>{% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th scope="row">Repo</th>
+        <td>
+          {% if repoid is not None %}
+            {% if repo_change_url %}
+              <a href="{{ repo_change_url }}" title="repoid={{ repoid }}"><code>{{ repoid }}</code></a>
+            {% else %}
+              <code>{{ repoid }}</code>
+            {% endif %}
+          {% else %}
+            <em>(any)</em>
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th scope="row">Commit</th>
+        <td>
+          {% if commitid %}
+            <code title="{{ commitid }}">{{ commitid|slice:":7" }}</code>
+          {% else %}
+            <em>(any)</em>
+          {% endif %}
+        </td>
+      </tr>
+    </table>
+  </fieldset>
+
+  {# ---- Approximate-count callout (no Redis call; values come from the chart) ---- #}
+  {#
+    The chart already has the bucket count and queue depth from its
+    LRANGE snapshot, so the approximate "will tombstone ~X" string is
+    derived in pure Python in the view (`approx` dict). When the
+    operator hand-edits the URL or arrives via a non-chart link any
+    of the four hints may be missing; we render the "not available"
+    fallback instead of computing a misleading number. The chunked
+    background-job worker computes the exact match count as it walks
+    so the audit log stays precise.
+  #}
+  <fieldset class="module">
+    <h2>Approximate impact</h2>
+    {% if approx %}
+      <p class="celery-approx-callout">
+        Will tombstone approximately
+        <strong>{{ approx.count|default_if_none:"&mdash;" }}</strong>
+        message(s)
+        {% if approx.pct is not None %}
+          (<strong>~{{ approx.pct|floatformat:1 }}%</strong> of the
+          queue at depth ~{{ approx.depth }}).
+        {% else %}
+          (queue depth ~{{ approx.depth }}).
+        {% endif %}
+      </p>
+      <p class="help">
+        Approximation derived from the chart's sampled-window bucket
+        size projected onto the live queue depth; the chunked clear
+        will compute the exact match count as it scans.
+      </p>
+    {% else %}
+      <p class="celery-approx-callout celery-approx-unknown">
+        <em>Approximate count not available</em> &mdash; the chunked
+        clear will compute the exact match count as it scans.
+      </p>
+    {% endif %}
+  </fieldset>
 
   <form method="post" novalidate>
     {% csrf_token %}
@@ -40,110 +121,53 @@
     {% if commitid %}<input type="hidden" name="commitid" value="{{ commitid }}">{% endif %}
 
     <fieldset class="module">
-      <h2>Scope</h2>
-      <p>
-        Queue: <code>{{ queue_name }}</code><br>
-        Task:  {% if task_name %}<code>{{ task_name }}</code>{% else %}<em>(any)</em>{% endif %}<br>
-        Repo:  {% if repoid is not None %}<code>{{ repoid }}</code>{% else %}<em>(any)</em>{% endif %}<br>
-        Commit:
-        {% if commitid %}
-          <code title="{{ commitid }}">{{ commitid|slice:":7" }}</code>
-        {% else %}
-          <em>(any)</em>
-        {% endif %}
-        {% if match_count >= 2 and kept_index is not None %}
-          <br>"Clear all but first" would keep
-          <code>index={{ kept_index }}</code> (the lowest-index match,
-          i.e. the next message a Celery worker would pop) and clear
-          the remaining {{ match_count|add:"-1" }} of {{ match_count }}.
-        {% endif %}
-      </p>
-    </fieldset>
-
-    <fieldset class="module">
-      <h2>Matched: {{ match_count }} message(s)</h2>
-
-      {% if match_count == 0 %}
-        <p><em>No celery_broker messages currently match this filter.</em></p>
-      {% else %}
-        <p>
-          The first {{ sample_targets|length }} matching message(s):
-        </p>
-        <table>
-          <thead>
-            <tr>
-              <th>Index</th>
-              <th>Task</th>
-              <th>repoid</th>
-              <th>commit</th>
-              <th>task id</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for t in sample_targets %}
-            <tr>
-              <td>{{ t.index_in_queue }}</td>
-              <td>{{ t.task_name|default:"—" }}</td>
-              <td>{{ t.repoid|default_if_none:"—" }}</td>
-              <td>{% if t.commitid %}<code>{{ t.commitid|slice:":7" }}</code>{% else %}—{% endif %}</td>
-              <td>{% if t.task_id %}<code>{{ t.task_id|slice:":8" }}</code>{% else %}—{% endif %}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-        {% if match_count > sample_targets|length %}
-          <p><em>Showing first {{ sample_targets|length }} of {{ match_count }} matching message(s).</em></p>
-        {% endif %}
-
-        <h3>Confirm and clear</h3>
-        <div class="form-row{% if confirm_error %} errors{% endif %}">
-          <div>
-            {% if confirm_error %}<ul class="errorlist"><li>{{ confirm_error }}</li></ul>{% endif %}
-            <label for="id_typed_confirm">Type <code>{{ expected_confirm }}</code> to confirm:</label>
-            <input type="text" name="typed_confirm" id="id_typed_confirm" value="{{ typed_confirm }}" autocomplete="off">
-            <div class="help">
-              Re-type the queue name above to enable the destructive
-              actions on the right. Dry-run does not require it.
-            </div>
+      <h2>Confirm and clear</h2>
+      <div class="form-row{% if confirm_error %} errors{% endif %}">
+        <div>
+          {% if confirm_error %}<ul class="errorlist"><li>{{ confirm_error }}</li></ul>{% endif %}
+          <label for="id_typed_confirm">Type <code>{{ expected_confirm }}</code> to confirm:</label>
+          <input type="text" name="typed_confirm" id="id_typed_confirm" value="{{ typed_confirm }}" autocomplete="off">
+          <div class="help">
+            Re-type the queue name above to enable the destructive
+            actions on the right. Dry-run does not require it.
           </div>
         </div>
+      </div>
 
-        {% comment %}
-        Three submit buttons share the form. Server-side dispatch on
-        the `action` value:
+      {% comment %}
+      Three submit buttons share the form. Server-side dispatch on
+      the `action` value:
 
-        * `dry_run` — neutral / `default` styling. Audited via
-          `celery_broker_clear(dry_run=True)`; queue untouched.
-        * `clear_keep_one` — destructive (red text). Only rendered
-          when match_count >= 2. Clears every match EXCEPT the
-          lowest-index one; "drop duplicate retries but leave one
-          running."
-        * `clear_all` — destructive (red text). Clears every match.
+      * `dry_run` &mdash; neutral / `default` styling. Spawns the
+        chunked background-job worker with `dry_run=True`; queue
+        untouched. Writes a `LogEntry` on completion.
+      * `clear_keep_one` &mdash; destructive (red text). Clears
+        every match EXCEPT the lowest-index one; "drop duplicate
+        retries but leave one running."
+      * `clear_all` &mdash; destructive (red text). Clears every
+        match.
 
-        The two destructive buttons are stacked vertically and
-        anchored to the right edge so they read as a distinct "what
-        to do once you've confirmed" cluster, separated visually
-        both from the dry-run button on the left and from each
-        other.
-        {% endcomment %}
-        <div class="submit-row celery-clear-actions">
-          <button type="submit" name="action" value="dry_run" class="default">
-            Dry-run (audit only, no mutations)
+      The two destructive buttons are stacked vertically and
+      anchored to the right edge so they read as a distinct "what
+      to do once you've confirmed" cluster, separated visually
+      both from the dry-run button on the left and from each
+      other.
+      {% endcomment %}
+      <div class="submit-row celery-clear-actions">
+        <button type="submit" name="action" value="dry_run" class="default">
+          Dry-run (audit only, no mutations)
+        </button>
+        <div class="celery-destructive-actions">
+          <button type="submit" name="action" value="clear_keep_one"
+                  class="button celery-destructive-button celery-clear-keep-one">
+            Clear all but first
           </button>
-          <div class="celery-destructive-actions">
-            {% if match_count >= 2 %}
-              <button type="submit" name="action" value="clear_keep_one"
-                      class="button celery-destructive-button celery-clear-keep-one">
-                Clear all but first ({{ match_count|add:"-1" }} of {{ match_count }} from {{ queue_name }})
-              </button>
-            {% endif %}
-            <button type="submit" name="action" value="clear_all"
-                    class="button celery-destructive-button celery-clear-all">
-              Clear all ({{ match_count }} from {{ queue_name }})
-            </button>
-          </div>
+          <button type="submit" name="action" value="clear_all"
+                  class="button celery-destructive-button celery-clear-all">
+            Clear all from {{ queue_name }}
+          </button>
         </div>
-      {% endif %}
+      </div>
     </fieldset>
 
     <p>
@@ -160,6 +184,27 @@
      deliberately don't use Django admin's `deletelink` class here
      because that swaps the background to red and the foreground to
      white; the user spec for this surface is "red text". */
+  .celery-clear-filter {
+    border-collapse: collapse;
+  }
+  .celery-clear-filter th,
+  .celery-clear-filter td {
+    padding: 4px 12px 4px 0;
+    text-align: left;
+    vertical-align: top;
+  }
+  .celery-clear-filter th {
+    width: 6em;
+    font-weight: 600;
+    color: var(--body-quiet-color, inherit);
+  }
+  .celery-approx-callout {
+    font-size: 1.05em;
+    margin: 0.25em 0;
+  }
+  .celery-approx-unknown {
+    color: var(--body-quiet-color, inherit);
+  }
   .celery-clear-actions {
     display: flex;
     flex-wrap: wrap;

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_clear_job.py
@@ -616,19 +616,25 @@ def test_clear_by_filter_view_redirects_to_progress_page_on_confirmed_submit(
     start_mock.assert_not_called()  # patched at module-level, not used
 
 
-def test_clear_by_filter_view_dry_run_preview_unchanged(patched_broker, superuser):
-    """The dry-run action keeps the synchronous shape: it calls
-    `celery_broker_clear(dry_run=True)`, re-renders the preview
-    page, and never spawns a chunked job. Pin so a future refactor
-    that fans dry-run out to a chunked job has to update this
-    test deliberately.
+def test_clear_by_filter_view_dry_run_redirects_to_progress_page(
+    patched_broker, superuser
+):
+    """Dry-run no longer keeps a synchronous shape; it now fans out
+    to the chunked-job worker (with `dry_run=True`) and 302s to the
+    progress page, exactly like the destructive actions. The audit
+    log entry still lands at job-completion under
+    `scope="celery_broker_clear"` with `mode=chunked-dry-run`.
     """
 
     queue = "notify"
     _push_envelopes(patched_broker, queue, n=2, repoid=1)
     rf = RequestFactory()
 
-    with mock.patch("redis_admin.admin.start_celery_broker_clear_job") as start_mock:
+    fake_job_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    with mock.patch(
+        "redis_admin.admin.start_celery_broker_clear_job",
+        return_value=fake_job_id,
+    ) as start_mock:
         request = rf.post(
             "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
             data={
@@ -640,16 +646,23 @@ def test_clear_by_filter_view_dry_run_preview_unchanged(patched_broker, superuse
         request.user = superuser
         admin_instance = _admin_instance()
         # `messages` middleware isn't installed on the bare
-        # RequestFactory; the view calls `messages.info(...)`. We
-        # use a stand-in storage so the call doesn't raise.
+        # RequestFactory; the view code path may call
+        # `messages.error(...)` on validation failures. Stand-in
+        # storage prevents an uncaught exception.
         request.session = {}
         request._messages = FallbackStorage(request)
         response = admin_instance.clear_by_filter_view(request)
 
-    # Dry-run re-renders the preview (200 OK, not 302) and never
-    # touches the chunked-job code path.
-    assert response.status_code == 200
-    start_mock.assert_not_called()
+    # Dry-run now spawns a chunked job and redirects, same shape as
+    # `clear_all` / `clear_keep_one`.
+    assert response.status_code == 302
+    assert response["Location"].endswith(f"/clear-by-filter/job/{fake_job_id}/"), (
+        response["Location"]
+    )
+    # And the chunked-job worker is invoked with `dry_run=True`.
+    start_mock.assert_called_once()
+    _, kwargs = start_mock.call_args
+    assert kwargs.get("dry_run") is True
 
 
 # ---- Audit log (django_db) -------------------------------------------------

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -54,7 +54,6 @@ from redis_admin.services import (
     _streaming_celery_clear,
     _substitute_filter_any,
     celery_broker_clear,
-    streaming_celery_count,
 )
 from shared.django_apps.codecov_auth.tests.factories import UserFactory
 from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
@@ -626,10 +625,10 @@ def test_substitute_filter_any_passes_through_set_slots():
 
 def test_substitute_filter_any_substitutes_unset_slots_with_wildcard():
     """All-`None` input becomes the all-wildcards triple — the
-    "unconstrained operator filter" shape that
-    `streaming_celery_count`, the chunked clear job, and the
-    `clear_by_filter_view` synthetic target all need to share so
-    they agree on which envelopes match.
+    "unconstrained operator filter" shape that the chunked clear
+    job needs so its filter target matches every envelope whose
+    explicitly-set slots equal the operator's input (and ignores
+    any unset slots).
     """
 
     triple = _substitute_filter_any(None, None, None)
@@ -653,16 +652,16 @@ def test_substitute_filter_any_treats_empty_string_as_unset_for_strings_only():
 
 def test_substitute_filter_any_keeps_streaming_count_and_clear_job_in_sync():
     """Regression for Bugbot review on PR #904 (LOW severity):
-    the `_FILTER_ANY`-substitution rule is shared across
-    `streaming_celery_count`, `_run_celery_broker_clear_job_body`,
-    and the `clear_by_filter_view` filter target. All three must
-    produce the same triple for the same operator input or the
-    dry-run count would silently disagree with the chunked
+    the `_FILTER_ANY`-substitution rule lives in
+    `_run_celery_broker_clear_job_body` (the chunked clear job)
+    where dry-run, keep-one and live-clear passes all derive
+    their filter triple from the same helper. If the rule drifts,
+    the dry-run count would silently disagree with the live
     clear's matched count — a data-loss vector.
 
-    Pin the contract here so a future helper-edit that breaks one
-    consumer breaks the test rather than letting the three call
-    sites drift.
+    Pin the helper's contract here so a future edit that breaks
+    one consumer breaks the test rather than letting the call
+    sites silently drift.
     """
 
     inputs = [
@@ -1263,65 +1262,166 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
     def _push(self, **kwargs):
         self.redis.rpush("celery", _build_envelope(**kwargs))
 
-    def test_chart_open_renders_preview_with_three_actions(self):
-        # The chart's "Clear queue" button POSTs the bucket's scope
-        # without an `action` value; the view should land on the
-        # preview page rather than mutating anything. The preview
-        # page must render all three submit buttons (dry-run,
-        # clear-all-but-first, clear-all) when match_count >= 2.
-        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
-        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
+    # ---- GET render: zero-Redis -------------------------------------
 
-        response = self.client.post(
+    def _instrument_redis(self):
+        """Wrap fakeredis in a counting MagicMock so the GET-no-Redis
+        tests can assert `proxy.method_calls == []`. The class's
+        `tearDown` restores the original `redis_admin_conn.get_connection`.
+        """
+
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        proxy = MagicMock(wraps=self.redis)
+        redis_admin_conn.get_connection = lambda kind="default": proxy  # type: ignore[assignment]
+        return proxy
+
+    def test_get_with_chart_hints_renders_approx_callout_without_redis_calls(self):
+        """The chart-driven GET passes (queue, task, repoid, commit)
+        plus four display hints. The view must render the
+        approximate-count callout from the hints alone — zero Redis
+        I/O, so the page returns instantly even on a 500k-deep queue.
+        Approximation is `round(bucket_count / total_visible *
+        total_depth)`.
+        """
+
+        proxy = self._instrument_redis()
+
+        response = self.client.get(
             "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
             {
                 "queue_name": "celery",
+                "task_name": "app.tasks.bundle_analysis.BundleAnalysisProcessor",
                 "repoid": "1",
-                "commitid": "aaaa",
+                "commitid": "aaaaaaa1234567890bcdef0123456789abcdef01",
+                "bucket_count": "7400",
+                "bucket_pct": "37.0",
+                "total_visible": "20000",
+                "total_depth": "211000",
             },
         )
 
         assert response.status_code == 200
         body = response.content.decode("utf-8", errors="replace")
-        assert "Matched: 2 message(s)" in body
-        # All three action buttons are wired up via distinct
-        # `action` values — assert on the form-input markers, not
-        # on the visible labels, so a future copy tweak doesn't
-        # silently weaken the test.
+        # round(7400 / 20000 * 211000) == 78_070; bucket_pct comes
+        # straight from the URL.
+        assert "Will tombstone approximately" in body
+        assert "78070" in body
+        assert "37.0" in body
+        assert "211000" in body
+        # Confirmation actions still wired up.
         assert 'name="action" value="dry_run"' in body
         assert 'name="action" value="clear_keep_one"' in body
         assert 'name="action" value="clear_all"' in body
-        # Both destructive buttons share the `celery-destructive-
-        # button` class, which carries the red-text styling.
-        assert "celery-destructive-button" in body
-        # No mutation happened.
-        assert self.redis.llen("celery") == 2
+        # Zero Redis ops on the GET — the whole point of this PR.
+        assert proxy.method_calls == [], (
+            f"GET clear-by-filter must not touch Redis; saw {proxy.method_calls!r}"
+        )
 
-    def test_dry_run_lists_targets_without_mutating(self):
-        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
-        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
-        self._push(kwargs={"repoid": 2, "commitid": "bbbb"})
+    def test_get_without_chart_hints_renders_unknown_callout_without_redis_calls(self):
+        """Hand-crafted URL without hints renders the
+        "Approximate count not available" branch — still no Redis.
+        """
 
-        response = self.client.post(
+        proxy = self._instrument_redis()
+
+        response = self.client.get(
             "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
             {
                 "queue_name": "celery",
                 "repoid": "1",
-                "commitid": "aaaa",
-                "action": "dry_run",
+                "commitid": "aaaaaaa1234567890bcdef0123456789abcdef01",
             },
         )
 
         assert response.status_code == 200
         body = response.content.decode("utf-8", errors="replace")
-        assert "Matched: 2 message(s)" in body
-        # Dry-run did not pop the queue.
-        assert self.redis.llen("celery") == 3
+        assert "Approximate count not available" in body
+        assert 'name="action" value="dry_run"' in body
+        assert 'name="action" value="clear_all"' in body
+        assert proxy.method_calls == [], (
+            f"GET clear-by-filter without hints must not touch Redis; "
+            f"saw {proxy.method_calls!r}"
+        )
 
-    def test_clear_all_clears_only_matching_messages(self):
+    def test_get_with_malformed_hints_falls_back_gracefully(self):
+        """Garbage hints coerce to `None` via `_coerce_int` /
+        `_coerce_float` and route to the "not available" branch
+        instead of raising.
+        """
+
+        proxy = self._instrument_redis()
+
+        response = self.client.get(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+            {
+                "queue_name": "celery",
+                "repoid": "1",
+                "bucket_count": "not-a-number",
+                "bucket_pct": "37%",
+                "total_visible": "twenty thousand",
+                "total_depth": "",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        assert "Approximate count not available" in body
+        assert proxy.method_calls == []
+
+    def test_get_with_zero_total_visible_falls_back_gracefully(self):
+        """Divide-by-zero guard: `total_visible == 0` would raise
+        `ZeroDivisionError`. The view must route to the "not
+        available" branch instead.
+        """
+
+        proxy = self._instrument_redis()
+
+        response = self.client.get(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+            {
+                "queue_name": "celery",
+                "repoid": "1",
+                "bucket_count": "100",
+                "bucket_pct": "0.0",
+                "total_visible": "0",
+                "total_depth": "100",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        assert "Approximate count not available" in body
+        assert proxy.method_calls == []
+
+    def test_get_renders_repo_admin_link_when_repoid_present(self):
+        """The filter row's `Repo` cell links into the Django admin
+        Repository change page so the chart's repo cell and the
+        confirmation page's link round-trip to the same URL.
+        """
+
+        self._instrument_redis()
+
+        response = self.client.get(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+            {
+                "queue_name": "celery",
+                "repoid": "42",
+                "commitid": "aaaaaaa1234567890bcdef0123456789abcdef01",
+            },
+        )
+        body = response.content.decode("utf-8", errors="replace")
+        assert "/core/repository/42/" in body
+
+    # ---- POST: redirects to chunked progress page -------------------
+
+    def test_post_clear_all_with_typed_confirm_redirects_to_progress_page(self):
+        """All three actions fan out to the chunked-job worker; the
+        view returns a 302 to the progress page. The view path
+        itself does no Redis I/O — the worker thread does.
+        """
+
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
-        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
-        self._push(kwargs={"repoid": 2, "commitid": "bbbb"})
 
         response = self.client.post(
             "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
@@ -1336,15 +1436,49 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
         )
 
         assert response.status_code in (302, 303)
-        # The two repoid=1 messages were tombstoned and LREM'd; the
-        # repoid=2 message remains. The kombu envelope's body is
-        # base64-encoded, so re-parse it to check the kwargs.
-        remaining = self.redis.lrange("celery", 0, -1)
-        assert len(remaining) == 1
-        envelope = json.loads(remaining[0])
-        body = json.loads(base64.b64decode(envelope["body"]).decode("utf-8"))
-        assert body[1].get("repoid") == 2
-        assert body[1].get("commitid") == "bbbb"
+        assert "/clear-by-filter/job/" in response["Location"]
+
+    def test_post_dry_run_redirects_to_progress_page(self):
+        """Dry-run no longer keeps a synchronous shape; it fans out
+        to the chunked worker (with `dry_run=True`) and 302s to the
+        progress page like the destructive actions.
+        """
+
+        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
+
+        response = self.client.post(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+            {
+                "queue_name": "celery",
+                "repoid": "1",
+                "commitid": "aaaa",
+                "action": "dry_run",
+            },
+            follow=False,
+        )
+
+        assert response.status_code in (302, 303)
+        assert "/clear-by-filter/job/" in response["Location"]
+
+    def test_post_clear_keep_one_with_typed_confirm_redirects_to_progress_page(self):
+        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
+
+        response = self.client.post(
+            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
+            {
+                "queue_name": "celery",
+                "repoid": "1",
+                "commitid": "aaaa",
+                "action": "clear_keep_one",
+                "typed_confirm": "celery",
+            },
+            follow=False,
+        )
+
+        assert response.status_code in (302, 303)
+        assert "/clear-by-filter/job/" in response["Location"]
+
+    # ---- POST: typed-confirm gate -----------------------------------
 
     def test_clear_all_requires_typed_confirmation(self):
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
@@ -1390,215 +1524,20 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
         assert "Typed confirmation must equal" in body
         assert self.redis.llen("celery") == 2
 
-    def test_task_name_filter_narrows_to_matching_task_only(self):
-        # Two task classes share `(repoid, commitid)`. The chart's
-        # row-level "Clear queue" submits `task_name` alongside
-        # repoid/commitid; that combination must clear only the
-        # targeted task and leave the other one in the queue.
-        self._push(
-            task="app.tasks.bundle_analysis.BundleAnalysisProcessor",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
-        self._push(
-            task="app.tasks.notify.NotifyTask",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
+    # ---- POST: legacy `action=confirm` shim ------------------------
+    #
+    # End-to-end exercise of the chunked worker (queue actually
+    # drained, audit-log shape, etc.) lives in
+    # `test_celery_broker_clear_job.py`. The tests below pin only
+    # the view's URL-shape contract — that the legacy POST shapes
+    # still 302 to the progress page rather than 404'ing or
+    # re-rendering the changelist.
 
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "task_name": "app.tasks.bundle_analysis.BundleAnalysisProcessor",
-                "repoid": "1",
-                "commitid": "aaaa",
-                "action": "clear_all",
-                "typed_confirm": "celery",
-            },
-            follow=False,
-        )
-
-        assert response.status_code in (302, 303)
-        remaining = self.redis.lrange("celery", 0, -1)
-        assert len(remaining) == 1
-        envelope = json.loads(remaining[0])
-        # The surviving message is the unrelated `notify` task.
-        assert envelope["headers"]["task"] == "app.tasks.notify.NotifyTask"
-
-    def test_task_name_alone_is_a_valid_narrowing_filter(self):
-        # task_name on its own (no repoid / commitid) is enough to
-        # clear — the chart's leftmost column lets operators clear
-        # "every notify task in this queue" without needing to pin
-        # a repo or commit.
-        self._push(
-            task="app.tasks.notify.NotifyTask",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
-        self._push(
-            task="app.tasks.bundle_analysis.BundleAnalysisProcessor",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
-
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "task_name": "app.tasks.notify.NotifyTask",
-                "action": "clear_all",
-                "typed_confirm": "celery",
-            },
-            follow=False,
-        )
-
-        assert response.status_code in (302, 303)
-        remaining = self.redis.lrange("celery", 0, -1)
-        assert len(remaining) == 1
-        envelope = json.loads(remaining[0])
-        assert envelope["headers"]["task"] == (
-            "app.tasks.bundle_analysis.BundleAnalysisProcessor"
-        )
-
-    def test_clear_keep_one_leaves_lowest_index_match_in_queue(self):
-        # `action=clear_keep_one` should clear every match EXCEPT
-        # the one with the lowest `index_in_queue` — i.e. the head-
-        # of-queue, the next message a Celery worker would pop.
-        # With three matching messages at indexes 0/1/2, indexes 1
-        # and 2 are cleared and index 0 stays.
-        self._push(
-            task="app.tasks.notify.NotifyTask",
-            task_id="keep-this-one",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
-        self._push(
-            task="app.tasks.notify.NotifyTask",
-            task_id="drop-1",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
-        self._push(
-            task="app.tasks.notify.NotifyTask",
-            task_id="drop-2",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
-        # Plus an unrelated task that should be untouched regardless.
-        self._push(
-            task="app.tasks.notify.NotifyTask",
-            task_id="unrelated",
-            kwargs={"repoid": 99, "commitid": "zzzz"},
-        )
-
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "task_name": "app.tasks.notify.NotifyTask",
-                "repoid": "1",
-                "commitid": "aaaa",
-                "action": "clear_keep_one",
-                "typed_confirm": "celery",
-            },
-            follow=False,
-        )
-
-        assert response.status_code in (302, 303)
-        remaining = self.redis.lrange("celery", 0, -1)
-        # Only `keep-this-one` (lowest-index match) and the
-        # unrelated repo=99 message survive.
-        surviving_task_ids = {json.loads(item)["headers"]["id"] for item in remaining}
-        assert surviving_task_ids == {"keep-this-one", "unrelated"}
-
-    def test_dry_run_audited_via_service_does_not_mutate(self):
-        # The dry-run button on the preview page funnels through
-        # `celery_broker_clear(dry_run=True)` so the audit log
-        # captures it; the queue itself is untouched.
-        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
-        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
-        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
-
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "repoid": "1",
-                "commitid": "aaaa",
-                "action": "dry_run",
-            },
-            follow=False,
-        )
-
-        assert response.status_code == 200
-        body = response.content.decode("utf-8", errors="replace")
-        # Dry-run re-renders the preview (200, no redirect) and the
-        # full match set survives in the queue.
-        assert "Matched: 3" in body
-        assert self.redis.llen("celery") == 3
-
-    def test_clear_keep_one_button_hidden_when_only_one_match(self):
-        # Single-match preview: the destructive "Clear all but
-        # first" button must not render — there's only one message
-        # and the keep-first semantic would clear nothing. The
-        # "Clear all" button still shows.
-        self._push(
-            task="app.tasks.notify.NotifyTask",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
-
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "task_name": "app.tasks.notify.NotifyTask",
-                "repoid": "1",
-                "commitid": "aaaa",
-            },
-        )
-
-        assert response.status_code == 200
-        body = response.content.decode("utf-8", errors="replace")
-        assert "Matched: 1 message(s)" in body
-        assert 'name="action" value="dry_run"' in body
-        assert 'name="action" value="clear_all"' in body
-        assert 'name="action" value="clear_keep_one"' not in body
-
-    def test_clear_keep_one_is_noop_when_only_one_match(self):
-        # Single-message bucket: `action=clear_keep_one` would have
-        # to drop the only in-flight message to do anything, which
-        # defeats the "keep first" semantic. The preview page only
-        # renders the button for match_count >= 2, but a hand-
-        # crafted POST or a count change between render and submit
-        # could still land here — the view must short-circuit with
-        # a friendly info message and leave the queue untouched.
-        self._push(
-            task="app.tasks.notify.NotifyTask",
-            task_id="only-one",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
-
-        response = self.client.post(
-            "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
-            {
-                "queue_name": "celery",
-                "task_name": "app.tasks.notify.NotifyTask",
-                "repoid": "1",
-                "commitid": "aaaa",
-                "action": "clear_keep_one",
-                "typed_confirm": "celery",
-            },
-            follow=False,
-        )
-
-        # Redirected back to the queue's changelist with an info
-        # message; the message is still in the queue.
-        assert response.status_code in (302, 303)
-        remaining = self.redis.lrange("celery", 0, -1)
-        assert len(remaining) == 1
-        envelope = json.loads(remaining[0])
-        assert envelope["headers"]["id"] == "only-one"
-
-    def test_legacy_confirm_action_still_clears_all(self):
-        # Backward-compat shim: the previous version of this view
-        # used `action=confirm`. New callers send `clear_all` /
-        # `clear_keep_one`; the shim keeps stale tabs / scripts
-        # working without re-loading.
-        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
+    def test_legacy_confirm_action_still_redirects_to_progress_page(self):
+        # The previous version of this view used `action=confirm`.
+        # The shim normalises that to `clear_all` (or
+        # `clear_keep_one` when `mode=keep_one` is set) so stale
+        # tabs / scripts keep working through this PR's deploy.
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
 
         response = self.client.post(
@@ -1614,29 +1553,17 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
         )
 
         assert response.status_code in (302, 303)
-        assert self.redis.llen("celery") == 0
+        assert "/clear-by-filter/job/" in response["Location"]
 
-    def test_legacy_confirm_with_mode_keep_one_routes_correctly(self):
-        # The old form posted `action=confirm` + `mode=keep_one` for
-        # the keep-first variant; the shim must route that to the
-        # new `clear_keep_one` action so the lowest-index match
-        # survives.
-        self._push(
-            task="t.K",
-            task_id="keep",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
-        self._push(
-            task="t.K",
-            task_id="drop",
-            kwargs={"repoid": 1, "commitid": "aaaa"},
-        )
+    def test_legacy_confirm_with_mode_keep_one_routes_to_keep_one(self):
+        # `action=confirm` + `mode=keep_one` must coerce to the new
+        # `clear_keep_one` action and 302 to the progress page.
+        self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
 
         response = self.client.post(
             "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
             {
                 "queue_name": "celery",
-                "task_name": "t.K",
                 "repoid": "1",
                 "commitid": "aaaa",
                 "mode": "keep_one",
@@ -1647,11 +1574,15 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
         )
 
         assert response.status_code in (302, 303)
-        remaining = self.redis.lrange("celery", 0, -1)
-        assert len(remaining) == 1
-        assert json.loads(remaining[0])["headers"]["id"] == "keep"
+        assert "/clear-by-filter/job/" in response["Location"]
+
+    # ---- Guards -----------------------------------------------------
 
     def test_refuses_clear_without_narrowing_filter(self):
+        # `clear_by_filter` is the per-bucket flow; "drain the
+        # whole queue" lives in the M5 `clear_by_scope` flow.
+        # Refusing the unscoped clear keeps the two surfaces non-
+        # overlapping (and prevents an audit-log shape collision).
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
 
         response = self.client.post(
@@ -1661,33 +1592,36 @@ class CeleryBrokerClearByFilterViewTest(TestCase):
                 "action": "clear_all",
                 "typed_confirm": "celery",
             },
-            follow=True,
+            follow=False,
         )
 
-        # Redirected back to changelist with an error message; queue
-        # unchanged because we refuse the empty-narrowing case.
-        assert response.status_code == 200
-        # Sanity: the message in `messages` framework is rendered as
-        # part of the changelist response.
+        # Redirected back to the changelist (not the progress
+        # page); no chunked job spawned, queue untouched.
+        assert response.status_code in (302, 303)
+        assert "/clear-by-filter/job/" not in response["Location"]
         assert self.redis.llen("celery") == 1
 
     def test_non_superuser_is_refused(self):
+        # Both GET and POST require superuser; a staff-only user
+        # must not reach the view body.
         self._push(kwargs={"repoid": 1, "commitid": "aaaa"})
         staff_user = UserFactory(is_staff=True, is_superuser=False)
         self.client.force_login(staff_user)
 
-        response = self.client.post(
+        response = self.client.get(
             "/admin/redis_admin/celerybrokerqueue/clear-by-filter/",
             {
                 "queue_name": "celery",
                 "repoid": "1",
-                "action": "clear_all",
-                "typed_confirm": "celery",
             },
         )
 
+        # Either a 403 (PermissionDenied raised inside the admin
+        # view) or a 302 to the admin login page (the
+        # `admin.site.admin_view` wrapper redirects when the
+        # staff-check fails first). Both indicate the view body
+        # was not reached.
         assert response.status_code in (403, 302)
-        assert self.redis.llen("celery") == 1
 
 
 # ---- Summary-mode queryset -------------------------------------------------
@@ -2534,53 +2468,6 @@ def test_streaming_clear_dry_run_returns_full_queue_match_count(patched_broker):
     assert patched_broker.llen(queue) == n
 
 
-def test_streaming_celery_count_returns_full_queue_match_count(patched_broker):
-    """Regression for the case where the clear-by-filter preview page
-    reported only ~2k matches on a queue with ~190k matches. The
-    streaming counter must walk the full LLEN(queue), not the capped
-    queryset window — the queryset path materialises only the first
-    `CELERY_BROKER_DISPLAY_LIMIT` (default 2_000) messages before
-    filtering, so on a queue dominated by one filter triple the
-    preview's `match_count` would underreport while "Clear all"
-    (unbounded) drained the full set.
-
-    `clear_by_filter_view` is a thin wrapper around this helper, so
-    pinning the helper's behaviour here covers the view fix too
-    without requiring the Django test client / Postgres.
-    """
-
-    queue = "bundle_analysis"
-    task = "app.tasks.bundle_analysis.BundleAnalysisProcessor"
-    repoid = 21222368
-    commitid = "0832c11a1f43c5e2a1b9f8a3e5d1c2b7e9a8d3f0"
-
-    # > CELERY_BROKER_DISPLAY_LIMIT so the queryset-bounded window
-    # would have underreported by `n - DISPLAY_LIMIT`.
-    n = redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT + 1_000
-    pipe = patched_broker.pipeline(transaction=False)
-    for _ in range(n):
-        pipe.rpush(
-            queue,
-            _build_envelope(task=task, kwargs={"repoid": repoid, "commitid": commitid}),
-        )
-    pipe.execute()
-
-    match_count, first_index = streaming_celery_count(
-        queue,
-        task_name=task,
-        repoid=repoid,
-        commitid=commitid,
-    )
-
-    assert match_count == n
-    # First match is at index 0 (every message in the queue matches
-    # the filter, and pass 1 walks ascending).
-    assert first_index == 0
-    # No mutation — `streaming_celery_count` is built on the dry-run
-    # streaming clear path.
-    assert patched_broker.llen(queue) == n
-
-
 def test_streaming_clear_dry_run_keep_one_skips_empty_queues(patched_broker):
     """Regression for Bugbot review on PR #903: when the dry-run
     preview spans multiple queues with `keep_one=True`, the
@@ -2650,7 +2537,7 @@ def test_celery_broker_clear_with_synthetic_filter_target_clears_full_queue(
     patched_broker,
 ):
     """Regression for Bugbot review on PR #903 (HIGH severity):
-    `clear_by_filter_view` previously passed `sample_targets` (the
+    the per-bucket clear path used to pass `sample_targets` (the
     materialised window capped at `CELERY_BROKER_DISPLAY_LIMIT`) as
     the `targets` arg to `celery_broker_clear`. When every match
     sat *beyond* that window -- e.g. a recent burst that filled the
@@ -2660,7 +2547,8 @@ def test_celery_broker_clear_with_synthetic_filter_target_clears_full_queue(
     executed, and the operator saw "Cleared 0 of N matching
     message(s)" while the queue stayed full.
 
-    The view now synthesises a single `CeleryBrokerQueue` directly
+    The chunked clear job (`_run_celery_broker_clear_job_body`)
+    now constructs a single synthetic `CeleryBrokerQueue` directly
     from the operator's filter inputs (queue + task_name? +
     repoid? + commitid?). This test pins that contract: a single
     synthetic target carrying just the filter triple must fan out
@@ -2711,73 +2599,17 @@ def test_celery_broker_clear_with_synthetic_filter_target_clears_full_queue(
     assert patched_broker.llen(queue) == 0
 
 
-def test_streaming_celery_count_wildcard_task_name_matches_any_task(patched_broker):
-    """Regression for the pre-existing wildcard bug surfaced by the
-    synthetic-target fix on PR #903: `streaming_celery_count` (and
-    the underlying `_streaming_celery_clear` filter) used exact-
-    tuple equality on `(task, repoid, commit)`. When the operator
-    left `task_name` unset (None), the filter tuple
-    `(None, 1, "aaaa")` could never match a real envelope (whose
-    `meta.task` is always populated), so the preview reported zero
-    matches even when the queryset's
-    `filter(repoid=1, commitid__startswith="aaaa")` would surface
-    rows.
-
-    With the wildcard fix, `None` slots in a filter tuple act as
-    "don't constrain on this field" -- mirroring the queryset's
-    "filter by what's set" semantic -- so the streaming counter
-    and the streaming clear agree with the queryset's match set.
-    """
-
-    queue = "celery"
-    repoid = 7
-    commitid = "deadbeefcafebabe1111222233334444aaaaaaaa"
-    task_a = "app.tasks.notify.NotifyTask"
-    task_b = "app.tasks.upload.UploadTask"
-
-    pipe = patched_broker.pipeline(transaction=False)
-    for _ in range(3):
-        pipe.rpush(
-            queue,
-            _build_envelope(
-                task=task_a, kwargs={"repoid": repoid, "commitid": commitid}
-            ),
-        )
-    for _ in range(2):
-        pipe.rpush(
-            queue,
-            _build_envelope(
-                task=task_b, kwargs={"repoid": repoid, "commitid": commitid}
-            ),
-        )
-    pipe.rpush(
-        queue,
-        _build_envelope(
-            task=task_a, kwargs={"repoid": repoid + 1, "commitid": commitid}
-        ),
-    )
-    pipe.execute()
-
-    match_count, first_index = streaming_celery_count(
-        queue,
-        task_name=None,
-        repoid=repoid,
-        commitid=commitid,
-    )
-    assert match_count == 5
-    assert first_index == 0
-    assert patched_broker.llen(queue) == 6
-
-
 def test_celery_broker_clear_synthetic_target_with_wildcard_task_name_drains_all_matches(
     patched_broker,
 ):
     """Companion for the wildcard fix: the synthetic-target path
-    constructed by `clear_by_filter_view` carries `task_name=None`
+    constructed by the chunked clear job carries `task_name=None`
     when the operator filtered by repoid/commit only, so the
-    clear path must honour the same wildcard semantic the
-    streaming counter uses -- otherwise the preview reports N
-    matches but "Clear all" silently no-ops.
+    streaming clear must honour the same wildcard semantic the
+    chunked job's filter-tuple builder uses — otherwise an
+    operator filter pinned only to repoid/commit would silently
+    no-op against any envelope whose task slot is non-null
+    (i.e. all real envelopes).
     """
 
     queue = "celery"


### PR DESCRIPTION
## Why

The lazy preview added in #907 still costs seconds because the
count requires a streaming `LRANGE` scan of the full queue —
the very work the preview was supposed to defer. On the
deepest queues (200k–500k+ messages) the operator-facing
confirmation page can take 5–15 seconds to first byte.

But the operator already saw the bucket count and queue depth
on the chart that linked them here. The chart's per-row "Clear
queue" button is the only way to land on this page in normal
use, and the chart computed both numbers to render its own
row. So the confirmation page can extrapolate an "approximately
N messages (~Y% of queue)" callout from those passed-through
hints — no further Redis call required, and no async polling /
skeleton placeholder either.

## What

* **Chart form** (`_frequency_chart.html`): per-row "Clear
  queue" form now carries `bucket_count`, `bucket_pct`,
  `total_visible`, and `total_depth` as hidden inputs. Method
  is `GET` since these are non-secret display hints.
* **`clear_by_filter_view`** GET: rip out **all** lazy-preview
  wiring (no `LLEN`, no `streaming_celery_count`, no preview
  cache, no background job, no sample materialization). Read
  the four hint params via new `_coerce_int` / `_coerce_float`
  helpers (so a hand-edited URL never 500s) and render the
  confirmation page synchronously.
* **`clear_by_filter_view`** POST: all three actions
  (`dry_run`, `clear_keep_one`, `clear_all`) now uniformly
  spawn the chunked background-job worker and 302 to the
  progress page. The synchronous-`dry_run`-rerender shape is
  gone — the chunked worker walks the queue and computes the
  exact match count as it scans, regardless of whether the
  pass tombstones anything. Audit log lands at job completion
  under `mode=chunked-dry-run` for the dry-run case.
* **`clear_by_filter.html`**: skeleton placeholders, JS
  include, and CSS include all deleted. Replaced with a static
  filter fieldset (queue, task, repo with admin link, commit
  with full-SHA tooltip) and an "Approximate impact"
  fieldset showing either the extrapolated count or
  "Approximate count not available — the chunked clear will
  compute the exact match count as it scans." Typed-
  confirmation pattern + three submits unchanged.
* **`services.streaming_celery_count`**: deleted (only caller
  was the deleted preview surface; chunked worker uses
  `_streaming_celery_clear` directly with `dry_run=True`).
* **README**: `clear-by-filter/` URLs row + "chart-driven
  targeted clear" section rewritten to document the chart-hint
  passthrough, the synchronous-no-Redis-I/O GET, and the
  uniform 302-to-progress shape across all three actions.
* **Note on PR #907**: that PR's lazy-preview infrastructure
  (preview/skip-count routes, JS, CSS, cache helpers, the two
  `REDIS_ADMIN_CLEAR_BY_FILTER_PREVIEW_*` settings) was never
  merged to `main`, so there was nothing on the file system to
  delete beyond `streaming_celery_count`. If #907 lands first,
  this PR will need a follow-up to drop those leftovers; until
  then the surface is already clean.

## Approximate-count display

Rendered inline (no JS) when all four hints are present and
`total_visible > 0`:

> Will tombstone approximately **78,500** messages (~37% of
> queue at depth 211,052)

Falls back to:

> Approximate count not available — the chunked clear will
> compute the exact match count as it scans.

…when any hint is missing / non-numeric / divides by zero.

## Tests

`CeleryBrokerClearByFilterViewTest` rewritten as a contract
suite over the new view shape:

* GET with chart hints renders the approximate-count callout
  with the right numbers and makes **zero Redis calls**
  (asserted via a `MagicMock` proxy on
  `redis_admin_conn.get_connection` whose `method_calls` must
  be empty after the request).
* GET without hints / with malformed hints / with zero
  `total_visible` falls back to "Approximate count not
  available", still no Redis calls.
* GET resolves the `core.Repository` admin link when `repoid`
  is set.
* POST `clear_all` / `clear_keep_one` / `dry_run` (with valid
  typed-confirm where required) each 302 to
  `…/clear-by-filter/job/<uuid>/`; `start_celery_broker_clear_job`
  is invoked once with the right `dry_run` / `keep_one` flags.
* Typed-confirm gate still rejects destructive POSTs with a
  200 + error message.
* Legacy `action=confirm` form shape still aliases through to
  the chunked-job path.
* Refusal of unscoped clears + superuser gating preserved.
* `test_clear_by_filter_view_dry_run_preview_unchanged` in
  `test_celery_broker_clear_job.py` renamed to
  `…_dry_run_redirects_to_progress_page` and updated to assert
  the new shape.

End-to-end exercise of the chunked worker (queue actually
drained, audit-log shape, `keep_one` survivor placement) lives
in `test_celery_broker_clear_job.py` (existing).

## Migration note

This PR removes URL routes that #907 *would* have introduced
(`clear-by-filter/preview/`, `clear-by-filter/skip-count/`)
but those routes were never merged to `main`, so there's
nothing externally linkable to break. The `clear-by-filter/`
route itself is unchanged.

If #907 merges first, rebase this PR on top of it; the
leftover preview helpers / settings / static files / preview
test file that #907 introduces should then be deleted as part
of the rebase.

## Test plan

- [x] `uv run ruff check redis_admin/`
- [x] `uv run ruff format --check redis_admin/`
- [x] `pytest -q apps/codecov-api/redis_admin/tests/` (294
      passed, run inside the api container which provides
      Postgres for the Django ORM tests)
- [ ] Manual smoke once deployed: open the celery_broker
      drill-down on a deep queue, click "Clear queue…" on a
      bucket, confirm the page renders sub-second with the
      approximate-count callout.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the celery broker admin clear-by-filter flow and how destructive/dry-run actions are executed (now always asynchronous), which could affect operator workflows and queue-clearing behavior if the new job-spawn path misfires. Risk is mitigated by preserving typed-confirmation gates, legacy `action=confirm` compatibility, and expanded tests around zero-Redis GET and redirects.
> 
> **Overview**
> Speeds up the celery broker `clear-by-filter` operator flow by making the confirmation page **fully synchronous with zero Redis I/O**, reusing count/depth hints passed from the frequency chart to show an *approximate* impact instead of doing a live scan.
> 
> Updates the chart’s per-bucket **Clear queue…** action to `GET` the confirmation URL with `bucket_count`/`bucket_pct`/`total_visible`/`total_depth` hints, and simplifies the confirmation template to a static filter summary (including a repo admin link) plus the approximate-impact callout.
> 
> Unifies `POST` handling so **all three actions** (`dry_run`, `clear_keep_one`, `clear_all`) now spawn the existing chunked background clear job and redirect to the progress page; removes the now-unused `streaming_celery_count` helper and updates docs/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d99499b61effe25257b6eeb5159c2b88fde661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->