### PR TITLE
fix: skip sync and notify for non-open pulls

### DIFF
--- a/apps/worker/tasks/sync_pull.py
+++ b/apps/worker/tasks/sync_pull.py
@@ -184,9 +184,9 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                 "pull_updated": False,
                 "reason": "no_db_pull",
             }
-        if pull.state != "open":
+        if pull.state == "closed":
             log.info(
-                "Skipping sync for non-open pull",
+                "Skipping sync for closed pull",
                 extra={**extra_info, "pull_state": pull.state},
             )
             return {
@@ -195,6 +195,8 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                 "pull_updated": False,
                 "reason": "pull_not_open",
             }
+        if pull.state == "merged":
+            should_send_notifications = False
         if enriched_pull.provider_pull is None:
             log.info(
                 "Not syncing pull since we can't find it in the provider. There is nothing to sync",

--- a/apps/worker/tasks/sync_pull.py
+++ b/apps/worker/tasks/sync_pull.py
@@ -187,7 +187,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         if pull.state != "open":
             log.info(
                 "Skipping sync for non-open pull",
-                extra=extra_info,
+                extra={**extra_info, "pull_state": pull.state},
             )
             return {
                 "notifier_called": False,

--- a/apps/worker/tasks/sync_pull.py
+++ b/apps/worker/tasks/sync_pull.py
@@ -184,6 +184,17 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                 "pull_updated": False,
                 "reason": "no_db_pull",
             }
+        if pull.state != "open":
+            log.info(
+                "Skipping sync for non-open pull",
+                extra=extra_info,
+            )
+            return {
+                "notifier_called": False,
+                "commit_updates_done": {"merged_count": 0, "soft_deleted_count": 0},
+                "pull_updated": False,
+                "reason": "pull_not_open",
+            }
         if enriched_pull.provider_pull is None:
             log.info(
                 "Not syncing pull since we can't find it in the provider. There is nothing to sync",

--- a/apps/worker/tasks/tests/integration/test_sync_pull.py
+++ b/apps/worker/tasks/tests/integration/test_sync_pull.py
@@ -86,51 +86,8 @@ class TestPullSyncTask:
         dbsession.flush()
         res = task.run_impl(dbsession, repoid=pull.repoid, pullid=pull.pullid)
         assert {
-            "notifier_called": True,
+            "notifier_called": False,
             "commit_updates_done": {"merged_count": 0, "soft_deleted_count": 0},
-            "pull_updated": True,
-            "reason": "success",
+            "pull_updated": False,
+            "reason": "pull_not_open",
         } == res
-        assert len(pull.flare) == 1
-        expected_flare = {
-            "_class": None,
-            "children": [
-                {
-                    "_class": None,
-                    "color": "red",
-                    "coverage": -1,
-                    "lines": 10,
-                    "name": "README.md",
-                },
-                {
-                    "_class": None,
-                    "color": "#e1e1e1",
-                    "coverage": 0,
-                    "lines": 3,
-                    "name": "codecov.yaml",
-                },
-                {
-                    "_class": None,
-                    "children": [
-                        {
-                            "_class": None,
-                            "color": "#e1e1e1",
-                            "coverage": 0,
-                            "lines": 7,
-                            "name": "test_sample.py",
-                        }
-                    ],
-                    "color": "#e1e1e1",
-                    "coverage": 0.0,
-                    "lines": 7,
-                    "name": "tests",
-                },
-            ],
-            "color": "#e1e1e1",
-            "coverage": 0.0,
-            "lines": 20,
-            "name": "",
-        }
-        assert expected_flare["children"] == pull.flare[0]["children"]
-        assert expected_flare == pull.flare[0]
-        assert pull.diff is None

--- a/apps/worker/tasks/tests/integration/test_sync_pull.py
+++ b/apps/worker/tasks/tests/integration/test_sync_pull.py
@@ -88,6 +88,6 @@ class TestPullSyncTask:
         assert {
             "notifier_called": False,
             "commit_updates_done": {"merged_count": 0, "soft_deleted_count": 0},
-            "pull_updated": False,
-            "reason": "pull_not_open",
+            "pull_updated": True,
+            "reason": "success",
         } == res

--- a/apps/worker/tasks/tests/unit/test_sync_pull.py
+++ b/apps/worker/tasks/tests/unit/test_sync_pull.py
@@ -280,6 +280,25 @@ def test_call_pullsync_task_no_provider_pull_only(
     }
 
 
+@pytest.mark.parametrize("state", ["closed", "merged"])
+def test_call_pullsync_task_pull_not_open(
+    dbsession, mocker, mock_redis, repository, pull, state
+):
+    task = PullSyncTask()
+    mocked_fetch_pr = mocker.patch(
+        "tasks.sync_pull.fetch_and_update_pull_request_information"
+    )
+    pull.state = state
+    mocked_fetch_pr.return_value = EnrichedPull(database_pull=pull, provider_pull=None)
+    res = task.run_impl(dbsession, repoid=repository.repoid, pullid=99)
+    assert res == {
+        "commit_updates_done": {"merged_count": 0, "soft_deleted_count": 0},
+        "notifier_called": False,
+        "pull_updated": False,
+        "reason": "pull_not_open",
+    }
+
+
 def test_call_pullsync_no_bot(dbsession, mock_redis, mocker, pull):
     task = PullSyncTask()
     mocker.patch(

--- a/apps/worker/tasks/tests/unit/test_sync_pull.py
+++ b/apps/worker/tasks/tests/unit/test_sync_pull.py
@@ -280,15 +280,14 @@ def test_call_pullsync_task_no_provider_pull_only(
     }
 
 
-@pytest.mark.parametrize("state", ["closed", "merged"])
-def test_call_pullsync_task_pull_not_open(
-    dbsession, mocker, mock_redis, repository, pull, state
+def test_call_pullsync_task_pull_closed(
+    dbsession, mocker, mock_redis, repository, pull
 ):
     task = PullSyncTask()
     mocked_fetch_pr = mocker.patch(
         "tasks.sync_pull.fetch_and_update_pull_request_information"
     )
-    pull.state = state
+    pull.state = "closed"
     mocked_fetch_pr.return_value = EnrichedPull(database_pull=pull, provider_pull=None)
     res = task.run_impl(dbsession, repoid=repository.repoid, pullid=99)
     assert res == {
@@ -296,6 +295,24 @@ def test_call_pullsync_task_pull_not_open(
         "notifier_called": False,
         "pull_updated": False,
         "reason": "pull_not_open",
+    }
+
+
+def test_call_pullsync_task_pull_merged_no_notification(
+    dbsession, mocker, mock_redis, repository, pull
+):
+    task = PullSyncTask()
+    mocked_fetch_pr = mocker.patch(
+        "tasks.sync_pull.fetch_and_update_pull_request_information"
+    )
+    pull.state = "merged"
+    mocked_fetch_pr.return_value = EnrichedPull(database_pull=pull, provider_pull=None)
+    res = task.run_impl(dbsession, repoid=repository.repoid, pullid=99)
+    assert res == {
+        "commit_updates_done": {"merged_count": 0, "soft_deleted_count": 0},
+        "notifier_called": False,
+        "pull_updated": False,
+        "reason": "not_in_provider",
     }
 
 


### PR DESCRIPTION
Prior to this fix, Codecov would comment on "open" PRs if we have never updated the state in DB. These PRs would be years old, and likely got a web hook. The SyncPull task would check and update the status, but it would also trigger the Notify task which would push the coment regardless of state.

This change adds "state != open" to the checks and will early return with approreate loggs and status without triggering the Notify. It has the added nenifit of saving us a few GitHub API calls to fetch head, base, parents, etc.

Cons: The change will prevent a final Notify on merge, if a customer is expecting this. I think this change would actually be desired as there is no chance for surprises after the PR is merged, when you can't action it.

--- References

https://github.com/codecov/umbrella/blob/086bd33488e8d44544b1f9abc73753f0fb903a19/apps/worker/tasks/sync_pull.py#L117 - should_send_notifications Always true, never changed

https://github.com/codecov/umbrella/blob/086bd33488e8d44544b1f9abc73753f0fb903a19/apps/worker/tasks/sync_pull.py#L172 - updates status in DB, but only breaks if somethings fails

https://github.com/codecov/umbrella/blob/086bd33488e8d44544b1f9abc73753f0fb903a19/apps/worker/tasks/sync_pull.py#L250 - Doesn't check state, checks should_send_notifications. triggers notify

https://github.com/codecov/umbrella/blob/086bd33488e8d44544b1f9abc73753f0fb903a19/apps/worker/tasks/notify.py#L210 - assumes it was only called after doing due diligence, notifies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in `PullSyncTask` can stop expected post-merge or post-close notifications/comments, impacting user-visible output. Logic is simple but affects a high-traffic background workflow and should be validated against state transitions.
> 
> **Overview**
> Prevents `PullSyncTask` from doing any further sync work for PRs already marked `closed`, returning early with reason `pull_not_open` and **never calling** the notify task.
> 
> Also disables notifications when a PR is `merged` by forcing `should_send_notifications=False`, and updates integration/unit tests to reflect the new notifier behavior and to cover the new `closed`/`merged` state handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd63b445a16964cb450a2f0d741144aa72cef954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->