### PR TITLE
feat(redis_admin): unacked queue per-message drill-down + frequency chart + clear-by-filter

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -24,6 +24,7 @@ ORM-backed rows — list_display, search, filters, pagination, and
 | `RedisQueue` | Queue families excluding celery: `uploads/*`, `ta_flake_key:*`, `latest_upload/*`, `upload-processing-state/*`, `intermediate-report/*`. Celery broker queues are hidden here (see `CeleryBrokerQueue` row below). | Yes (superuser only) |
 | `RedisQueueItem` | Items inside a single non-celery queue (LIST entries / SET members / HASH fields / STRING value). | Yes (superuser only) |
 | `CeleryBrokerQueue` | Two-mode admin for `celery_broker`. **Summary mode** (no `queue_name__exact`): one row per known queue with `LLEN` and a drill-in link. **Drill-down mode** (`?queue_name__exact=<queue>`): one row per kombu message, with the envelope parsed into `task_name` / `repoid` / `commitid` / `task_id` / `ownerid` / `pullid` columns + a `(repoid, commitid)` frequency chart above the table. The default discovery surface for celery queues. | Yes (superuser only) |
+| `UnackedQueueItem` | Two-mode admin for Kombu's `unacked` HASH + `unacked_index` ZSET (worker-reserved messages). Summary mode: one row with `HLEN(unacked)` as the depth. Detail mode (`?routing_key__exact=<queue>`): one row per reserved message, with `routing_key` / `task_name` / `repoid` / `commitid` / visibility-timeout deadline columns + a `(routing_key, task, repoid, commitid)` frequency chart. Maps the Grafana `redis_key_size{key="unacked"}` panel into a clickable surface. | Yes (superuser only) |
 | `RedisLock` | Lock families: `*_lock_*`, `upload_finisher_gate_*`, `ta_flake_lock:*`, `lock_attempts:*`, `ta_notifier_fence:*`, `coordination_lock:*` | Read-only (always) |
 
 Lock families are flagged `is_deletable=False` in the registry and
@@ -44,6 +45,9 @@ accidentally surfaces them under `RedisQueue`.
 | `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/` | Progress page for a chunked clear job (HTML, superuser-only). Polls the status JSON view every ~1s; renders a `<progress>` bar, matched / total / drift / pass counters, and a Cancel button. |
 | `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/status/` | JSON snapshot of a chunked clear job (superuser-only); 404s on unknown / expired ids. |
 | `/admin/redis_admin/celerybrokerqueue/clear-by-filter/job/<uuid>/cancel/` | POST-only cancel endpoint (superuser-only); flags `cancel_requested=1` and returns 202 with the latest snapshot. Cancel lands at the next chunk boundary. |
+| `/admin/redis_admin/unackedqueueitem/` | **Unacked summary** — one row carrying `HLEN(unacked)` as `depth` and a drill-in link |
+| `/admin/redis_admin/unackedqueueitem/?routing_key__exact=<queue>` | **Unacked drill-down** — per-reservation rows for one logical queue, with a `(routing_key, task, repoid, commitid)` frequency chart and per-row `HDEL` + `ZREM` clear semantics |
+| `/admin/redis_admin/unackedqueueitem/clear-by-filter/` | Same flow as the celery broker version, but each clear hits both `unacked` (HDEL) and `unacked_index` (ZREM) so the two keys stay paired (see "Unacked queue admin" below). |
 | `/admin/redis_admin/redislock/` | Browse Redis locks (read-only) |
 | `/admin/redis_admin/redisqueue/clear-by-scope/` | M6 — cross-family clear-by-scope (superuser only) |
 
@@ -452,6 +456,99 @@ reused: `LogEntry.change_message` with `scope =
 "celery_broker_clear"`, count, sample, families. Superuser-only
 (`has_delete_permission`) and dry-run-required (`clear_dry_run`
 must run before the destructive `clear_selected` arms).
+
+## Unacked queue admin
+
+The Grafana broker dashboard surfaces a `redis_key_size{key="unacked",
+cluster="$var_cluster"}` panel — when it climbs, on-call wants the
+same per-message drill-down + frequency chart + clear-by-filter
+flow that `CeleryBrokerQueueAdmin` already gives us for the
+queue-side LISTs. `UnackedQueueAdmin` is that surface; it maps
+the panel's HLEN directly into a clickable admin page.
+
+### Kombu's `unacked` Redis layout
+
+When a Celery worker reserves a message via `BRPOPLPUSH`, Kombu's
+Redis transport — see `kombu.transport.redis.Channel.unacked_key`
+(`"unacked"`) and `Channel.unacked_index_key` (`"unacked_index"`)
+— moves the envelope onto **two coordinated keys**, both on the
+**broker** Redis (not cache):
+
+- `unacked` — a Redis **HASH** keyed by `delivery_tag`
+  (UUID-like). Each value is the JSON-serialised triple
+  `[message_dict, exchange_str, routing_key_str]`. The
+  `routing_key` field tells you which logical queue the message
+  was reserved from. `message_dict["body"]` is base64-encoded
+  JSON of the same celery envelope shape that
+  `redis_admin.families.parse_celery_envelope` already
+  understands, so `task_name` / `repoid` / `commitid` /
+  `task_id` / `ownerid` / `pullid` extraction is reused.
+- `unacked_index` — a Redis **ZSET** with score = visibility-
+  timeout deadline (unix timestamp) and member = `delivery_tag`.
+  Kombu's restore-loop pops the lowest-deadline entries that
+  have aged past the timeout and re-enqueues them at the head
+  of the original list (so a dead worker's reservations don't
+  hang the queue forever).
+
+Because `unacked` and `unacked_index` are paired, a clear
+operation **must** issue both `HDEL unacked <delivery_tag>`
+**and** `ZREM unacked_index <delivery_tag>`. Skipping the ZREM
+leaves a phantom entry in `unacked_index` whose periodic
+restore-loop tick attempts a `HGET unacked <delivery_tag>`,
+finds nothing, and silently no-ops — but it still wastes a
+ZPOPMIN every visibility-timeout tick. The
+`_streaming_unacked_clear` pipeline always batches the two
+commands together (see `services.py`).
+
+### How it differs from `CeleryBrokerQueueAdmin`
+
+| Dimension | `celery_broker` | `unacked` |
+|---|---|---|
+| Storage | one **LIST** per logical queue (`celery`, `notify`, …) | one global **HASH** carrying all reserved messages, regardless of routing_key |
+| Discovery axis | iterate the known queue names from settings | `HSCAN unacked` once; the per-message `routing_key` field tells you which queue each reservation came from |
+| Clear primitive | LSET-tombstone + LREM (race-safe under concurrent BRPOPLPUSH) | `HDEL` + `ZREM` paired in a pipeline (HASH fields don't shift indices, so no tombstone is needed) |
+| Per-row deadline | n/a (queued messages have no per-row deadline) | `ZSCORE unacked_index <delivery_tag>` per visible row; lazily resolved so summary mode skips the ZSCORE round-trip |
+| Frequency chart axes | `(task, repoid, commitid)` | `(routing_key, task, repoid, commitid)` — adds `routing_key` so the operator can see which logical queue's reservations are stuck |
+| `keep_one` semantic | keep the message at the lowest list index (oldest by FIFO order) | keep the lowest-deadline match (most-likely-to-be-restored-next, so the operator keeps the example most likely to reappear in the queue) |
+
+### URLs
+
+| Path | Purpose |
+|---|---|
+| `/admin/redis_admin/unackedqueueitem/` | **Summary** — one row carrying `HLEN(unacked)` as `depth` and a drill-in link |
+| `/admin/redis_admin/unackedqueueitem/?routing_key__exact=<queue>` | **Detail** — one row per reserved message scoped to `routing_key`, with `(routing_key, task, repoid, commitid)` frequency chart on top |
+| `/admin/redis_admin/unackedqueueitem/<routing_key>/chart-fragment/` | Lazy-loaded HTML fragment for the frequency chart (mirrors celery `chart_fragment_view`) |
+| `/admin/redis_admin/unackedqueueitem/clear-by-filter/` | Confirmation page for clearing matched messages. Same chart-hint URL params as celery (`bucket_count`, `bucket_pct`, `total_visible`, `total_depth`) so the page renders **without** Redis I/O. POST exposes dry-run / clear-keep-one / clear-all actions; each spawns a chunked job and 302s to the progress page. |
+| `/admin/redis_admin/unackedqueueitem/clear-by-filter/job/<uuid>/` | Progress page (HTML, superuser-only); polls the JSON status endpoint every ~1s and surfaces a `<progress>` bar, matched / drained / `zrem_removed` / pass counters. |
+| `/admin/redis_admin/unackedqueueitem/clear-by-filter/job/<uuid>/status/` | JSON snapshot of a chunked clear job; 404s on unknown / expired ids. |
+| `/admin/redis_admin/unackedqueueitem/clear-by-filter/job/<uuid>/cancel/` | POST-only cancel endpoint (superuser-only); flags `cancel_requested=1`, returns 202. Cancel lands at the next chunk boundary. |
+
+The `unacked` family is registered in `families.py` with
+`connection_kind="broker"` (it lives on the broker Redis, next
+to the celery queue LISTs) and is excluded from
+`RedisQueueAdmin.get_queryset` via
+`.family_exclude("celery_broker", "unacked")` so the generic
+queue browser doesn't show a dead row that overlaps this
+admin's surface — the discovery flow points operators directly
+from Grafana to this admin, just like `CeleryBrokerQueueAdmin`.
+
+### Operator self-verify
+
+```python
+from redis_admin import conn as _c
+
+r = _c.get_connection(kind="broker")
+print("unacked HLEN:", r.hlen("unacked"))
+print("unacked_index ZCARD:", r.zcard("unacked_index"))
+```
+
+Healthy state: `HLEN ≈ ZCARD`, and both numbers should track
+the active worker reservation count. A persistent gap between
+the two (`HLEN < ZCARD` or vice versa) means a previous clear
+half-completed; visit
+`/admin/redis_admin/unackedqueueitem/?routing_key__exact=<queue>`
+to inspect surviving reservations and re-run a clear job to
+re-pair the keys.
 
 ## Adding a new family
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -2850,6 +2850,15 @@ class UnackedQueueAdmin(admin.ModelAdmin):
         routing_key = request.GET.get("routing_key__exact")
         if routing_key:
             queryset = queryset.filter(routing_key__exact=routing_key)
+        elif request.GET.get("view_all") == "1":
+            # Summary drill-in passes `view_all=1` so the queryset
+            # joins the admin in detail mode (`is_summary_mode()`
+            # returns False) without scoping to a single
+            # routing_key. Without this the queryset stayed in
+            # summary mode and `_materialise_summary` produced a
+            # single dashes-row under the detail columns (Bugbot
+            # review on PR #911).
+            queryset.view_all = True
         # Plumb the request through so the changelist and the
         # frequency-chart context builder share a single HSCAN +
         # parse pass per render. Mirrors the celery_broker pattern.

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -2789,7 +2789,25 @@ class UnackedQueueAdmin(admin.ModelAdmin):
 
     @staticmethod
     def _is_summary_request(request: HttpRequest) -> bool:
-        return not request.GET.get("routing_key__exact")
+        # Detail mode flips on either:
+        #   - `routing_key__exact=<queue>` — slice to one queue's
+        #     reservations (default drill-in surface, mirrors
+        #     `CeleryBrokerQueueAdmin`'s `queue_name__exact` pivot).
+        #   - `view_all=1` — show every reserved message regardless
+        #     of routing_key. Needed because the unacked HASH is
+        #     one global bucket carrying every queue's
+        #     reservations: the summary row has no single
+        #     routing_key to point at, so the summary's drill-in
+        #     link uses `?view_all=1` to land on detail mode and
+        #     then lets the operator narrow via the sidebar
+        #     `routing_key` filter. Without this, the drill-in
+        #     link looped back to summary mode (Bugbot review on
+        #     PR #911).
+        if request.GET.get("routing_key__exact"):
+            return False
+        if request.GET.get("view_all") == "1":
+            return False
+        return True
 
     def get_ordering(self, request: HttpRequest):
         if self._is_summary_request(request):
@@ -3488,11 +3506,15 @@ class UnackedQueueAdmin(admin.ModelAdmin):
         # Wildcard routing_key: render every unacked message in
         # the HASH. The sidebar `routing_key` filter narrows
         # from there. The summary row has no routing_key value
-        # itself (depth-only marker), so we don't have a single
-        # queue to point at — operators use the sidebar to
-        # slice.
+        # itself (depth-only marker), so the link adds
+        # `?view_all=1` rather than `?routing_key__exact=<queue>`.
+        # `_is_summary_request` recognises `view_all=1` as the
+        # explicit "show every reservation" flag and flips into
+        # detail mode without filtering — without this the link
+        # looped back to summary mode (Bugbot review on PR #911).
+        url = f"{base}?view_all=1"
         return format_html(
             '<a href="{}">view {} unacked message(s) \u2192</a>',
-            base,
+            url,
             depth,
         )

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -44,21 +44,33 @@ from .families import FAMILIES, iter_families, iter_keys
 from .families import (
     _resolve_celery_queue_names as _celery_queue_names,  # noqa: PLC2701 - reused for filter lookups
 )
-from .models import CeleryBrokerQueue, RedisLock, RedisQueue, RedisQueueItem
+from .models import (
+    CeleryBrokerQueue,
+    RedisLock,
+    RedisQueue,
+    RedisQueueItem,
+    UnackedQueueItem,
+)
 from .queryset import (
     CeleryBrokerQueueQuerySet,
     RedisItemQuerySet,
+    UnackedQueueQuerySet,
     _build_redis_queue,
     _stream_frequency_aggregate,
     resolve_payload_preview,
 )
 from .services import (
     _CELERY_CLEAR_JOB_TERMINAL_STATES,
+    _UNACKED_CLEAR_JOB_TERMINAL_STATES,
     celery_broker_clear,
     get_celery_broker_clear_job,
+    get_unacked_clear_job,
     redis_delete,
     request_cancel_celery_broker_clear_job,
+    request_cancel_unacked_clear_job,
     start_celery_broker_clear_job,
+    start_unacked_clear_job,
+    unacked_clear,
 )
 
 log = logging.getLogger(__name__)
@@ -377,17 +389,20 @@ class FamilyFilter(admin.SimpleListFilter):
 
 
 class QueueFamilyFilter(FamilyFilter):
-    """`FamilyFilter` for `RedisQueueAdmin` — omits `celery_broker`.
+    """`FamilyFilter` for `RedisQueueAdmin` — omits `celery_broker`
+    and `unacked`.
 
-    The queue changelist hides `celery_broker` rows entirely
-    (`get_queryset` calls `.family_exclude("celery_broker")`) so
-    leaving the value in the dropdown surfaces a clickable option
-    that filters the page to zero rows. Dropping it from the
+    The queue changelist hides `celery_broker` and `unacked` rows
+    entirely (`get_queryset` calls `.family_exclude(...)`) so
+    leaving those values in the dropdown surfaces clickable options
+    that filter the page to zero rows. Dropping them from the
     choice list keeps the sidebar in sync with what the admin can
-    actually display.
+    actually display. `unacked` has its own dedicated admin
+    (`UnackedQueueAdmin`) for the same reason `celery_broker` does:
+    per-message drill-down + frequency chart + clear-by-filter.
     """
 
-    excluded_names = frozenset({"celery_broker"})
+    excluded_names = frozenset({"celery_broker", "unacked"})
 
 
 class LockFamilyFilter(FamilyFilter):
@@ -597,15 +612,15 @@ class RedisQueueAdmin(admin.ModelAdmin):
         return bool(request.user and request.user.is_superuser)
 
     def get_queryset(self, request: HttpRequest):
-        # Hide `celery_broker` queues: they have their own admin
-        # (`CeleryBrokerQueueAdmin`) which understands the
-        # one-row-per-message shape and surfaces a `(repoid,
-        # commitid)` frequency chart on the drill-down page. Showing
-        # them here would offer a redundant, less-informative view
-        # (one row + DEL of the entire queue) and defeat the
-        # discovery flow that points operators at the per-message
-        # admin from Grafana.
-        return super().get_queryset(request).family_exclude("celery_broker")
+        # Hide `celery_broker` and `unacked` queues: each has its own
+        # admin (`CeleryBrokerQueueAdmin`, `UnackedQueueAdmin`) that
+        # understands the one-row-per-message shape and surfaces a
+        # `(repoid, commitid)` frequency chart on the drill-down
+        # page. Showing them here would offer a redundant, less-
+        # informative view (one row + DEL of the entire queue/HASH)
+        # and defeat the discovery flow that points operators at
+        # the per-message admin from Grafana.
+        return super().get_queryset(request).family_exclude("celery_broker", "unacked")
 
     def get_fieldsets(self, request, obj=None):
         # Avoid the default ModelForm-based fieldset detection (which would
@@ -2460,5 +2475,1024 @@ class CeleryBrokerQueueAdmin(admin.ModelAdmin):
             '<a href="{}?{}">view {} message(s) \u2192</a>',
             base,
             query,
+            depth,
+        )
+
+
+# ---- Kombu unacked drill-down admin ---------------------------------------
+#
+# Per-message admin surface for Kombu's unacked HASH (`unacked` +
+# `unacked_index`). Mirrors `CeleryBrokerQueueAdmin` end-to-end:
+# two-mode polymorphic changelist (summary vs per-message),
+# lazy-loaded frequency chart on the detail page, clear-by-filter
+# with chunked background-job worker, dry-run preview / clear all
+# / clear all but lowest-deadline. The differences from the
+# celery_broker admin are:
+#
+# * **Mode switch parameter.** `routing_key__exact=<queue>` flips
+#   detail mode (vs `queue_name__exact` for celery_broker). The
+#   unacked HASH is one global key, so "queue" doesn't apply at
+#   the key level — `routing_key` (the original queue name on
+#   the value side) is the equivalent slice.
+# * **Summary row.** Exactly one row carrying `HLEN(unacked)` as
+#   `depth`, vs one row per known celery queue.
+# * **Frequency chart axis.** Aggregates by
+#   `(routing_key, task_name, repoid, commitid)` rather than the
+#   3-tuple — the unacked HASH spans every queue, so the
+#   routing_key column tells the operator which queue this stuck
+#   message came from.
+# * **Clear contract.** Paired `HDEL unacked <field>` +
+#   `ZREM unacked_index <field>` per match (no LSET-tombstone /
+#   LREM dance — HASH fields don't shift on delete).
+# * **`keep_one`.** Keeps the lowest-`ZSCORE` (soonest visibility-
+#   deadline) match, so the kept example is the one Kombu's
+#   restore-loop is most likely to re-enqueue first — which is
+#   what the operator's debug tooling will catch.
+
+
+class UnackedRoutingKeyFilter(admin.SimpleListFilter):
+    """Sidebar dropdown of `routing_key` values present in the unacked HASH.
+
+    Mirrors `CeleryQueueFilter` for the unacked admin: the
+    well-known celery queue names from `BaseCeleryConfig` are
+    surfaced as picker options so an on-call engineer who sees a
+    spike in a specific queue can click straight through to its
+    in-flight messages. Selecting a value flips the changelist
+    from summary to detail mode.
+
+    We deliberately don't enumerate the *actual* routing_keys
+    present in the live HASH (which would require an HSCAN +
+    decode pass per page render); instead we enumerate the same
+    canonical list `families.celery_broker.fixed_keys` uses, so
+    the picker is always in sync with the broker's expected
+    queue set even when the unacked HASH happens to be empty.
+    """
+
+    title = "routing key"
+    parameter_name = "routing_key__exact"
+
+    def lookups(self, request, model_admin):
+        return tuple((name, name) for name in _celery_queue_names())
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if not value:
+            return queryset
+        return queryset.filter(routing_key__exact=value)
+
+
+class UnackedTaskFilter(admin.SimpleListFilter):
+    """Dropdown of `task_name` values currently observed in the
+    unacked HASH for the selected `routing_key`.
+
+    Same shape as `CeleryBrokerTaskFilter` but reads from the
+    unacked queryset; only meaningful in detail mode (when
+    `routing_key__exact` is set), so `lookups` returns `()` in
+    summary mode and the filter renders as "All" only.
+    """
+
+    title = "task"
+    parameter_name = "unacked_task"
+
+    def lookups(self, request, model_admin):
+        routing_key = request.GET.get("routing_key__exact")
+        if not routing_key:
+            return ()
+        try:
+            qs = UnackedQueueQuerySet(
+                UnackedQueueItem, routing_key=routing_key
+            )._fetch_all()
+        except Exception:  # pragma: no cover - defensive
+            return ()
+        seen: list[tuple[str, str]] = []
+        seen_set: set[str] = set()
+        for row in qs:
+            name = row.task_name
+            if name and name not in seen_set:
+                seen_set.add(name)
+                seen.append((name, name))
+        seen.sort()
+        return tuple(seen)
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(task_name__exact=value)
+        return queryset
+
+
+class UnackedRepoidFilter(admin.SimpleListFilter):
+    """Free-text repoid filter for the unacked admin. Same shape
+    as `CeleryBrokerRepoidFilter`.
+    """
+
+    title = "repoid"
+    parameter_name = "repoid"
+
+    def lookups(self, request, model_admin):
+        return ()
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(repoid__exact=value)
+        return queryset
+
+    def has_output(self) -> bool:  # pragma: no cover - admin convention
+        return False
+
+
+class UnackedCommitFilter(admin.SimpleListFilter):
+    """Same shape as `CeleryBrokerCommitFilter` for unacked."""
+
+    title = "commit"
+    parameter_name = "commitid"
+
+    def lookups(self, request, model_admin):
+        return ()
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(commitid__startswith=value)
+        return queryset
+
+    def has_output(self) -> bool:  # pragma: no cover - admin convention
+        return False
+
+
+def _parse_unacked_search_term(term: str) -> dict[str, str]:
+    """Pull `key:value` tokens out of the unacked search bar.
+
+    Mirrors `_parse_celery_search_term` plus a `routing_key:` /
+    `rk:` shorthand so an operator can paste a queue name without
+    leaving the search field. Other recognised keys: `repoid`,
+    `commit` / `commitid`, `task` / `task_name`, `task_id`,
+    `ownerid`, `pullid`, `delivery_tag` / `tag`. Bare tokens
+    become `task_name__icontains`.
+    """
+
+    bare: list[str] = []
+    out: dict[str, str] = {}
+    for tok in term.split():
+        if ":" in tok:
+            key, _, value = tok.partition(":")
+            key = key.strip().lower()
+            value = value.strip()
+            if not value:
+                continue
+            if key == "repoid":
+                out["repoid__exact"] = value
+            elif key in ("commit", "commitid"):
+                out["commitid__startswith"] = value
+            elif key in ("task", "task_name"):
+                out["task_name__exact"] = value
+            elif key == "task_id":
+                out["task_id__exact"] = value
+            elif key == "ownerid":
+                out["ownerid__exact"] = value
+            elif key == "pullid":
+                out["pullid__exact"] = value
+            elif key in ("rk", "routing_key", "queue", "queue_name"):
+                out["routing_key__exact"] = value
+            elif key in ("tag", "delivery_tag"):
+                out["delivery_tag__exact"] = value
+            else:
+                bare.append(tok)
+        else:
+            bare.append(tok)
+    if bare:
+        out["task_name__icontains"] = " ".join(bare)
+    return out
+
+
+@admin.register(UnackedQueueItem)
+class UnackedQueueAdmin(admin.ModelAdmin):
+    """Two-mode admin for Kombu's unacked HASH.
+
+    Summary mode (no `routing_key__exact`) renders one row carrying
+    `HLEN(unacked)`. Detail mode (`?routing_key__exact=<queue>`)
+    renders one row per HASH field whose decoded
+    `[envelope, exchange, routing_key]` triple has
+    `routing_key == <queue>`. The same model
+    (`UnackedQueueItem`) backs both modes;
+    `get_list_display` / `get_list_filter` / `get_actions` flip
+    based on URL.
+
+    Mirrors `CeleryBrokerQueueAdmin` so reviewers familiar with
+    that surface can navigate this one by analogy. The two
+    differences worth flagging:
+
+    * The mode-switch parameter is `routing_key__exact` (not
+      `queue_name__exact`) — the unacked HASH is global across
+      queues, and the routing_key dimension lives in the values.
+    * The summary list contains a single row, not one per
+      queue. There's only one unacked HASH per broker, so a
+      multi-row summary would be misleading. Operators looking
+      for per-queue counts should drill in on each queue
+      individually.
+    """
+
+    summary_list_display = ("routing_key_summary", "depth", "messages_link")
+    message_list_display = (
+        "delivery_tag_short",
+        "routing_key",
+        "task_name",
+        "repoid_link",
+        "commitid_link",
+        "ownerid",
+        "pullid",
+        "task_id_short",
+        "visibility_deadline",
+        "payload_preview_truncated",
+    )
+    list_display = message_list_display
+    list_filter = (
+        UnackedRoutingKeyFilter,
+        UnackedTaskFilter,
+        UnackedRepoidFilter,
+        UnackedCommitFilter,
+    )
+    list_per_page = redis_admin_settings.ITEM_PAGE_SIZE
+    show_full_result_count = False
+    # Detail mode default ordering: ZSET deadline ascending so the
+    # message most likely to be re-enqueued by Kombu's restore-loop
+    # surfaces at the top. Summary mode just has the one row, so
+    # ordering is moot — kept here for consistency.
+    ordering = ("visibility_deadline",)
+    summary_ordering: tuple[str, ...] = ("-depth",)
+    search_fields = ("task_name",)
+    search_help_text = (
+        "search by 'rk:notify_celery', 'repoid:1234', 'commit:abc', "
+        "'task:BundleAnalysisProcessor', 'tag:<delivery_tag>', "
+        "'ownerid:N', 'pullid:N'. Bare tokens are matched against "
+        "the task name."
+    )
+    readonly_fields = (
+        "pk_token",
+        "delivery_tag",
+        "routing_key",
+        "exchange",
+        "visibility_deadline",
+        "task_name",
+        "task_id",
+        "repoid",
+        "commitid",
+        "ownerid",
+        "pullid",
+        "payload_preview",
+    )
+    actions = ("clear_dry_run", "clear_selected")
+
+    # ---- Permissions / read-only safety -----------------------------------
+
+    def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
+        return bool(request.user and request.user.is_staff)
+
+    def has_view_permission(self, request: HttpRequest, obj=None) -> bool:
+        return bool(request.user and request.user.is_staff)
+
+    def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
+        # Staff can dry-run; only superusers can commit a destructive
+        # clear (matches `CeleryBrokerQueueAdmin` and
+        # `RedisQueueAdmin`).
+        return bool(request.user and request.user.is_superuser)
+
+    def lookup_allowed(self, lookup, value) -> bool:
+        if lookup in (
+            "routing_key__exact",
+            "routing_key",
+            "exchange",
+            "exchange__exact",
+            "repoid",
+            "repoid__exact",
+            "commitid",
+            "commitid__startswith",
+            "commitid__exact",
+            "task_name",
+            "task_name__exact",
+            "task_name__icontains",
+            "task_id",
+            "task_id__exact",
+            "ownerid",
+            "ownerid__exact",
+            "pullid",
+            "pullid__exact",
+            "delivery_tag",
+            "delivery_tag__exact",
+        ):
+            return True
+        return super().lookup_allowed(lookup, value)
+
+    @staticmethod
+    def _is_summary_request(request: HttpRequest) -> bool:
+        return not request.GET.get("routing_key__exact")
+
+    def get_ordering(self, request: HttpRequest):
+        if self._is_summary_request(request):
+            return self.summary_ordering
+        return self.ordering
+
+    def get_list_display(self, request: HttpRequest):
+        if self._is_summary_request(request):
+            return self.summary_list_display
+        return self.message_list_display
+
+    def get_list_display_links(self, request: HttpRequest, list_display):
+        if self._is_summary_request(request):
+            return (None,) if not list_display else None
+        return super().get_list_display_links(request, list_display)
+
+    def get_list_filter(self, request: HttpRequest):
+        if self._is_summary_request(request):
+            # Summary view shows one row; the message-shaped
+            # sidebar filters don't apply. Surface only the
+            # routing_key filter so operators can drill in
+            # without leaving the page.
+            return (UnackedRoutingKeyFilter,)
+        return self.list_filter
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        actions.pop("delete_selected", None)
+        if self._is_summary_request(request):
+            actions.pop("clear_dry_run", None)
+            actions.pop("clear_selected", None)
+        return actions
+
+    def get_queryset(self, request: HttpRequest):
+        # Bypass ChangeList's `.filter(**lookup_params)` plumbing so
+        # the `routing_key__exact` flip between summary and detail
+        # mode survives even when no list_filter is declared on the
+        # URL.
+        queryset = self.model._default_manager.all()
+        routing_key = request.GET.get("routing_key__exact")
+        if routing_key:
+            queryset = queryset.filter(routing_key__exact=routing_key)
+        # Plumb the request through so the changelist and the
+        # frequency-chart context builder share a single HSCAN +
+        # parse pass per render. Mirrors the celery_broker pattern.
+        queryset._request = request
+        return queryset
+
+    def changelist_view(self, request: HttpRequest, extra_context=None):
+        ctx = dict(extra_context or {})
+        if not self._is_summary_request(request):
+            ctx["routing_key"] = request.GET.get("routing_key__exact", "")
+            ctx["scan_limit_label"] = (
+                f"{redis_admin_settings.CELERY_BROKER_SCAN_LIMIT:,}"
+            )
+        return super().changelist_view(request, ctx)
+
+    def _build_frequency_chart_context(
+        self, request: HttpRequest, routing_key: str
+    ) -> dict | None:
+        """Compute the unacked frequency-chart payload for a routing_key.
+
+        Returns `None` when the chart should not render (no
+        buckets, broker outage). Mirrors
+        `CeleryBrokerQueueAdmin._build_frequency_chart_context`
+        but aggregates over the full HASH (then filters to
+        `routing_key` matches) rather than a per-queue LRANGE.
+
+        We construct the queryset under the routing_key scope so
+        the queryset's cached path picks up the materialised rows
+        when the changelist already populated the per-request
+        cache; the streaming path is the fallback for direct hits
+        on the chart-fragment URL.
+        """
+
+        try:
+            qs = UnackedQueueQuerySet(
+                UnackedQueueItem,
+                routing_key=routing_key,
+                request=request,
+            )
+            buckets = qs.frequency_by_routing_task_repo_commit()
+        except Exception:  # pragma: no cover - broker outage path
+            return None
+        if not buckets:
+            return None
+        try:
+            client = _conn.get_connection(kind="broker")
+            hlen = client.hlen("unacked")
+            total_depth = int(hlen) if isinstance(hlen, int) and hlen >= 0 else 0
+        except Exception:  # pragma: no cover - defensive
+            total_depth = sum(b.count for b in buckets)
+        # `total_visible` mirrors the celery_broker chart's
+        # `len(_fetch_all())` — for unacked we use the sum of
+        # bucket counts (the pct denominator was the sample
+        # window when the streaming path ran; the cached path
+        # already normalised on the materialised rows).
+        total_visible = sum(b.count for b in buckets) or total_depth
+        try:
+            clear_url = reverse("admin:redis_admin_unackedqueueitem_clear_by_filter")
+        except NoReverseMatch:  # pragma: no cover - URL is wired below
+            clear_url = ""
+        repo_displays = _resolve_repo_displays(b.repoid for b in buckets)
+        rows: list[dict[str, Any]] = []
+        for bucket in buckets:
+            display = repo_displays.get(bucket.repoid) if bucket.repoid else None
+            change_url: str | None = None
+            if bucket.repoid is not None:
+                try:
+                    change_url = reverse(
+                        "admin:core_repository_change", args=[bucket.repoid]
+                    )
+                except NoReverseMatch:  # pragma: no cover - admin always wires this
+                    change_url = None
+            rows.append(
+                {
+                    "routing_key": bucket.routing_key,
+                    "task_name": bucket.task_name,
+                    "repoid": bucket.repoid,
+                    "repo_display": display,
+                    "repo_change_url": change_url,
+                    "commitid": bucket.commitid,
+                    "count": bucket.count,
+                    "pct": bucket.pct,
+                }
+            )
+        return {
+            "routing_key": routing_key,
+            "buckets": rows,
+            "total_visible": total_visible,
+            "total_depth": total_depth,
+            "can_clear": request.user.is_superuser,
+            "clear_by_filter_url": clear_url,
+        }
+
+    def chart_fragment_view(
+        self, request: HttpRequest, routing_key: str
+    ) -> HttpResponse:
+        """Render the unacked frequency-chart fragment.
+
+        Same loading dance as
+        `CeleryBrokerQueueAdmin.chart_fragment_view`: fetched
+        async by the changelist's `<script>` on
+        `DOMContentLoaded`, returns 204 when there are no
+        buckets so the JS can drop the loader without rendering
+        an empty chart.
+        """
+
+        if not (request.user and request.user.is_staff):
+            raise PermissionDenied(
+                "redis_admin chart-fragment is restricted to staff users"
+            )
+        chart_ctx = self._build_frequency_chart_context(request, routing_key)
+        if chart_ctx is None:
+            return HttpResponse(status=204)
+        ctx = {
+            **self.admin_site.each_context(request),
+            "chart": chart_ctx,
+        }
+        return render(
+            request,
+            "admin/redis_admin/unackedqueueitem/_frequency_chart.html",
+            ctx,
+            content_type="text/html",
+        )
+
+    def get_urls(self):
+        urls = super().get_urls()
+        opts = self.model._meta
+        clear_url = path(
+            "clear-by-filter/",
+            self.admin_site.admin_view(self.clear_by_filter_view),
+            name=f"{opts.app_label}_{opts.model_name}_clear_by_filter",
+        )
+        clear_progress_url = path(
+            "clear-by-filter/job/<uuid:job_id>/",
+            self.admin_site.admin_view(self.clear_by_filter_progress_view),
+            name=f"{opts.app_label}_{opts.model_name}_clear_by_filter_progress",
+        )
+        clear_status_url = path(
+            "clear-by-filter/job/<uuid:job_id>/status/",
+            self.admin_site.admin_view(self.clear_by_filter_status_view),
+            name=f"{opts.app_label}_{opts.model_name}_clear_by_filter_status",
+        )
+        clear_cancel_url = path(
+            "clear-by-filter/job/<uuid:job_id>/cancel/",
+            self.admin_site.admin_view(self.clear_by_filter_cancel_view),
+            name=f"{opts.app_label}_{opts.model_name}_clear_by_filter_cancel",
+        )
+        chart_fragment_url = path(
+            "<str:routing_key>/chart-fragment/",
+            self.admin_site.admin_view(self.chart_fragment_view),
+            name="unackedqueueitem-chart-fragment",
+        )
+        return [
+            clear_url,
+            clear_progress_url,
+            clear_status_url,
+            clear_cancel_url,
+            chart_fragment_url,
+            *urls,
+        ]
+
+    def clear_by_filter_view(self, request: HttpRequest) -> HttpResponse:
+        """Targeted unacked clear by `(routing_key?, task_name?, repoid?, commitid?)`.
+
+        Mirrors `CeleryBrokerQueueAdmin.clear_by_filter_view` but
+        for the HASH+ZSET unacked layout. Reachable from the
+        frequency chart's per-row "Clear" button. POST actions:
+
+        * `dry_run` — counts matches without mutating; spawns the
+          chunked worker with `dry_run=True` and 302s to the
+          progress page.
+        * `clear_keep_one` — clear every match EXCEPT the
+          lowest-`ZSCORE` (soonest visibility-deadline) one.
+        * `clear_all` — clear every match.
+
+        Both destructive actions gate on a typed-confirmation
+        check (operator must re-type the routing_key, or `unacked`
+        when the filter is wildcard-routing-key).
+
+        ## Zero-Redis-I/O GET render
+
+        Same approximate-count callout pattern as celery_broker:
+        the chart hands us `bucket_count` / `total_visible` /
+        `total_depth` / `bucket_pct` so we can render a
+        "will clear ~X messages (~Y%)" string in pure Python
+        without an HSCAN sweep on the GET. The chunked worker
+        computes the exact count as it walks.
+        """
+
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-filter is restricted to superusers"
+            )
+
+        params = request.POST if request.method == "POST" else request.GET
+        routing_key = (params.get("routing_key") or "").strip()
+        task_name = (params.get("task_name") or "").strip()
+        repoid_raw = (params.get("repoid") or "").strip()
+        commitid = (params.get("commitid") or "").strip()
+        action = (request.POST.get("action") or "").strip()
+
+        opts = self.model._meta
+        changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+        if routing_key:
+            changelist_url = (
+                f"{changelist_url}?{urlencode({'routing_key__exact': routing_key})}"
+            )
+
+        repoid: int | None = None
+        if repoid_raw:
+            try:
+                repoid = int(repoid_raw)
+            except ValueError:
+                messages.error(
+                    request,
+                    f"repoid must be an integer; got {repoid_raw!r}",
+                )
+                return HttpResponseRedirect(changelist_url)
+
+        # At least one narrowing filter is required — otherwise
+        # this view collapses into "clear the whole unacked
+        # HASH", which is too sharp an edge for an admin button
+        # (the operator should be running `redis-cli DEL unacked
+        # unacked_index` directly with full deliberation, not
+        # clicking through here).
+        if not routing_key and repoid is None and not commitid and not task_name:
+            messages.error(
+                request,
+                "Refusing to clear: at least one of routing_key, "
+                "task_name, repoid, or commitid must be set",
+            )
+            return HttpResponseRedirect(changelist_url)
+
+        # Typed-confirm value: prefer routing_key (specific
+        # scope), fall back to the literal `unacked` when the
+        # operator opted for a wildcard routing_key clear (which
+        # is broader and arguably warrants the more solemn
+        # phrasing).
+        expected_confirm = routing_key or "unacked"
+        typed_confirm = (request.POST.get("typed_confirm") or "").strip()
+        confirm_error: str | None = None
+
+        destructive_actions = {"clear_keep_one", "clear_all"}
+        valid_actions = destructive_actions | {"dry_run"}
+
+        if request.method == "POST" and action in valid_actions:
+            if action in destructive_actions and typed_confirm != expected_confirm:
+                confirm_error = f"Typed confirmation must equal {expected_confirm!r}"
+            else:
+                dry_run = action == "dry_run"
+                keep_one = action == "clear_keep_one"
+                job_id = start_unacked_clear_job(
+                    user=request.user,
+                    routing_key=routing_key or None,
+                    task_name=task_name or None,
+                    repoid=repoid,
+                    commitid=commitid or None,
+                    keep_one=keep_one,
+                    dry_run=dry_run,
+                )
+                progress_url = reverse(
+                    f"admin:{opts.app_label}_{opts.model_name}"
+                    "_clear_by_filter_progress",
+                    kwargs={"job_id": job_id},
+                )
+                return HttpResponseRedirect(progress_url)
+
+        bucket_count = _coerce_int(params.get("bucket_count"))
+        total_visible = _coerce_int(params.get("total_visible"))
+        total_depth = _coerce_int(params.get("total_depth"))
+        bucket_pct = _coerce_float(params.get("bucket_pct"))
+        approx: dict[str, Any] | None = None
+        if (
+            bucket_count is not None
+            and total_visible is not None
+            and total_visible > 0
+            and total_depth
+        ):
+            approx = {
+                "count": round(bucket_count / total_visible * total_depth),
+                "pct": bucket_pct,
+                "depth": total_depth,
+            }
+
+        repo_change_url: str | None = None
+        if repoid is not None:
+            try:
+                repo_change_url = reverse("admin:core_repository_change", args=[repoid])
+            except NoReverseMatch:  # pragma: no cover - admin always registered
+                repo_change_url = None
+
+        bucket_count_hint = "" if bucket_count is None else str(bucket_count)
+        bucket_pct_hint = "" if bucket_pct is None else str(bucket_pct)
+        total_visible_hint = "" if total_visible is None else str(total_visible)
+        total_depth_hint = "" if total_depth is None else str(total_depth)
+
+        ctx = {
+            **self.admin_site.each_context(request),
+            "title": (
+                f"Clear unacked ({routing_key}) by filter"
+                if routing_key
+                else "Clear unacked by filter"
+            ),
+            "opts": opts,
+            "routing_key": routing_key,
+            "task_name": task_name,
+            "repoid": repoid,
+            "repo_change_url": repo_change_url,
+            "commitid": commitid,
+            "approx": approx,
+            "bucket_count_hint": bucket_count_hint,
+            "bucket_pct_hint": bucket_pct_hint,
+            "total_visible_hint": total_visible_hint,
+            "total_depth_hint": total_depth_hint,
+            "expected_confirm": expected_confirm,
+            "typed_confirm": typed_confirm,
+            "confirm_error": confirm_error,
+            "changelist_url": changelist_url,
+        }
+        return render(
+            request,
+            "admin/redis_admin/unackedqueueitem/clear_by_filter.html",
+            ctx,
+        )
+
+    # ---- Chunked-clear background-job views ------------------------------
+
+    def _job_progress_context(
+        self, *, job_id: str, job: dict[str, str]
+    ) -> dict[str, Any]:
+        def _int(field: str, default: int = 0) -> int:
+            try:
+                return int(job.get(field) or default)
+            except (TypeError, ValueError):
+                return default
+
+        opts = self.model._meta
+        status_url = reverse(
+            f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_status",
+            kwargs={"job_id": job_id},
+        )
+        cancel_url = reverse(
+            f"admin:{opts.app_label}_{opts.model_name}_clear_by_filter_cancel",
+            kwargs={"job_id": job_id},
+        )
+        changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+        routing_key = job.get("filter_routing_key", "")
+        if routing_key:
+            changelist_url = (
+                f"{changelist_url}?{urlencode({'routing_key__exact': routing_key})}"
+            )
+
+        status = job.get("status", "pending")
+        return {
+            "job_id": job_id,
+            "job": job,
+            "status": status,
+            "is_terminal": status in _UNACKED_CLEAR_JOB_TERMINAL_STATES,
+            "routing_key": routing_key,
+            "filter_routing_key": routing_key,
+            "filter_task": job.get("filter_task", ""),
+            "filter_repoid": job.get("filter_repoid", ""),
+            "filter_commitid": job.get("filter_commitid", ""),
+            "dry_run": job.get("dry_run") == "1",
+            "keep_one": job.get("keep_one") == "1",
+            "started_at": job.get("started_at", ""),
+            "updated_at": job.get("updated_at", ""),
+            "completed_at": job.get("completed_at", ""),
+            "total_estimated": _int("total_estimated"),
+            "processed": _int("processed"),
+            "matched": _int("matched"),
+            "zrem_removed": _int("zrem_removed"),
+            "passes_run": _int("passes_run"),
+            "error": job.get("error", ""),
+            "cancel_requested": job.get("cancel_requested") == "1",
+            "status_url": status_url,
+            "cancel_url": cancel_url,
+            "changelist_url": changelist_url,
+        }
+
+    def clear_by_filter_progress_view(
+        self, request: HttpRequest, job_id
+    ) -> HttpResponse:
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-filter is restricted to superusers"
+            )
+
+        opts = self.model._meta
+        changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+        job_id_str = str(job_id)
+        job = get_unacked_clear_job(job_id_str)
+        if job is None:
+            messages.error(
+                request,
+                f"Clear job {job_id_str} not found (may have expired or "
+                f"been submitted on a different deployment).",
+            )
+            return HttpResponseRedirect(changelist_url)
+
+        progress_ctx = self._job_progress_context(job_id=job_id_str, job=job)
+        ctx = {
+            **self.admin_site.each_context(request),
+            "title": (
+                f"Clearing unacked "
+                f"({progress_ctx['routing_key'] or '*'}) "
+                f"(job {job_id_str[:8]})"
+            ),
+            "opts": opts,
+            **progress_ctx,
+        }
+        return render(
+            request,
+            "admin/redis_admin/unackedqueueitem/clear_by_filter_progress.html",
+            ctx,
+        )
+
+    def clear_by_filter_status_view(self, request: HttpRequest, job_id) -> HttpResponse:
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-filter is restricted to superusers"
+            )
+
+        job_id_str = str(job_id)
+        job = get_unacked_clear_job(job_id_str)
+        if job is None:
+            return JsonResponse(
+                {"error": "not_found", "job_id": job_id_str}, status=404
+            )
+
+        progress_ctx = self._job_progress_context(job_id=job_id_str, job=job)
+        return JsonResponse(
+            {
+                "job_id": job_id_str,
+                "status": progress_ctx["status"],
+                "is_terminal": progress_ctx["is_terminal"],
+                "routing_key": progress_ctx["routing_key"],
+                "filter_routing_key": progress_ctx["filter_routing_key"],
+                "filter_task": progress_ctx["filter_task"],
+                "filter_repoid": progress_ctx["filter_repoid"],
+                "filter_commitid": progress_ctx["filter_commitid"],
+                "dry_run": progress_ctx["dry_run"],
+                "keep_one": progress_ctx["keep_one"],
+                "started_at": progress_ctx["started_at"],
+                "updated_at": progress_ctx["updated_at"],
+                "completed_at": progress_ctx["completed_at"],
+                "total_estimated": progress_ctx["total_estimated"],
+                "processed": progress_ctx["processed"],
+                "matched": progress_ctx["matched"],
+                "zrem_removed": progress_ctx["zrem_removed"],
+                "passes_run": progress_ctx["passes_run"],
+                "error": progress_ctx["error"],
+                "cancel_requested": progress_ctx["cancel_requested"],
+            }
+        )
+
+    def clear_by_filter_cancel_view(self, request: HttpRequest, job_id) -> HttpResponse:
+        if not request.user.is_superuser:
+            raise PermissionDenied(
+                "redis_admin clear-by-filter is restricted to superusers"
+            )
+        if request.method != "POST":
+            return HttpResponseNotAllowed(["POST"])
+
+        job_id_str = str(job_id)
+        ok = request_cancel_unacked_clear_job(job_id_str)
+        if not ok:
+            return JsonResponse(
+                {"error": "not_found", "job_id": job_id_str}, status=404
+            )
+        job = get_unacked_clear_job(job_id_str) or {}
+        return JsonResponse(
+            {
+                "job_id": job_id_str,
+                "cancel_requested": job.get("cancel_requested") == "1",
+                "status": job.get("status", ""),
+            },
+            status=202,
+        )
+
+    def get_search_results(self, request, queryset, search_term):
+        if not search_term:
+            return queryset, False
+        kwargs = _parse_unacked_search_term(search_term)
+        if not kwargs:
+            return queryset, False
+        try:
+            return queryset.filter(**kwargs), False
+        except NotImplementedError:
+            return queryset.none(), False
+
+    # ---- Change form (per-message inspector) -----------------------------
+
+    def get_fieldsets(self, request, obj=None):
+        return ((None, {"fields": list(self.readonly_fields)}),)
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        ctx = {
+            "show_save": False,
+            "show_save_and_continue": False,
+            "show_save_and_add_another": False,
+            "show_save_as_new": False,
+        }
+        if extra_context:
+            ctx.update(extra_context)
+        return super().changeform_view(request, object_id, form_url, ctx)
+
+    def save_model(self, request, obj, form, change):
+        raise RuntimeError("UnackedQueueItem rows are read-only.")
+
+    # ---- Bulk clear (dry-run + confirm) ----------------------------------
+
+    @admin.action(
+        description="Dry-run: count what 'clear selected' would clear",
+        permissions=("delete",),
+    )
+    def clear_dry_run(self, request: HttpRequest, queryset) -> None:
+        result = unacked_clear(list(queryset), user=request.user, dry_run=True)
+        self.message_user(
+            request,
+            (
+                f"Dry-run: would clear {result.count} unacked message(s); "
+                f"sample={list(result.sample[:5])}"
+            ),
+            level=messages.INFO,
+        )
+
+    @admin.action(
+        description="Clear selected (dry-run preview, then confirm)",
+        permissions=("delete",),
+    )
+    def clear_selected(self, request: HttpRequest, queryset):
+        """Two-stage clear; HDEL+ZREM path on commit."""
+
+        selected = list(queryset)
+        selected_pks = request.POST.getlist("_selected_action") or [
+            obj.pk for obj in selected
+        ]
+
+        if request.POST.get("confirm") == "yes":
+            result = unacked_clear(selected, user=request.user, dry_run=False)
+            self.message_user(
+                request,
+                f"Cleared {result.count} unacked message(s).",
+                level=messages.SUCCESS,
+            )
+            return None
+
+        dry_run_result = unacked_clear(selected, user=request.user, dry_run=True)
+        opts = self.model._meta
+        ctx = {
+            **self.admin_site.each_context(request),
+            "title": "Confirm clear of selected unacked messages",
+            "opts": opts,
+            "action_name": "clear_selected",
+            "selected": selected,
+            "selected_pks": selected_pks,
+            "dry_run_result": dry_run_result,
+            "media": self.media,
+        }
+        return render(
+            request, "admin/redis_admin/clear_selected_confirmation.html", ctx
+        )
+
+    def delete_queryset(self, request: HttpRequest, queryset) -> None:
+        result = unacked_clear(list(queryset), user=request.user, dry_run=False)
+        self.message_user(
+            request,
+            f"Cleared {result.count} unacked message(s).",
+            level=messages.SUCCESS,
+        )
+
+    def delete_model(self, request: HttpRequest, obj: UnackedQueueItem) -> None:
+        result = unacked_clear([obj], user=request.user, dry_run=False)
+        self.message_user(
+            request,
+            (
+                f"Cleared unacked message {obj.delivery_tag[:12]} "
+                f"({result.count} removed)."
+            ),
+            level=messages.SUCCESS,
+        )
+
+    # ---- Display helpers --------------------------------------------------
+
+    @admin.display(description="routing key")
+    def routing_key_summary(self, obj: UnackedQueueItem) -> str:
+        # Summary mode: there's only one row, so we render a
+        # static `unacked (HASH)` label rather than echoing the
+        # empty `routing_key` field that summary rows carry.
+        return "unacked (HASH)"
+
+    @admin.display(description="repo")
+    def repoid_link(self, obj: UnackedQueueItem) -> str:
+        if obj.repoid is None:
+            return "—"
+        try:
+            url = reverse("admin:core_repository_change", args=[obj.repoid])
+        except NoReverseMatch:
+            return str(obj.repoid)
+        return format_html('<a href="{}">{}</a>', url, obj.repoid)
+
+    @admin.display(description="commit")
+    def commitid_link(self, obj: UnackedQueueItem) -> str:
+        if not obj.commitid:
+            return "—"
+        try:
+            base = reverse("admin:core_commit_changelist")
+        except NoReverseMatch:
+            return obj.commitid[:7]
+        url = f"{base}?{urlencode({'q': obj.commitid})}"
+        return format_html(
+            '<a href="{}" title="{}">{}</a>', url, obj.commitid, obj.commitid[:7]
+        )
+
+    @admin.display(description="task id")
+    def task_id_short(self, obj: UnackedQueueItem) -> str:
+        if not obj.task_id:
+            return "—"
+        short = obj.task_id[:8]
+        return format_html('<span title="{}">{}</span>', obj.task_id, short)
+
+    @admin.display(description="delivery tag")
+    def delivery_tag_short(self, obj: UnackedQueueItem) -> str:
+        # delivery_tag is a kombu UUID; the first 12 chars are
+        # plenty to disambiguate within a single broker's
+        # in-flight set and keep the column narrow.
+        if not obj.delivery_tag:
+            return "—"
+        short = obj.delivery_tag[:12]
+        return format_html('<span title="{}">{}</span>', obj.delivery_tag, short)
+
+    @admin.display(description="payload")
+    def payload_preview_truncated(self, obj: UnackedQueueItem) -> str:
+        return resolve_payload_preview(obj)
+
+    @admin.display(description="messages")
+    def messages_link(self, obj: UnackedQueueItem) -> str:
+        """Drill-in link for the summary row.
+
+        Summary mode renders one row carrying `HLEN(unacked)`;
+        the `messages_link` column points at the same admin URL
+        without a `routing_key__exact` filter, which renders the
+        per-message detail page over the full HASH. From there
+        the operator can apply the routing_key sidebar filter
+        to slice by queue.
+        """
+
+        depth = obj.depth or 0
+        try:
+            base = reverse("admin:redis_admin_unackedqueueitem_changelist")
+        except NoReverseMatch:  # pragma: no cover - defensive
+            return f"{depth} message(s)"
+        # Wildcard routing_key: render every unacked message in
+        # the HASH. The sidebar `routing_key` filter narrows
+        # from there. The summary row has no routing_key value
+        # itself (depth-only marker), so we don't have a single
+        # queue to point at — operators use the sidebar to
+        # slice.
+        return format_html(
+            '<a href="{}">view {} unacked message(s) \u2192</a>',
+            base,
             depth,
         )

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -177,6 +177,22 @@ def _parse_celery_broker_key(_: str) -> ParsedKey:
     return ParsedKey(family="celery_broker")
 
 
+def _parse_unacked_key(_: str) -> ParsedKey:
+    """Kombu's unacked HASH (`unacked`) and its sibling ZSET
+    (`unacked_index`) carry no repo / commit / task info in the
+    *key* — that's all in the values. Per-value decoding (see
+    `_unacked_decode_value`) is what surfaces those fields. Same
+    pattern as `_parse_celery_broker_key`.
+
+    Verified against
+    `kombu.transport.redis.Channel.unacked_key` /
+    `unacked_index_key` (defaults: `"unacked"` and
+    `"unacked_index"`).
+    """
+
+    return ParsedKey(family="unacked")
+
+
 def _operator_configured_celery_queues() -> tuple[str, ...]:
     """Read the deployment's declared list of Celery queue names.
 
@@ -399,6 +415,62 @@ def _celery_decode_value(raw_decoded: str) -> str:
     return raw_decoded
 
 
+def _unacked_decode_value(raw_decoded: str) -> str:
+    """Prefix one HASH-value triple with a one-line summary if we can.
+
+    Each unacked HASH value is the JSON-encoded triple
+    `[envelope_dict, exchange_str, routing_key_str]`. We pluck the
+    envelope, run the same `parse_celery_envelope` we use for the
+    celery_broker family, and prepend a `[task=… repoid=… commit=…
+    rk=…]` summary so an operator viewing the raw HASH from the
+    generic `RedisQueueItem` admin (URL-tampering / curiosity path
+    only — the dedicated `UnackedQueueAdmin` is the supported
+    surface) still sees the structured shape at a glance.
+
+    The `rk=` segment is the Kombu `routing_key` slot from the
+    triple — important on this family specifically because
+    `unacked` spans every queue, so the operator needs to know
+    which queue this stuck message came from. Falls back to
+    returning the raw value verbatim when the envelope can't be
+    parsed.
+    """
+
+    try:
+        outer = orjson.loads(raw_decoded)
+    except (ValueError, TypeError):
+        return raw_decoded
+    if not isinstance(outer, list) or len(outer) < 1:
+        return raw_decoded
+    envelope = outer[0]
+    routing_key = outer[2] if len(outer) >= 3 and isinstance(outer[2], str) else None
+
+    envelope_str: str | None
+    if isinstance(envelope, str):
+        envelope_str = envelope
+    elif isinstance(envelope, dict):
+        try:
+            envelope_str = orjson.dumps(envelope).decode("utf-8")
+        except (TypeError, ValueError):
+            envelope_str = None
+    else:
+        envelope_str = None
+
+    parts: list[str] = []
+    if envelope_str is not None:
+        task, repoid, commitid = _peek_celery_envelope(envelope_str)
+        if task:
+            parts.append(f"task={task}")
+        if repoid is not None:
+            parts.append(f"repoid={repoid}")
+        if commitid:
+            parts.append(f"commit={commitid[:7]}")
+    if routing_key:
+        parts.append(f"rk={routing_key}")
+    if parts:
+        return f"[{' '.join(parts)}] {raw_decoded}"
+    return raw_decoded
+
+
 def _celery_pattern(filters: Mapping[str, Any]) -> str | None:
     """Celery queue *keys* don't carry repoid/commitid; if those filters
     are set, every Celery queue would be dropped post-scan, so skip the
@@ -408,6 +480,27 @@ def _celery_pattern(filters: Mapping[str, Any]) -> str | None:
     if filters.get("repoid") is not None or filters.get("commitid_prefix"):
         return None
     return "enterprise_*"
+
+
+def _unacked_pattern(filters: Mapping[str, Any]) -> str | None:
+    """Unacked HASH / ZSET keys (`unacked`, `unacked_index`) don't
+    carry repoid / commitid in the *key* — that's all in the
+    values. Skip the family entirely if either filter is set so
+    `iter_keys` doesn't run a doomed SCAN.
+
+    The `unacked_index` ZSET sibling is intentionally NOT
+    surfaced via SCAN (we don't want it appearing as its own
+    queue row); the family registers `fixed_keys=("unacked",)`
+    only, so iter_keys stops at the HASH. The ZSET is read by
+    `UnackedQueueQuerySet` directly via ZSCORE per row.
+    """
+
+    if filters.get("repoid") is not None or filters.get("commitid_prefix"):
+        return None
+    # No SCAN needed — the only fixed key is `unacked`. Returning
+    # an empty string skips the SCAN loop in `iter_keys` while
+    # still letting the `fixed_keys` enumeration run.
+    return ""
 
 
 # ---- Lock parsers (M4.3) ---------------------------------------------------
@@ -740,6 +833,28 @@ FAMILIES: tuple[Family, ...] = (
         # Celery queues live on the broker Redis (`services.celery_broker`),
         # which in production is a separate Memorystore from the cache Redis
         # the rest of the families use. See `redis_admin.conn` for details.
+        connection_kind="broker",
+    ),
+    Family(
+        name="unacked",
+        # `unacked` is a singleton HASH (one per broker), so there's
+        # no SCAN pattern to match — `fixed_keys=("unacked",)` is the
+        # whole story. `unacked_index` (ZSET) is deliberately NOT a
+        # fixed key because surfacing it as its own queue row would
+        # double-count (it's an internal index, not a queue) and
+        # invite operators to clear it independently of the HASH —
+        # which would orphan the ZSET members and break Kombu's
+        # restore-loop. The dedicated `UnackedQueueAdmin` reads the
+        # ZSET via ZSCORE per row instead.
+        scan_pattern="",
+        redis_type="hash",
+        parse_key=_parse_unacked_key,
+        pattern_for=_unacked_pattern,
+        fixed_keys=("unacked",),
+        decode_value=_unacked_decode_value,
+        # Same Redis as celery_broker — Kombu's unacked bookkeeping
+        # lives next to the queue keys themselves on the broker
+        # Memorystore in production.
         connection_kind="broker",
     ),
     # ---- Locks (M4.3) -----------------------------------------------------

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -293,6 +293,13 @@ class CeleryEnvelopeMeta:
     `kwargs` carries the raw decoded keyword-args dict (the second
     element of the kombu body list) when present, so the admin can
     render a `payload_preview` without re-parsing the envelope.
+
+    `comparison_id` is read from `ComputeComparisonTask` envelopes,
+    which carry only `comparison_id` (no `repoid` / `commitid`)
+    in their kwargs; the queryset later batch-resolves it to a
+    `(repoid, commitid)` pair via the `compare_commitcomparison`
+    table so operators can still filter those messages by repo
+    or commit on the changelist.
     """
 
     task: str | None = None
@@ -301,6 +308,7 @@ class CeleryEnvelopeMeta:
     commitid: str | None = None
     ownerid: int | None = None
     pullid: int | None = None
+    comparison_id: int | None = None
     kwargs: dict[str, Any] | None = None
 
 
@@ -356,6 +364,7 @@ def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
     commitid: str | None = None
     ownerid: int | None = None
     pullid: int | None = None
+    comparison_id: int | None = None
     kwargs: dict[str, Any] | None = None
     body_b64 = envelope.get("body")
     if isinstance(body_b64, str) and body_b64:
@@ -374,6 +383,12 @@ def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
                 commitid = cid
             ownerid = _coerce_int(kwargs.get("ownerid"))
             pullid = _coerce_int(kwargs.get("pullid"))
+            # `ComputeComparisonTask` carries only `comparison_id`
+            # in its kwargs — pull it into a dedicated field so the
+            # queryset's post-materialisation hydration path can
+            # batch-resolve it to a `(repoid, commitid)` pair via
+            # the `compare_commitcomparison` table.
+            comparison_id = _coerce_int(kwargs.get("comparison_id"))
     return CeleryEnvelopeMeta(
         task=task,
         task_id=task_id,
@@ -381,6 +396,7 @@ def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
         commitid=commitid,
         ownerid=ownerid,
         pullid=pullid,
+        comparison_id=comparison_id,
         kwargs=kwargs,
     )
 

--- a/apps/codecov-api/redis_admin/models.py
+++ b/apps/codecov-api/redis_admin/models.py
@@ -13,6 +13,7 @@ from .queryset import (
     CeleryBrokerQueueQuerySet,
     RedisItemQuerySet,
     RedisQueueQuerySet,
+    UnackedQueueQuerySet,
 )
 
 
@@ -184,6 +185,102 @@ class CeleryBrokerQueue(models.Model):
         raise NotImplementedError(
             "CeleryBrokerQueue.delete is not supported on individual "
             "instances; use redis_admin.services.celery_broker_clear "
+            "(which the admin's clear flow already invokes)."
+        )
+
+
+class UnackedQueueItemManager(models.Manager):
+    def get_queryset(self) -> UnackedQueueQuerySet:  # type: ignore[override]
+        return UnackedQueueQuerySet(self.model)
+
+
+class UnackedQueueItem(models.Model):
+    """A single Kombu unacked-message envelope.
+
+    Surfaces Kombu's Redis transport unacked bookkeeping as one row
+    per `delivery_tag`. The Grafana panel
+    `redis_key_size{key="unacked"}` corresponds to this admin's
+    `HLEN unacked` snapshot — the same hash whose drill-down this
+    admin renders.
+
+    Storage layout (verified against
+    `kombu.transport.redis.Channel.unacked_key` /
+    `unacked_index_key` in this venv):
+
+    * `unacked` — Redis HASH. Field = `delivery_tag` (UUID-ish
+      string). Value = JSON-serialised
+      `[message_dict, exchange_str, routing_key_str]` triple.
+      `message_dict["body"]` is base64-encoded JSON of the celery
+      envelope, the same shape `parse_celery_envelope` understands.
+    * `unacked_index` — Redis ZSET. Score = visibility-timeout
+      deadline (unix ts). Member = `delivery_tag`. Used by Kombu's
+      restore-loop to re-enqueue messages whose worker died.
+
+    To clear an unacked entry, both `HDEL unacked <delivery_tag>`
+    AND `ZREM unacked_index <delivery_tag>` are required. Skipping
+    the ZREM leaves a phantom in `unacked_index` that points at a
+    non-existent HASH field, which Kombu will then try to restore
+    from the (now missing) hash entry.
+
+    Mirrors `CeleryBrokerQueue`'s "two-mode" pattern: when no
+    `routing_key__exact` filter is set, the queryset returns one
+    summary row carrying `depth = HLEN(unacked)`; with the filter
+    set, it returns per-message rows scoped to that routing_key
+    (the original queue these messages were delivered from).
+
+    `pk_token` shape: `unacked#<delivery_tag>` for a message row and
+    `unacked#summary` for the singleton summary row, mirroring the
+    `CeleryBrokerQueue` convention so admin URL plumbing
+    (`change_view`, `pk__in=[...]` bulk actions) works without
+    customisation. `default_permissions` includes `delete` because
+    superusers can clear individual messages from the changelist.
+    """
+
+    pk_token = models.CharField(primary_key=True, max_length=600)
+    delivery_tag = models.CharField(max_length=128, blank=True)
+    routing_key = models.CharField(max_length=256, blank=True)
+    exchange = models.CharField(max_length=128, blank=True)
+    visibility_deadline = models.DateTimeField(null=True, blank=True)
+    task_name = models.CharField(max_length=256, blank=True)
+    task_id = models.CharField(max_length=128, blank=True)
+    repoid = models.IntegerField(null=True, blank=True)
+    commitid = models.CharField(max_length=64, blank=True)
+    ownerid = models.IntegerField(null=True, blank=True)
+    pullid = models.IntegerField(null=True, blank=True)
+    payload_preview = models.TextField(blank=True)
+    # Set ONLY on the summary row (no `routing_key__exact` filter):
+    # `HLEN unacked` at the time of materialisation. None on
+    # per-message rows.
+    depth = models.IntegerField(null=True, blank=True)
+
+    objects = UnackedQueueItemManager()
+
+    class Meta:
+        managed = False
+        app_label = "redis_admin"
+        verbose_name = "Unacked queue item"
+        verbose_name_plural = "Unacked queue"
+        default_permissions = ("view", "delete")
+
+    def __str__(self) -> str:
+        if self.depth is not None:
+            return f"unacked (depth={self.depth})"
+        if self.task_name:
+            return f"unacked[{self.delivery_tag}] {self.task_name}"
+        return f"unacked[{self.delivery_tag}]"
+
+    def save(self, *args, **kwargs):  # pragma: no cover - safety net
+        raise RuntimeError("UnackedQueueItem is read-only; saves are not supported.")
+
+    def delete(self, *args, **kwargs):  # pragma: no cover - routed via service
+        # Real deletion goes through `services.unacked_clear` so the
+        # paired `HDEL unacked <tag>` + `ZREM unacked_index <tag>`
+        # contract is honoured atomically; a bare HDEL leaves a
+        # phantom in `unacked_index` for Kombu's restore loop to
+        # trip over.
+        raise NotImplementedError(
+            "UnackedQueueItem.delete is not supported on individual "
+            "instances; use redis_admin.services.unacked_clear "
             "(which the admin's clear flow already invokes)."
         )
 

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -1976,6 +1976,7 @@ class UnackedQueueQuerySet:
         model,
         *,
         routing_key: str | None = None,
+        view_all: bool = False,
         ordering: tuple[str, ...] = (),
         filters: dict[str, Any] | None = None,
         request: Any = None,
@@ -1984,6 +1985,13 @@ class UnackedQueueQuerySet:
     ) -> None:
         self.model = model
         self.routing_key = routing_key
+        # `view_all` lets the admin's "view N unacked message(s) →"
+        # link drop into per-message detail mode without picking a
+        # specific routing_key. Without this flag the queryset
+        # would still report `is_summary_mode()` and feed a single
+        # summary row to the admin's detail-column rendering — a
+        # row of dashes (Bugbot review on PR #911).
+        self.view_all = view_all
         self._ordering = ordering
         self._filters: dict[str, Any] = dict(filters or {})
         self._result_cache: list | None = None
@@ -2006,12 +2014,14 @@ class UnackedQueueQuerySet:
         self,
         *,
         routing_key: Any = _UNSET,
+        view_all: Any = _UNSET,
         ordering: tuple[str, ...] | None = None,
         filters: dict[str, Any] | None = None,
     ) -> UnackedQueueQuerySet:
         return UnackedQueueQuerySet(
             self.model,
             routing_key=self.routing_key if routing_key is _UNSET else routing_key,
+            view_all=self.view_all if view_all is _UNSET else view_all,
             ordering=self._ordering if ordering is None else ordering,
             filters=(
                 {**self._filters, **(filters or {})} if filters else dict(self._filters)
@@ -2259,12 +2269,18 @@ class UnackedQueueQuerySet:
         )
 
     def is_summary_mode(self) -> bool:
-        """No `routing_key__exact` filter → render the single
-        summary row (one per HASH, since there's only one
-        `unacked` HASH per broker).
+        """No `routing_key__exact` filter and no `view_all` flag
+        → render the single summary row (one per HASH, since
+        there's only one `unacked` HASH per broker).
+
+        `view_all` lets the admin land on detail-mode without
+        scoping to a single routing_key (the summary drill-in
+        link's behaviour); the materialiser then surfaces every
+        reserved message and the operator narrows via the
+        sidebar `routing_key` filter.
         """
 
-        return self.routing_key is None
+        return self.routing_key is None and not self.view_all
 
     @sentry_sdk.trace
     def _materialise_summary(self) -> list:
@@ -2333,9 +2349,14 @@ class UnackedQueueQuerySet:
 
     _REQUEST_CACHE_ATTR: str = "_unacked_hscan_cache"
 
-    def _request_cache_key(self) -> tuple[str, int]:
+    def _request_cache_key(self) -> tuple[str, bool, int]:
+        # `view_all` rides on the cache key so a routing_key-scoped
+        # render and a `view_all=1` render don't share a snapshot:
+        # the routing_key path narrows in `_matches_filters` after
+        # caching, while `view_all=1` keeps every row.
         return (
             self.routing_key or "",
+            self.view_all,
             redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT,
         )
 

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -1932,6 +1932,18 @@ def _stream_unacked_frequency_aggregate(
     if not counter or total == 0:
         return [], 0
 
+    # Re-normalise `total` from the surviving counter so the
+    # rendered percentages sum to 100% across the chart's
+    # buckets. Without this, all-None unparseable envelopes
+    # (which `total += 1` but never land in `counter`) inflate
+    # the denominator and make percentages add up to less than
+    # 100% (Bugbot review on PR #911 — same shape as the
+    # cached path's `total = sum(counter.values())` re-norm
+    # in `frequency_by_routing_task_repo_commit`).
+    total = sum(counter.values())
+    if total == 0:
+        return [], 0
+
     ordered = sorted(
         counter.items(),
         key=lambda kv: (

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -14,6 +14,7 @@ hood so the models need no real database table.
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
 from collections import Counter
 from collections.abc import Iterator
@@ -1725,6 +1726,807 @@ class CeleryBrokerQueueQuerySet:
         if not self.queue_name or not redis.exists(self.queue_name):
             return []
         buckets, _total = _stream_frequency_aggregate(redis, self.queue_name, top=top)
+        return buckets
+
+    # ---- Admin compatibility shims ---------------------------------------
+
+    @property
+    def query(self):
+        ordering = self._ordering
+
+        class _Query:
+            order_by = ordering
+            select_related = False
+            distinct = False
+
+        return _Query()
+
+    @property
+    def ordered(self) -> bool:
+        return bool(self._ordering)
+
+    @property
+    def db(self) -> str:
+        return "default"
+
+
+# ---- Kombu unacked queue queryset (per-message drill-down) ----------------
+#
+# Backs `UnackedQueueItem`. The Kombu Redis transport stores
+# in-flight (BRPOPLPUSH'd) messages in two keys on the broker
+# Redis:
+#
+# * `unacked` (HASH) — field=`delivery_tag`, value=JSON-serialised
+#   `[message_dict, exchange_str, routing_key_str]` triple.
+# * `unacked_index` (ZSET) — score=visibility-timeout deadline,
+#   member=`delivery_tag`. Used by Kombu's restore-loop to
+#   re-enqueue messages whose worker died.
+#
+# Defaults verified against
+# `kombu.transport.redis.Channel.unacked_key` /
+# `unacked_index_key` (defaults: `"unacked"` and
+# `"unacked_index"`).
+#
+# Two-mode semantics mirror `CeleryBrokerQueueQuerySet`: with no
+# `routing_key__exact` filter the queryset returns one summary row
+# (`HLEN unacked`); with the filter set it returns per-message rows
+# scoped to that routing_key. Connection routes to `kind="broker"`
+# unconditionally — Kombu never lives on the cache Redis.
+
+# Kombu's default key names (`Channel.unacked_key` /
+# `Channel.unacked_index_key`). Pinned here as constants both for
+# documentation and so the test suite can override them via
+# the queryset constructor to exercise non-default deployments.
+_UNACKED_KEY: str = "unacked"
+_UNACKED_INDEX_KEY: str = "unacked_index"
+
+
+_UNACKED_FILTER_KEYS: dict[str, str] = {
+    "routing_key": "routing_key",
+    "routing_key__exact": "routing_key",
+    "exchange": "exchange_exact",
+    "exchange__exact": "exchange_exact",
+    "repoid": "repoid",
+    "repoid__exact": "repoid",
+    "commitid": "commitid_prefix",
+    "commitid__exact": "commitid_exact",
+    "commitid__startswith": "commitid_prefix",
+    "task_name": "task_name_exact",
+    "task_name__exact": "task_name_exact",
+    "task_name__icontains": "task_name_substring",
+    "task_id": "task_id_exact",
+    "task_id__exact": "task_id_exact",
+    "ownerid": "ownerid",
+    "ownerid__exact": "ownerid",
+    "pullid": "pullid",
+    "pullid__exact": "pullid",
+    "delivery_tag": "delivery_tag_exact",
+    "delivery_tag__exact": "delivery_tag_exact",
+    # Admin bulk-action `pk__in=[...]` shortcut. Each pk_token is
+    # `unacked#<delivery_tag>`, so we extract the suffixes and turn
+    # them into a delivery_tag set filter.
+    "pk__in": "pk_in",
+}
+
+
+@dataclass(frozen=True)
+class UnackedFrequencyBucket:
+    """One row of the unacked drill-down frequency chart.
+
+    Aggregates messages by `(routing_key, task_name, repoid,
+    commitid)` rather than the celery-broker chart's
+    `(task_name, repoid, commitid)` triple — `routing_key` is the
+    fourth axis here because the unacked HASH carries messages from
+    every queue at once. Without the routing_key column, "clear all
+    messages for repo X commit Y" would silently span queues that
+    share `(task, repoid, commitid)` but live under different
+    routing keys, which is rarely what an operator wants.
+
+    `pct` is the bucket's share of the sampled window (the same
+    `CELERY_BROKER_SCAN_LIMIT` we use for the celery_broker chart).
+    The HASH has no inherent ordering so HSCAN returns fields in
+    Redis-internal order; the chart's percentages are over the
+    sampled window, not necessarily over the whole HLEN.
+    """
+
+    routing_key: str | None
+    task_name: str | None
+    repoid: int | None
+    commitid: str | None
+    count: int
+    pct: float
+
+
+def _decode_unacked_value(decoded: str) -> tuple[str | None, str | None, str | None]:
+    """Pull `(envelope_str, exchange, routing_key)` from one unacked HASH value.
+
+    Kombu serialises each value as
+    `dumps([message_dict, exchange_str, routing_key_str])`. The
+    `message_dict` is the same kombu envelope shape (with `body`
+    base64) that `parse_celery_envelope` already understands —
+    re-emit it as a JSON string here so callers can hand it
+    directly to that parser without re-implementing the kombu
+    envelope shape locally.
+    """
+
+    try:
+        outer = json.loads(decoded)
+    except (ValueError, TypeError):
+        return None, None, None
+    if not isinstance(outer, list) or len(outer) < 1:
+        return None, None, None
+    envelope = outer[0]
+    exchange = outer[1] if len(outer) >= 2 and isinstance(outer[1], str) else None
+    routing_key = outer[2] if len(outer) >= 3 and isinstance(outer[2], str) else None
+    if isinstance(envelope, str):
+        envelope_str = envelope
+    elif isinstance(envelope, dict):
+        try:
+            envelope_str = json.dumps(envelope)
+        except (TypeError, ValueError):
+            envelope_str = None
+    else:
+        envelope_str = None
+    return envelope_str, exchange, routing_key
+
+
+def _stream_unacked_frequency_aggregate(
+    redis,
+    *,
+    top: int = _FREQUENCY_TOP_DEFAULT,
+    unacked_key: str = _UNACKED_KEY,
+) -> tuple[list[UnackedFrequencyBucket], int]:
+    """Streaming `(routing_key, task_name, repoid, commitid)` aggregator.
+
+    Walks `unacked` via `HSCAN` up to `CELERY_BROKER_SCAN_LIMIT`
+    fields. Each chunk is parsed and immediately discarded — the
+    only retained state is a rolling `Counter` keyed on the
+    4-tuple. Returns `(buckets, total_sampled)` where
+    `total_sampled` is the full sampled count (used as the `pct`
+    denominator) and `buckets` is the top-N list.
+
+    Mirrors `_stream_frequency_aggregate` for the celery_broker
+    chart, but iterates via HSCAN (HASH) instead of LRANGE (LIST)
+    and groups by an additional `routing_key` axis since the
+    unacked HASH spans every queue.
+    """
+
+    cap = redis_admin_settings.CELERY_BROKER_SCAN_LIMIT
+    counter: Counter[tuple[str | None, str | None, int | None, str | None]] = Counter()
+    total = 0
+
+    if not redis.exists(unacked_key):
+        return [], 0
+
+    scan_count = redis_admin_settings.SCAN_COUNT
+    for _raw_field, raw_value in redis.hscan_iter(unacked_key, count=scan_count):
+        if total >= cap:
+            break
+        decoded = _decode_value(raw_value)
+        envelope_str, _exchange, routing_key = _decode_unacked_value(decoded)
+        # Normalise empty-string routing_key to None so the
+        # all-axes-empty drop below catches both `routing_key=""`
+        # (Kombu writes the empty string when no exchange/queue
+        # is named) and `routing_key=None` (decoder fallback).
+        if not routing_key:
+            routing_key = None
+        if envelope_str is None:
+            if routing_key is None:
+                total += 1
+                continue
+            counter[(routing_key, None, None, None)] += 1
+            total += 1
+            continue
+        meta = parse_celery_envelope(envelope_str)
+        if (
+            routing_key is None
+            and meta.task is None
+            and meta.repoid is None
+            and meta.commitid is None
+        ):
+            total += 1
+            continue
+        counter[(routing_key, meta.task, meta.repoid, meta.commitid)] += 1
+        total += 1
+
+    if not counter or total == 0:
+        return [], 0
+
+    ordered = sorted(
+        counter.items(),
+        key=lambda kv: (
+            -kv[1],
+            _ordering_tuple_for_str(kv[0][0]),
+            _ordering_tuple_for_str(kv[0][1]),
+            _ordering_tuple_for_int(kv[0][2]),
+            _ordering_tuple_for_str(kv[0][3]),
+        ),
+    )
+    buckets: list[UnackedFrequencyBucket] = []
+    for (routing_key, task_name, repoid, commitid), count in ordered[:top]:
+        pct = (count / total) * 100.0 if total else 0.0
+        buckets.append(
+            UnackedFrequencyBucket(
+                routing_key=routing_key,
+                task_name=task_name,
+                repoid=repoid,
+                commitid=commitid,
+                count=count,
+                pct=pct,
+            )
+        )
+    return buckets, total
+
+
+class UnackedQueueQuerySet:
+    """Fake QuerySet over Kombu's unacked HASH.
+
+    Two-mode semantics: with no `routing_key__exact` filter,
+    materialises a single summary row whose `depth` is the live
+    `HLEN(unacked)`. With the filter set, materialises per-message
+    rows scoped to that routing_key.
+
+    Connection is hard-coded to `kind="broker"` since the unacked
+    bookkeeping lives on the Celery broker Redis (next to the
+    queue keys themselves), not on the cache Redis.
+    """
+
+    def __init__(
+        self,
+        model,
+        *,
+        routing_key: str | None = None,
+        ordering: tuple[str, ...] = (),
+        filters: dict[str, Any] | None = None,
+        request: Any = None,
+        unacked_key: str = _UNACKED_KEY,
+        unacked_index_key: str = _UNACKED_INDEX_KEY,
+    ) -> None:
+        self.model = model
+        self.routing_key = routing_key
+        self._ordering = ordering
+        self._filters: dict[str, Any] = dict(filters or {})
+        self._result_cache: list | None = None
+        # The two key names ride on the queryset so callers can
+        # override them per-request (Kombu allows both via
+        # `transport_options`); production deployments leave the
+        # defaults in place.
+        self._unacked_key = unacked_key
+        self._unacked_index_key = unacked_index_key
+        # Optional `HttpRequest` reference. When set, the parsed
+        # HSCAN snapshot is stashed on the request so the
+        # changelist and the frequency-chart context builder reuse
+        # a single round-trip per page render. Mirrors
+        # `CeleryBrokerQueueQuerySet`'s per-request cache.
+        self._request = request
+
+    # ---- Cloning helpers --------------------------------------------------
+
+    def _clone(
+        self,
+        *,
+        routing_key: Any = _UNSET,
+        ordering: tuple[str, ...] | None = None,
+        filters: dict[str, Any] | None = None,
+    ) -> UnackedQueueQuerySet:
+        return UnackedQueueQuerySet(
+            self.model,
+            routing_key=self.routing_key if routing_key is _UNSET else routing_key,
+            ordering=self._ordering if ordering is None else ordering,
+            filters=(
+                {**self._filters, **(filters or {})} if filters else dict(self._filters)
+            ),
+            request=self._request,
+            unacked_key=self._unacked_key,
+            unacked_index_key=self._unacked_index_key,
+        )
+
+    def all(self) -> UnackedQueueQuerySet:
+        return self._clone()
+
+    def none(self) -> UnackedQueueQuerySet:
+        empty = self._clone(routing_key=None)
+        empty._result_cache = []
+        return empty
+
+    def using(self, alias) -> UnackedQueueQuerySet:
+        return self
+
+    # ---- Compatibility shims for django.contrib.admin.utils ---------------
+
+    @property
+    def verbose_name(self):
+        return self.model._meta.verbose_name
+
+    @property
+    def verbose_name_plural(self):
+        return self.model._meta.verbose_name_plural
+
+    # ---- Filtering -------------------------------------------------------
+
+    def _interpret_filter_kwargs(
+        self, kwargs: dict[str, Any]
+    ) -> tuple[Any, dict[str, Any]]:
+        new_routing_key: Any = _UNSET
+        new_filters: dict[str, Any] = {}
+        for key, value in kwargs.items():
+            target = _UNACKED_FILTER_KEYS.get(key)
+            if target is None:
+                raise NotImplementedError(
+                    "UnackedQueueQuerySet.filter only supports "
+                    f"{sorted(_UNACKED_FILTER_KEYS)}; got {key!r}"
+                )
+            if target == "routing_key":
+                new_routing_key = None if value is None or value == "" else str(value)
+                continue
+            if value is None or value == "":
+                continue
+            if target in ("repoid", "ownerid", "pullid"):
+                try:
+                    new_filters[target] = int(value)
+                except (TypeError, ValueError):
+                    new_filters["__empty__"] = True
+            elif target in ("commitid_prefix", "commitid_exact"):
+                new_filters[target] = str(value)
+            elif target in (
+                "task_name_exact",
+                "task_id_exact",
+                "exchange_exact",
+                "delivery_tag_exact",
+            ):
+                new_filters[target] = str(value)
+            elif target == "task_name_substring":
+                new_filters[target] = str(value).lower()
+            elif target == "pk_in":
+                tags: set[str] = set()
+                bad = False
+                for raw in value or ():
+                    raw_str = str(raw)
+                    prefix, sep, tail = raw_str.rpartition("#")
+                    if not sep or not prefix or not tail:
+                        bad = True
+                        break
+                    if tail == "summary":
+                        # Summary pk_token has no message-shape; the
+                        # only bulk action we expose is message-shaped
+                        # clears. Force empty rather than over-match.
+                        bad = True
+                        break
+                    tags.add(tail)
+                if bad:
+                    new_filters["__empty__"] = True
+                else:
+                    new_filters["pk_in_tags"] = tags
+        return new_routing_key, new_filters
+
+    def filter(self, *args, **kwargs) -> UnackedQueueQuerySet:
+        if args:
+            raise NotImplementedError(
+                "UnackedQueueQuerySet.filter does not accept positional Q objects"
+            )
+        new_routing_key, new_filters = self._interpret_filter_kwargs(kwargs)
+        return self._clone(routing_key=new_routing_key, filters=new_filters)
+
+    def exclude(self, *args, **kwargs) -> UnackedQueueQuerySet:
+        if not args and not kwargs:
+            return self._clone()
+        raise NotImplementedError("UnackedQueueQuerySet.exclude is not implemented")
+
+    def order_by(self, *fields: str) -> UnackedQueueQuerySet:
+        return self._clone(ordering=tuple(fields))
+
+    def get(self, *args, **kwargs):
+        """Resolve a single row by `pk_token = 'unacked#<delivery_tag>'`.
+
+        `unacked#summary` resolves to the summary row.
+        """
+
+        if args:
+            raise self.model.DoesNotExist(
+                f"{self.model.__name__} positional get() is not supported"
+            )
+        pk = (
+            kwargs.pop("pk", None)
+            or kwargs.pop("pk__exact", None)
+            or kwargs.pop("pk_token", None)
+            or kwargs.pop("pk_token__exact", None)
+        )
+        if kwargs:
+            raise NotImplementedError(
+                "UnackedQueueQuerySet.get only supports pk/pk_token; "
+                f"got extra {list(kwargs)!r}"
+            )
+        if pk is None:
+            raise self.model.DoesNotExist(
+                f"{self.model.__name__} matching no kwargs does not exist"
+            )
+        pk_str = str(pk)
+        prefix, sep, tail = pk_str.rpartition("#")
+        if not sep or not prefix or not tail:
+            raise self.model.DoesNotExist(
+                f"pk_token must look like 'unacked#<delivery_tag>'; got {pk_str!r}"
+            )
+        if tail == "summary":
+            redis = self._connection()
+            depth = int(redis.hlen(self._unacked_key) or 0)
+            return self._build_summary_row(depth)
+        # Direct HGET path skips the per-message materialisation
+        # (which is bounded by `CELERY_BROKER_DISPLAY_LIMIT`) so a
+        # delivery_tag past that cap still resolves cleanly when
+        # the operator clicks through.
+        redis = self._connection()
+        raw = redis.hget(self._unacked_key, tail)
+        if raw is None:
+            raise self.model.DoesNotExist(
+                f"unacked HASH does not contain field {tail!r}"
+            )
+        decoded = _decode_value(raw)
+        envelope_str, exchange, routing_key = _decode_unacked_value(decoded)
+        meta: CeleryEnvelopeMeta
+        if envelope_str is None:
+            meta = CeleryEnvelopeMeta()
+        else:
+            meta = parse_celery_envelope(envelope_str)
+        deadline = self._read_deadline(redis, tail)
+        row = self._build_row(
+            delivery_tag=tail,
+            routing_key=routing_key or "",
+            exchange=exchange or "",
+            deadline=deadline,
+            meta=meta,
+        )
+        # Eagerly resolve the preview here so the change_form
+        # readonly field surface (which reads `obj.payload_preview`
+        # directly) shows the body kwargs. Singleton call — cost
+        # is one envelope's render, not the full HASH's.
+        resolve_payload_preview(row)
+        return row
+
+    # ---- Materialisation -------------------------------------------------
+
+    def _connection(self) -> Any:
+        # Unacked bookkeeping always lives on the broker Redis;
+        # the cache Redis never sees these keys.
+        return _conn.get_connection(kind="broker")
+
+    def _read_deadline(self, redis, delivery_tag: str) -> _dt.datetime | None:
+        """`ZSCORE unacked_index <tag>` rendered as a UTC datetime.
+
+        Kombu's restore-loop uses these scores (visibility-timeout
+        deadlines, unix timestamps) to re-enqueue messages whose
+        worker died. Surfacing them here lets the operator see
+        "this message will be restored at 12:34:56" without
+        shelling into Redis.
+        """
+
+        try:
+            score = redis.zscore(self._unacked_index_key, delivery_tag)
+        except Exception:  # pragma: no cover - defensive
+            return None
+        if score is None:
+            return None
+        try:
+            return _dt.datetime.fromtimestamp(float(score), tz=_dt.UTC)
+        except (TypeError, ValueError, OverflowError):  # pragma: no cover
+            return None
+
+    def _build_row(
+        self,
+        *,
+        delivery_tag: str,
+        routing_key: str,
+        exchange: str,
+        deadline: _dt.datetime | None,
+        meta: CeleryEnvelopeMeta,
+    ) -> Any:
+        # Mirrors `CeleryBrokerQueueQuerySet._build_row`: defer
+        # the `_summarise_kwargs_for_preview` cost to first display
+        # so a 2k-row materialisation isn't spending JSON-render
+        # cycles on rows the changelist will paginate past.
+        row = self.model(
+            pk_token=f"unacked#{delivery_tag}",
+            delivery_tag=delivery_tag,
+            routing_key=routing_key,
+            exchange=exchange,
+            visibility_deadline=deadline,
+            task_name=meta.task or "",
+            task_id=meta.task_id or "",
+            repoid=meta.repoid,
+            commitid=meta.commitid or "",
+            ownerid=meta.ownerid,
+            pullid=meta.pullid,
+            payload_preview="",
+            depth=None,
+        )
+        row._kwargs_for_preview = meta.kwargs
+        return row
+
+    def _build_summary_row(self, depth: int) -> Any:
+        return self.model(
+            pk_token="unacked#summary",
+            delivery_tag="",
+            routing_key="",
+            exchange="",
+            visibility_deadline=None,
+            task_name="",
+            task_id="",
+            repoid=None,
+            commitid="",
+            ownerid=None,
+            pullid=None,
+            payload_preview="",
+            depth=depth,
+        )
+
+    def is_summary_mode(self) -> bool:
+        """No `routing_key__exact` filter → render the single
+        summary row (one per HASH, since there's only one
+        `unacked` HASH per broker).
+        """
+
+        return self.routing_key is None
+
+    @sentry_sdk.trace
+    def _materialise_summary(self) -> list:
+        """Single summary row carrying `HLEN(unacked)`.
+
+        Mirrors `CeleryBrokerQueueQuerySet._materialise_summary`
+        but emits exactly one row instead of one per known queue —
+        the unacked HASH is global across queues, and the
+        routing_key dimension lives inside the values, not in the
+        HASH name.
+        """
+
+        redis = self._connection()
+        try:
+            depth = int(redis.hlen(self._unacked_key) or 0)
+        except Exception:  # pragma: no cover - defensive
+            depth = 0
+        return [self._build_summary_row(depth)]
+
+    @sentry_sdk.trace
+    def _materialise(self) -> list:
+        if self.is_summary_mode():
+            return self._materialise_summary()
+        cached = self._read_request_cache()
+        if cached is not None:
+            return cached
+        redis = self._connection()
+        if not redis.exists(self._unacked_key):
+            return []
+        cap = redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT
+        scan_count = redis_admin_settings.SCAN_COUNT
+        rows: list = []
+        # Walk via HSCAN — bounded by `CELERY_BROKER_DISPLAY_LIMIT`
+        # so a 100k-deep unacked HASH doesn't materialise every row
+        # into Python on a single page render.
+        for raw_field, raw_value in redis.hscan_iter(
+            self._unacked_key, count=scan_count
+        ):
+            if len(rows) >= cap:
+                break
+            tag = _decode_value(raw_field)
+            decoded = _decode_value(raw_value)
+            envelope_str, exchange, routing_key = _decode_unacked_value(decoded)
+            if envelope_str is None:
+                meta = CeleryEnvelopeMeta()
+            else:
+                meta = parse_celery_envelope(envelope_str)
+            # ZSCORE per row within the bounded display window. The
+            # chart aggregator skips this entirely (it doesn't need
+            # deadlines), so the cost only lands on the changelist
+            # render where the operator wants the value visible.
+            deadline = self._read_deadline(redis, tag)
+            rows.append(
+                self._build_row(
+                    delivery_tag=tag,
+                    routing_key=routing_key or "",
+                    exchange=exchange or "",
+                    deadline=deadline,
+                    meta=meta,
+                )
+            )
+        self._write_request_cache(rows)
+        return rows
+
+    # ---- Per-request HSCAN cache ----------------------------------------
+
+    _REQUEST_CACHE_ATTR: str = "_unacked_hscan_cache"
+
+    def _request_cache_key(self) -> tuple[str, int]:
+        return (
+            self.routing_key or "",
+            redis_admin_settings.CELERY_BROKER_DISPLAY_LIMIT,
+        )
+
+    def _read_request_cache(self) -> list | None:
+        if self._request is None or self.is_summary_mode():
+            return None
+        cache = getattr(self._request, self._REQUEST_CACHE_ATTR, None)
+        if cache is None:
+            return None
+        return cache.get(self._request_cache_key())
+
+    def _write_request_cache(self, rows: list) -> None:
+        if self._request is None or self.is_summary_mode():
+            return
+        cache = getattr(self._request, self._REQUEST_CACHE_ATTR, None)
+        if cache is None:
+            cache = {}
+            setattr(self._request, self._REQUEST_CACHE_ATTR, cache)
+        cache[self._request_cache_key()] = rows
+
+    def _matches_filters(self, row: Any) -> bool:
+        f = self._filters
+        if f.get("__empty__"):
+            return False
+        # Summary rows skip the message filters — same shape as the
+        # celery broker queryset where `depth is not None` flags a
+        # summary row.
+        if row.depth is not None:
+            return True
+        # `routing_key` is the primary scope for unacked messages;
+        # enforce it post-materialisation so a chained filter (e.g.
+        # changelist's sidebar `routing_key` lookup) narrows
+        # correctly.
+        if self.routing_key is not None and (row.routing_key or "") != self.routing_key:
+            return False
+        repoid = f.get("repoid")
+        if repoid is not None and row.repoid != repoid:
+            return False
+        ownerid = f.get("ownerid")
+        if ownerid is not None and row.ownerid != ownerid:
+            return False
+        pullid = f.get("pullid")
+        if pullid is not None and row.pullid != pullid:
+            return False
+        commit_exact = f.get("commitid_exact")
+        if commit_exact and (row.commitid or "") != commit_exact:
+            return False
+        commit_prefix = f.get("commitid_prefix")
+        if commit_prefix and not (row.commitid or "").startswith(commit_prefix):
+            return False
+        task_exact = f.get("task_name_exact")
+        if task_exact and (row.task_name or "") != task_exact:
+            return False
+        task_substring = f.get("task_name_substring")
+        if task_substring and task_substring not in (row.task_name or "").lower():
+            return False
+        task_id_exact = f.get("task_id_exact")
+        if task_id_exact and (row.task_id or "") != task_id_exact:
+            return False
+        exchange_exact = f.get("exchange_exact")
+        if exchange_exact and (row.exchange or "") != exchange_exact:
+            return False
+        delivery_tag_exact = f.get("delivery_tag_exact")
+        if delivery_tag_exact and (row.delivery_tag or "") != delivery_tag_exact:
+            return False
+        pk_in_tags = f.get("pk_in_tags")
+        if pk_in_tags is not None and row.delivery_tag not in pk_in_tags:
+            return False
+        return True
+
+    def _fetch_all(self) -> list:
+        if self._result_cache is not None:
+            return self._result_cache
+        if self._filters.get("__empty__"):
+            self._result_cache = []
+            return []
+        rows = self._materialise()
+        rows = [r for r in rows if self._matches_filters(r)]
+        for field in reversed(self._ordering):
+            reverse = field.startswith("-")
+            attr = field.lstrip("-")
+            rows.sort(
+                key=lambda obj, attr=attr: _ordering_key(obj, attr), reverse=reverse
+            )
+        self._result_cache = rows
+        return rows
+
+    def __iter__(self) -> Iterator:
+        return iter(self._fetch_all())
+
+    def iterator(self, chunk_size: int | None = None) -> Iterator:
+        return iter(self._fetch_all())
+
+    def __len__(self) -> int:
+        return len(self._fetch_all())
+
+    def count(self) -> int:
+        return len(self._fetch_all())
+
+    def __getitem__(self, item):
+        return self._fetch_all()[item]
+
+    def __bool__(self) -> bool:
+        return bool(self._fetch_all())
+
+    def delete(self):
+        # Real deletion goes through `services.unacked_clear` so
+        # the paired HDEL+ZREM contract is honoured.
+        raise NotImplementedError(
+            "UnackedQueueQuerySet.delete is not supported; use "
+            "redis_admin.services.unacked_clear"
+        )
+
+    # ---- Frequency aggregation ------------------------------------------
+
+    def frequency_by_routing_task_repo_commit(
+        self, *, top: int = _FREQUENCY_TOP_DEFAULT
+    ) -> list[UnackedFrequencyBucket]:
+        """Top `(routing_key, task_name, repoid, commitid)` quadruples.
+
+        Drives the unacked drill-down's frequency chart. Two paths
+        identical in shape to `frequency_by_task_repo_commit` on
+        the celery_broker queryset:
+
+        1. Cached path: if the per-request HSCAN snapshot is
+           already populated, aggregate over those rows. Bounded
+           by `CELERY_BROKER_DISPLAY_LIMIT`.
+        2. Streaming path: streams the full HASH via
+           `_stream_unacked_frequency_aggregate` (bounded by
+           `CELERY_BROKER_SCAN_LIMIT`).
+
+        Buckets where every axis is `None` are dropped so the
+        chart's row click can't produce an empty-scope clear.
+        """
+
+        if self.is_summary_mode():
+            return []
+
+        cached = self._result_cache
+        if cached is not None:
+            rows = cached
+            total = len(rows)
+            if total == 0:
+                return []
+            counter: Counter[tuple[str | None, str | None, int | None, str | None]] = (
+                Counter()
+            )
+            for row in rows:
+                rk = row.routing_key or None
+                tn = row.task_name or None
+                cm = row.commitid or None
+                if rk is None and tn is None and row.repoid is None and cm is None:
+                    continue
+                counter[(rk, tn, row.repoid, cm)] += 1
+            # Re-normalise the running total to drop fully-empty
+            # rows from the pct denominator so the chart's
+            # percentages reflect the rendered buckets.
+            total = sum(counter.values())
+            if not counter:
+                return []
+            ordered = sorted(
+                counter.items(),
+                key=lambda kv: (
+                    -kv[1],
+                    _ordering_tuple_for_str(kv[0][0]),
+                    _ordering_tuple_for_str(kv[0][1]),
+                    _ordering_tuple_for_int(kv[0][2]),
+                    _ordering_tuple_for_str(kv[0][3]),
+                ),
+            )
+            buckets: list[UnackedFrequencyBucket] = []
+            for (routing_key, task_name, repoid, commitid), count in ordered[:top]:
+                pct = (count / total) * 100.0 if total else 0.0
+                buckets.append(
+                    UnackedFrequencyBucket(
+                        routing_key=routing_key,
+                        task_name=task_name,
+                        repoid=repoid,
+                        commitid=commitid,
+                        count=count,
+                        pct=pct,
+                    )
+                )
+            return buckets
+
+        redis = self._connection()
+        if not redis.exists(self._unacked_key):
+            return []
+        buckets, _total = _stream_unacked_frequency_aggregate(
+            redis, top=top, unacked_key=self._unacked_key
+        )
         return buckets
 
     # ---- Admin compatibility shims ---------------------------------------

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -37,7 +37,12 @@ from django.db import close_old_connections
 
 from . import conn as _conn
 from . import settings as redis_admin_settings
-from .families import ConnectionKind, find_family, parse_celery_envelope
+from .families import (
+    CeleryEnvelopeMeta,
+    ConnectionKind,
+    find_family,
+    parse_celery_envelope,
+)
 from .families import _decode as _decode_value
 from .models import (
     CeleryBrokerQueue,
@@ -1912,9 +1917,13 @@ def _streaming_unacked_clear(
                 decoded = _decode_value(raw_value)
                 envelope_str, _exchange, routing_key = _decode_unacked_value(decoded)
                 if envelope_str is None:
-                    meta = type(
-                        "M", (), {"task": None, "repoid": None, "commitid": None}
-                    )()
+                    # Use the canonical empty `CeleryEnvelopeMeta`
+                    # rather than an ad-hoc fake. The fake was
+                    # missing fields (e.g. `comparison_id`) that
+                    # any future filter expansion would touch and
+                    # raise `AttributeError` on (Bugbot review on
+                    # PR #911).
+                    meta = CeleryEnvelopeMeta()
                 else:
                     meta = parse_celery_envelope(envelope_str)
                 chunk_buffer.append((field_name, routing_key, meta))

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -1822,15 +1822,34 @@ def _streaming_unacked_clear(
                 if dry_run:
                     continue
                 chunk_targets.append(field_name)
+                # `pass_matches` accumulates exactly once per
+                # match here. The post-pass-1 keep_one branch
+                # below intentionally does NOT extend it again:
+                # before the bugfix, every keep_one pass-1 match
+                # was stashed in `pass_matches` twice (once via
+                # this append, once via a now-removed
+                # `pass_matches.extend(chunk_targets)`). The
+                # post-pass HDEL+ZREM pipeline then issued
+                # duplicate commands per non-keeper. Idempotent
+                # on Redis (second HDEL/ZREM returns 0, leaving
+                # counters truthful) but doubled the round-trip
+                # volume on a long clear. Test
+                # `test_unacked_clear_keep_one_pass_one_does_not_double_pipeline`
+                # pins the no-duplicate-pipeline contract.
                 pass_matches.append(field_name)
 
             if chunk_targets and pass_num == 0 and keep_one:
-                # On pass 1 we can't HDEL yet (the keeper is
-                # determined post-pass), so defer: stash matches
-                # into `pass_matches` only. The post-pass HDEL/ZREM
-                # below will run one big pipeline against the full
-                # filtered list, minus the keeper.
-                pass_matches.extend(chunk_targets)
+                # On pass 1 we can't HDEL yet — the keeper is the
+                # lowest-deadline match across the *full pass*,
+                # determined post-pass via batched ZSCORE. The
+                # per-field `pass_matches.append(field_name)`
+                # above already stashed every chunk-level match
+                # exactly once; we deliberately don't extend
+                # `pass_matches` again here (see comment above).
+                # The post-pass HDEL+ZREM pipeline below runs one
+                # big batch against `pass_matches` minus the
+                # resolved keeper.
+                pass
             elif chunk_targets:
                 pipe = redis.pipeline(transaction=False)
                 for field_name in chunk_targets:

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -1752,9 +1752,6 @@ def _streaming_unacked_clear(
     # still exists; if a worker drained it between passes, the
     # next pass's lowest-deadline match becomes the new keeper.
     keeper_field: str | None = None
-    # Per-pass collected match list so pass 1 can compute the
-    # ZSCORE-based keeper after the full sweep.
-    pass1_match_fields: list[str] = []
 
     for pass_num in range(_UNACKED_MAX_PASSES):
         passes_run = pass_num + 1
@@ -1808,8 +1805,6 @@ def _streaming_unacked_clear(
                 matches_found += 1
                 if first_match_field is None:
                     first_match_field = field_name
-                if pass_num == 0:
-                    pass1_match_fields.append(field_name)
                 # `keep_one`: skip the keeper across all passes.
                 # On pass 1 we don't yet know the lowest-deadline
                 # match (that's computed after the pass), so we
@@ -1944,6 +1939,15 @@ def _streaming_unacked_clear(
             )
             targets = [f for f in pass_matches if f != keeper_field]
             if targets:
+                # Capture pre-drain counters so the post-pass
+                # progress callback below can report `matched_delta`
+                # and the cumulative `zrem_removed`. Without this,
+                # the operator's progress page permanently reports
+                # `matched=0` and `zrem_removed=0` for keep_one
+                # clears: the per-chunk callback runs while pass-1
+                # keep_one is still deferring all mutations to this
+                # post-pass pipeline (Bugbot review on PR #911).
+                pre_drain_hdel = matches_hdel
                 pipe = redis.pipeline(transaction=False)
                 for field_name in targets:
                     pipe.hdel(unacked_key, field_name)
@@ -1971,6 +1975,36 @@ def _streaming_unacked_clear(
                         matches_zrem += int(reply or 0)
                     except (TypeError, ValueError):
                         pass
+                # Notify the progress callback now that the deferred
+                # post-pass HDEL+ZREM have actually mutated the
+                # broker. Without this tick, the operator's progress
+                # page on a keep_one clear permanently shows
+                # `matched=0` / `zrem_removed=0` because every
+                # per-chunk tick during the pass-1 sweep reported
+                # zero deltas (mutations were all deferred to here).
+                if progress_callback is not None:
+                    snapshot = _UnackedChunkProgress(
+                        pass_num=passes_run,
+                        chunk_index=chunk_index,
+                        processed_delta=0,
+                        matched_delta=matches_hdel - pre_drain_hdel,
+                        found_delta=0,
+                        total_hdel=total_hdel + matches_hdel,
+                        total_zrem=total_zrem + matches_zrem,
+                        total_found=total_found + matches_found,
+                    )
+                    try:
+                        cancel_now = bool(progress_callback(snapshot))
+                    except Exception:  # pragma: no cover - defensive
+                        log.exception(
+                            "redis_admin._streaming_unacked_clear: "
+                            "post-pass keep_one progress_callback raised; "
+                            "treating as no-cancel"
+                        )
+                        cancel_now = False
+                    chunk_index += 1
+                    if cancel_now:
+                        cancelled = True
 
         log.info(
             "redis_admin.unacked_clear: pass=%d depth=%d "

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -39,7 +39,14 @@ from . import conn as _conn
 from . import settings as redis_admin_settings
 from .families import ConnectionKind, find_family, parse_celery_envelope
 from .families import _decode as _decode_value
-from .models import CeleryBrokerQueue, RedisLock, RedisQueue, RedisQueueItem
+from .models import (
+    CeleryBrokerQueue,
+    RedisLock,
+    RedisQueue,
+    RedisQueueItem,
+    UnackedQueueItem,
+)
+from .queryset import _UNACKED_INDEX_KEY, _UNACKED_KEY, _decode_unacked_value
 
 log = logging.getLogger(__name__)
 
@@ -1537,6 +1544,940 @@ def _run_celery_broker_clear_job_body(
     _record_audit(
         user=user,
         scope="celery_broker_clear",
+        count=count,
+        refused=(),
+        sample=sample,
+        families=families,
+        dry_run=dry_run,
+        extra=extra,
+    )
+
+
+# ---- Kombu unacked clear (HASH-based, paired HDEL+ZREM) -------------------
+#
+# The unacked clear has the same operator semantics as the celery
+# broker clear (filter by `(routing_key, task, repoid, commitid)`,
+# `keep_one`, `dry_run`, chunked background-job worker for long
+# clears) but its Redis side is materially simpler: HASH fields
+# don't shift on delete, so there is no LSET-tombstone /
+# verify-before-LSET problem to navigate. A match resolves to a
+# pair of `HDEL unacked <field>` + `ZREM unacked_index <field>`,
+# pipelined per chunk. Skipping the ZREM would leave a phantom
+# in `unacked_index` that points at a non-existent HASH field —
+# Kombu's restore loop would then attempt to re-enqueue an
+# already-cleared message and either error or silently do
+# nothing depending on the broker version, so the pairing is
+# enforced unconditionally even on dry-run previews (counts
+# only — no actual mutations on dry_run).
+#
+# Layout reference: `kombu.transport.redis.Channel.unacked_key`
+# / `unacked_index_key` (defaults: `"unacked"` and
+# `"unacked_index"`).
+
+
+def _substitute_filter_any_unacked(
+    routing_key: str | None,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+) -> tuple:
+    """Substitute `_FILTER_ANY` for unset operator filter slots
+    on the 4-axis unacked filter shape.
+
+    The chunked unacked clear uses a 4-tuple
+    `(routing_key, task_name, repoid, commitid)` rather than the
+    celery-broker clear's 3-tuple. `routing_key` is the additional
+    axis because the unacked HASH spans every queue at once — an
+    operator who runs "clear all messages for repo X commit Y"
+    without scoping by routing_key would silently drain matches
+    from every queue, which is rarely what they want. We could
+    have funnelled `routing_key` through a separate exact-match
+    scope and reused the existing 3-tuple helper, but that would
+    have surfaced as a different code path on the matching side
+    and made `_FILTER_ANY` substitution rules drift between the
+    two helpers. The 4-tuple keeps the wildcard semantics
+    centralised and visible at a glance.
+
+    Truthiness vs `is None` rules match
+    `_substitute_filter_any`: integer-typed `repoid` uses
+    `is not None` to leave `0` valid; string-typed
+    `routing_key` / `task_name` / `commitid` treat `""` and
+    `None` both as "unset" because the admin form coerces
+    missing input to `""`.
+    """
+
+    return (
+        routing_key if routing_key else _FILTER_ANY,
+        task_name if task_name else _FILTER_ANY,
+        repoid if repoid is not None else _FILTER_ANY,
+        commitid if commitid else _FILTER_ANY,
+    )
+
+
+def _unacked_envelope_matches_any_filter(
+    routing_key: str | None,
+    meta,
+    filter_tuples: frozenset,
+) -> bool:
+    """Return True if the parsed envelope + routing_key matches any tuple.
+
+    Each filter tuple is
+    `(routing_key, task_name, repoid, commitid)` where any slot
+    may be the `_FILTER_ANY` sentinel ("wildcard / do not
+    constrain on this field"). `None` in a slot means "match only
+    envelopes whose corresponding parsed field is `None`".
+    Mirrors `_envelope_matches_any_filter` for the 4-axis shape.
+    """
+
+    for ft_rk, ft_task, ft_repoid, ft_commitid in filter_tuples:
+        if ft_rk is not _FILTER_ANY and ft_rk != routing_key:
+            continue
+        if ft_task is not _FILTER_ANY and ft_task != meta.task:
+            continue
+        if ft_repoid is not _FILTER_ANY and ft_repoid != meta.repoid:
+            continue
+        if ft_commitid is not _FILTER_ANY and ft_commitid != meta.commitid:
+            continue
+        return True
+    return False
+
+
+# HSCAN cursor batch size. Kept smaller than the celery_broker
+# LRANGE chunk because HSCAN's cursor batches are looser
+# (`count` is advisory) and we want sub-second progress and
+# cancel-landing on a multi-hundred-thousand-deep HASH. The
+# synchronous path uses the same value — there's no
+# verify-before-LSET asymmetry to optimise for.
+_UNACKED_CLEAR_CHUNK: int = 1_000
+
+# Hard cap on how many full HSCAN passes the streaming clear
+# attempts. HASH delete is much more deterministic than the
+# LSET-tombstone celery clear (no shift between snapshot and
+# delete), so one full pass typically drains the matches; we
+# keep a small buffer for racing producers (workers writing new
+# unacked entries during the clear). 3 is enough for a quiet
+# broker; the synchronous path almost always exits after pass 1
+# via the `matches_found == 0` early-exit.
+_UNACKED_MAX_PASSES: int = 3
+
+
+@dataclass(frozen=True)
+class _UnackedClearStats:
+    """Per-run stats from `_streaming_unacked_clear`.
+
+    Mirrors `_StreamingClearStats` but uses HASH-native counters:
+    `total_hdel` / `total_zrem` are the actual `HDEL` / `ZREM`
+    integer replies summed across all pipelines. `total_found`
+    is every match observed across passes (drives the dry-run
+    preview). `cancelled` is set when the optional progress
+    callback returned `True`.
+    """
+
+    total_hdel: int
+    total_zrem: int
+    total_found: int
+    first_match_field: str | None
+    passes_run: int
+    cancelled: bool = False
+
+
+@dataclass(frozen=True)
+class _UnackedChunkProgress:
+    pass_num: int  # 1-based pass index
+    chunk_index: int  # 0-based chunk index within the current pass
+    processed_delta: int  # fields walked in this chunk (HSCAN batch size)
+    matched_delta: int  # matches HDELed+ZREMmed in this chunk (live runs)
+    found_delta: int  # all matches observed in this chunk
+    total_hdel: int
+    total_zrem: int
+    total_found: int
+
+
+def _streaming_unacked_clear(
+    redis,
+    filter_tuples: frozenset,
+    *,
+    keep_one: bool = False,
+    dry_run: bool = False,
+    chunk_size: int | None = None,
+    progress_callback: Callable[[_UnackedChunkProgress], bool] | None = None,
+    unacked_key: str = _UNACKED_KEY,
+    unacked_index_key: str = _UNACKED_INDEX_KEY,
+) -> _UnackedClearStats:
+    """Streaming HSCAN+pipelined-HDEL/ZREM clear for the `unacked` HASH.
+
+    Walks `unacked` via `HSCAN` in `_UNACKED_CLEAR_CHUNK`-field
+    chunks, parses each value's
+    `[envelope, exchange, routing_key]` triple, decodes the
+    envelope with `parse_celery_envelope`, and matches against
+    `filter_tuples` via `_unacked_envelope_matches_any_filter`.
+
+    For each chunk's matches we issue a single
+    `pipeline(transaction=False)` of paired `HDEL unacked <fields...>`
+    + `ZREM unacked_index <fields...>` ops. Pairing is unconditional:
+    skipping the ZREM would leave a phantom in `unacked_index`
+    that points at a non-existent HASH field, and Kombu's restore
+    loop would then attempt to re-enqueue an already-cleared
+    message.
+
+    `keep_one=True` skips the *lowest-deadline* match across all
+    passes — i.e. the message most likely to be re-enqueued first
+    by Kombu's restore loop. The lowest-deadline match is
+    determined via `ZSCORE unacked_index <field>` for every match
+    seen during pass 1; pass 2+ honour the same keeper. Useful
+    for "I want to keep one example to inspect but clear the
+    rest" — the kept example is the one the operator's debug
+    tooling will actually catch when it gets re-enqueued.
+
+    `dry_run=True` walks the HASH once and accumulates
+    `total_found` without issuing any HDEL/ZREM.
+
+    Returns `_UnackedClearStats`. The caller uses
+    `total_found` for the dry-run preview and `total_hdel` for
+    the live-clear count.
+    """
+
+    chunk = chunk_size if chunk_size is not None else _UNACKED_CLEAR_CHUNK
+
+    total_hdel = 0
+    total_zrem = 0
+    total_found = 0
+    cancelled = False
+    first_match_field: str | None = None
+    passes_run = 0
+
+    # `keep_one` keeper field is determined off the pass-1 sweep
+    # (we need ZSCOREs across all matches to pick the lowest-
+    # deadline one). On pass 2+ we re-use the same keeper if it
+    # still exists; if a worker drained it between passes, the
+    # next pass's lowest-deadline match becomes the new keeper.
+    keeper_field: str | None = None
+    # Per-pass collected match list so pass 1 can compute the
+    # ZSCORE-based keeper after the full sweep.
+    pass1_match_fields: list[str] = []
+
+    for pass_num in range(_UNACKED_MAX_PASSES):
+        passes_run = pass_num + 1
+        matches_found = 0
+        matches_hdel = 0
+        matches_zrem = 0
+        pass_matches: list[str] = []
+
+        if not redis.exists(unacked_key):
+            break
+
+        try:
+            depth = int(redis.hlen(unacked_key) or 0)
+        except Exception:  # pragma: no cover - defensive
+            depth = 0
+        log.info(
+            "redis_admin.unacked_clear: pass=%d depth=%d",
+            passes_run,
+            depth,
+        )
+
+        chunk_index = 0
+        chunk_buffer: list[tuple[str, str | None, Any]] = []
+
+        def _flush_chunk() -> None:
+            """Process one accumulated batch of HSCAN entries:
+            filter, optionally HDEL/ZREM, then drive progress.
+
+            Defined as a closure so the chunk-flush logic stays
+            readable in the streaming loop below — moving it out
+            would lift a dozen counter mutations into a separate
+            signature.
+            """
+
+            nonlocal matches_found, matches_hdel, matches_zrem
+            nonlocal first_match_field, chunk_index
+            if not chunk_buffer:
+                return
+
+            chunk_processed = len(chunk_buffer)
+            chunk_hdel_before = matches_hdel
+            chunk_zrem_before = matches_zrem
+            chunk_found_before = matches_found
+
+            chunk_targets: list[str] = []
+            for field_name, routing_key, meta in chunk_buffer:
+                if not _unacked_envelope_matches_any_filter(
+                    routing_key, meta, filter_tuples
+                ):
+                    continue
+                matches_found += 1
+                if first_match_field is None:
+                    first_match_field = field_name
+                if pass_num == 0:
+                    pass1_match_fields.append(field_name)
+                # `keep_one`: skip the keeper across all passes.
+                # On pass 1 we don't yet know the lowest-deadline
+                # match (that's computed after the pass), so we
+                # collect every match into `chunk_targets` and
+                # filter the keeper out at end-of-pass1 below.
+                # On pass 2+ we already have `keeper_field`, so
+                # filter it out inline here.
+                if keep_one and pass_num > 0 and field_name == keeper_field:
+                    continue
+                if dry_run:
+                    continue
+                chunk_targets.append(field_name)
+                pass_matches.append(field_name)
+
+            if chunk_targets and pass_num == 0 and keep_one:
+                # On pass 1 we can't HDEL yet (the keeper is
+                # determined post-pass), so defer: stash matches
+                # into `pass_matches` only. The post-pass HDEL/ZREM
+                # below will run one big pipeline against the full
+                # filtered list, minus the keeper.
+                pass_matches.extend(chunk_targets)
+            elif chunk_targets:
+                pipe = redis.pipeline(transaction=False)
+                for field_name in chunk_targets:
+                    pipe.hdel(unacked_key, field_name)
+                for field_name in chunk_targets:
+                    pipe.zrem(unacked_index_key, field_name)
+                try:
+                    replies = pipe.execute(raise_on_error=False)
+                except TypeError:  # pragma: no cover - older clients
+                    try:
+                        replies = pipe.execute()
+                    except Exception:  # pragma: no cover - defensive
+                        replies = [0] * (2 * len(chunk_targets))
+                # First half: HDEL replies, second half: ZREM
+                # replies. Both are the integer count of fields
+                # actually removed (0 or 1 per call). We sum
+                # them so phantom-pair fix-ups (a ZREM landing on
+                # an index entry whose HASH field was already
+                # gone) still increment `total_zrem` — that's
+                # the signal that we cleaned up after a previous
+                # incomplete clear.
+                n = len(chunk_targets)
+                for reply in replies[:n]:
+                    if isinstance(reply, Exception):
+                        continue
+                    try:
+                        matches_hdel += int(reply or 0)
+                    except (TypeError, ValueError):
+                        pass
+                for reply in replies[n:]:
+                    if isinstance(reply, Exception):
+                        continue
+                    try:
+                        matches_zrem += int(reply or 0)
+                    except (TypeError, ValueError):
+                        pass
+
+            if progress_callback is not None:
+                snapshot = _UnackedChunkProgress(
+                    pass_num=passes_run,
+                    chunk_index=chunk_index,
+                    processed_delta=chunk_processed,
+                    matched_delta=matches_hdel - chunk_hdel_before,
+                    found_delta=matches_found - chunk_found_before,
+                    total_hdel=total_hdel + matches_hdel,
+                    total_zrem=total_zrem + matches_zrem,
+                    total_found=total_found + matches_found,
+                )
+                try:
+                    cancel_now = bool(progress_callback(snapshot))
+                except Exception:  # pragma: no cover - defensive
+                    log.exception(
+                        "redis_admin._streaming_unacked_clear: "
+                        "progress_callback raised; treating as no-cancel"
+                    )
+                    cancel_now = False
+                if cancel_now:
+                    raise _UnackedCancel()
+            chunk_index += 1
+            chunk_buffer.clear()
+
+        try:
+            for raw_field, raw_value in redis.hscan_iter(unacked_key, count=chunk):
+                field_name = _decode_value(raw_field)
+                decoded = _decode_value(raw_value)
+                envelope_str, _exchange, routing_key = _decode_unacked_value(decoded)
+                if envelope_str is None:
+                    meta = type(
+                        "M", (), {"task": None, "repoid": None, "commitid": None}
+                    )()
+                else:
+                    meta = parse_celery_envelope(envelope_str)
+                chunk_buffer.append((field_name, routing_key, meta))
+                if len(chunk_buffer) >= chunk:
+                    _flush_chunk()
+            _flush_chunk()
+        except _UnackedCancel:
+            cancelled = True
+
+        # End of pass. On pass 1 with keep_one we now know the
+        # full match set, so pick the lowest-deadline keeper via
+        # ZSCORE and HDEL+ZREM the rest in one big pipeline.
+        if (
+            pass_num == 0
+            and keep_one
+            and pass_matches
+            and not dry_run
+            and not cancelled
+        ):
+            keeper_field = _pick_lowest_deadline_keeper(
+                redis, pass_matches, unacked_index_key=unacked_index_key
+            )
+            targets = [f for f in pass_matches if f != keeper_field]
+            if targets:
+                pipe = redis.pipeline(transaction=False)
+                for field_name in targets:
+                    pipe.hdel(unacked_key, field_name)
+                for field_name in targets:
+                    pipe.zrem(unacked_index_key, field_name)
+                try:
+                    replies = pipe.execute(raise_on_error=False)
+                except TypeError:  # pragma: no cover - older clients
+                    try:
+                        replies = pipe.execute()
+                    except Exception:  # pragma: no cover - defensive
+                        replies = [0] * (2 * len(targets))
+                n = len(targets)
+                for reply in replies[:n]:
+                    if isinstance(reply, Exception):
+                        continue
+                    try:
+                        matches_hdel += int(reply or 0)
+                    except (TypeError, ValueError):
+                        pass
+                for reply in replies[n:]:
+                    if isinstance(reply, Exception):
+                        continue
+                    try:
+                        matches_zrem += int(reply or 0)
+                    except (TypeError, ValueError):
+                        pass
+
+        log.info(
+            "redis_admin.unacked_clear: pass=%d depth=%d "
+            "hdel_removed=%d zrem_removed=%d",
+            passes_run,
+            depth,
+            matches_hdel,
+            matches_zrem,
+        )
+
+        total_hdel += matches_hdel
+        total_zrem += matches_zrem
+        total_found += matches_found
+
+        if dry_run or cancelled:
+            break
+        if matches_found == 0:
+            break
+        if keep_one:
+            # `keep_one` has at most one keeper across all passes;
+            # if pass 1 cleared everything else we're done.
+            break
+
+    return _UnackedClearStats(
+        total_hdel=total_hdel,
+        total_zrem=total_zrem,
+        total_found=total_found,
+        first_match_field=first_match_field,
+        passes_run=passes_run,
+        cancelled=cancelled,
+    )
+
+
+class _UnackedCancel(Exception):
+    """Internal: control-flow signal used by `_streaming_unacked_clear`
+    to bail out of the HSCAN iterator on operator cancel without
+    threading a sentinel through the closure return values.
+    """
+
+
+def _pick_lowest_deadline_keeper(
+    redis,
+    fields: Iterable[str],
+    *,
+    unacked_index_key: str = _UNACKED_INDEX_KEY,
+) -> str | None:
+    """Return the `delivery_tag` with the smallest ZSCORE in
+    `unacked_index`, or the first field whose ZSCORE is missing.
+
+    The "smallest score = soonest visibility deadline" mapping
+    is Kombu's restore-loop semantic: lower score = earlier
+    deadline = sooner re-enqueued. So "keep the one most likely
+    to come back first" means keep the lowest-score match — the
+    one the operator's debug tooling is most likely to actually
+    catch in flight.
+
+    Fields with a missing ZSCORE (phantom HASH-without-ZSET
+    entries from a prior partial clear) sort *first* so we keep
+    them: they're never going to be re-enqueued by Kombu's
+    restore-loop on their own (no index entry), and clearing
+    them along with the rest of the matches would make the
+    keep_one semantic surprising on a half-cleared HASH.
+    """
+
+    fields_list = list(fields)
+    if not fields_list:
+        return None
+    best_field: str | None = None
+    best_score: float | None = None
+    for field_name in fields_list:
+        try:
+            score = redis.zscore(unacked_index_key, field_name)
+        except Exception:  # pragma: no cover - defensive
+            score = None
+        if score is None:
+            return field_name
+        score_f = float(score)
+        if best_score is None or score_f < best_score:
+            best_score = score_f
+            best_field = field_name
+    return best_field
+
+
+def unacked_clear(
+    targets: Iterable[UnackedQueueItem],
+    *,
+    user,
+    dry_run: bool = False,
+    keep_one: bool = False,
+) -> DeleteResult:
+    """Synchronously clear the given unacked messages.
+
+    Parallels `celery_broker_clear` but for the unacked HASH.
+    Targets must already be `UnackedQueueItem` rows materialised
+    from `UnackedQueueQuerySet`, which carry the `delivery_tag`
+    we need for HDEL+ZREM. Wraps in a sentry span and writes a
+    `LogEntry` audit row with `scope="unacked_clear"`.
+    """
+
+    span_name = "unacked_dry_run" if dry_run else "unacked_execute"
+    with sentry_sdk.start_span(op="redis.admin.delete", name=span_name) as span:
+        try:
+            span.set_tag("redis_admin.dry_run", dry_run)
+            span.set_tag("redis_admin.scope", "unacked_clear")
+        except AttributeError:  # pragma: no cover - older sdks
+            pass
+        return _unacked_clear(
+            targets, user=user, dry_run=dry_run, keep_one=keep_one, span=span
+        )
+
+
+def _unacked_clear(
+    targets: Iterable[UnackedQueueItem],
+    *,
+    user,
+    dry_run: bool,
+    keep_one: bool,
+    span,
+) -> DeleteResult:
+    # Gather the operator's per-message `(routing_key, task,
+    # repoid, commitid)` tuples and their delivery_tag samples
+    # for the audit log. Each materialised target carries an
+    # exact tuple — there are no wildcards on this path; the
+    # chunked job is the wildcard surface.
+    filter_set: set = set()
+    sample_source: list[str] = []
+    for target in targets:
+        if not isinstance(target, UnackedQueueItem):
+            log.warning(
+                "redis_admin.unacked_clear: ignoring non-unacked target %r",
+                type(target),
+            )
+            continue
+        if not target.delivery_tag:
+            continue
+        filter_set.add(
+            (
+                target.routing_key or None,
+                target.task_name or None,
+                target.repoid,
+                target.commitid or None,
+            )
+        )
+        sample_source.append(target.delivery_tag)
+
+    sample = tuple(sample_source[:_AUDIT_SAMPLE_SIZE])
+    families = ("unacked",) if filter_set else ()
+
+    if not filter_set:
+        result_count = 0
+        total_hdel = 0
+        total_zrem = 0
+        total_found = 0
+        passes_run = 0
+    else:
+        redis = _conn.get_connection(kind="broker")
+        stats = _streaming_unacked_clear(
+            redis,
+            frozenset(filter_set),
+            keep_one=keep_one,
+            dry_run=dry_run,
+        )
+        total_hdel = stats.total_hdel
+        total_zrem = stats.total_zrem
+        total_found = stats.total_found
+        passes_run = stats.passes_run
+        if dry_run:
+            # Mirror celery_broker_clear's keep_one preview:
+            # subtract one keeper if there are any matches at all
+            # (the unacked HASH is global, so there's exactly one
+            # keeper, not one per queue).
+            if keep_one and total_found > 0:
+                result_count = max(0, total_found - 1)
+            else:
+                result_count = total_found
+        else:
+            result_count = total_hdel
+
+    result = DeleteResult(
+        count=result_count,
+        sample=sample,
+        families=families,
+        dry_run=dry_run,
+        refused=(),
+    )
+
+    mode = (
+        "dry-run" if dry_run else ("all-but-first" if keep_one else "all-from-bucket")
+    )
+    _record_audit(
+        user=user,
+        scope="unacked_clear",
+        count=result.count,
+        refused=(),
+        sample=sample,
+        families=families,
+        dry_run=dry_run,
+        extra={
+            "mode": mode,
+            "passes_run": passes_run,
+            "total_hdel": total_hdel,
+            "total_zrem": total_zrem,
+            "total_found": total_found,
+        },
+    )
+    try:
+        span.set_data("redis_admin.count", result.count)
+        span.set_data("redis_admin.passes_run", passes_run)
+        span.set_data("redis_admin.total_hdel", total_hdel)
+        span.set_data("redis_admin.total_zrem", total_zrem)
+    except AttributeError:  # pragma: no cover - older sdks
+        pass
+    return result
+
+
+# ---- Chunked unacked clear jobs (background-thread variant) ---------------
+#
+# Same lifecycle pattern as the celery_broker chunked clear:
+# `start_unacked_clear_job` returns a `job_id` immediately, the
+# clear runs in a daemon thread, and the operator polls a status
+# hash for progress + drives cancellation through it. Job state
+# lives on the cache redis (NOT the broker) so a clear that
+# drains the unacked HASH doesn't accidentally evict its own
+# progress hash.
+_UNACKED_CLEAR_JOB_KEY_PREFIX: str = "redis_admin:unacked_clear_job"
+_UNACKED_CLEAR_JOB_TTL_SECONDS: int = 24 * 60 * 60
+_UNACKED_CLEAR_JOB_TERMINAL_STATES: frozenset[str] = frozenset(
+    {"completed", "cancelled", "failed"}
+)
+# Test-only thread handle. Same convention as
+# `_clear_job_threads`: production polls via the JSON status
+# endpoint; the dict is here so tests can `.join(timeout=...)`
+# deterministically.
+_unacked_clear_job_threads: dict[str, threading.Thread] = {}
+_unacked_clear_job_threads_lock = threading.Lock()
+
+
+def _unacked_job_key(job_id: str) -> str:
+    return f"{_UNACKED_CLEAR_JOB_KEY_PREFIX}:{job_id}"
+
+
+def start_unacked_clear_job(
+    *,
+    user,
+    routing_key: str | None = None,
+    task_name: str | None = None,
+    repoid: int | None = None,
+    commitid: str | None = None,
+    keep_one: bool = False,
+    dry_run: bool = False,
+) -> str:
+    """Spawn a background `unacked_clear` job; return its `job_id`.
+
+    Mirrors `start_celery_broker_clear_job` but takes a 4-axis
+    `(routing_key, task_name, repoid, commitid)` filter shape.
+    Initialises a hash at `redis_admin:unacked_clear_job:<job_id>`
+    on the cache redis with the operator's filter shape and the
+    snapshot `HLEN(unacked)` as `total_estimated`, then launches
+    a daemon thread that walks the HASH in chunks. The HTTP
+    request returns immediately so the gunicorn worker doesn't
+    sit on the actual clear; the operator polls the JSON status
+    view for progress.
+    """
+
+    job_id = str(uuid.uuid4())
+    cache = _conn.get_connection(kind="default")
+    try:
+        broker = _conn.get_connection(kind="broker")
+        total_estimated = int(broker.hlen(_UNACKED_KEY) or 0)
+    except Exception:  # pragma: no cover - broker outage path
+        total_estimated = 0
+
+    user_id = getattr(user, "id", None) or getattr(user, "pk", None) or 0
+    now = _utc_now_iso()
+    initial = {
+        "status": "pending",
+        "filter_routing_key": routing_key or "",
+        "filter_task": task_name or "",
+        "filter_repoid": "" if repoid is None else str(repoid),
+        "filter_commitid": commitid or "",
+        "dry_run": "1" if dry_run else "0",
+        "keep_one": "1" if keep_one else "0",
+        "user_id": str(user_id),
+        "started_at": now,
+        "updated_at": now,
+        "completed_at": "",
+        "total_estimated": str(total_estimated),
+        "processed": "0",
+        "matched": "0",
+        # `zrem_removed` is logged separately from `matched` so
+        # the operator's progress page can spot phantom-pair
+        # fix-ups (a ZREM landing on an index entry whose HASH
+        # field was already gone from a prior incomplete clear).
+        "zrem_removed": "0",
+        "passes_run": "0",
+        "error": "",
+        "cancel_requested": "0",
+    }
+    key = _unacked_job_key(job_id)
+    pipe = cache.pipeline(transaction=False)
+    pipe.hset(key, mapping=initial)
+    pipe.expire(key, _UNACKED_CLEAR_JOB_TTL_SECONDS)
+    pipe.execute()
+
+    thread = threading.Thread(
+        target=_run_unacked_clear_job,
+        kwargs={
+            "job_id": job_id,
+            "routing_key": routing_key,
+            "task_name": task_name,
+            "repoid": repoid,
+            "commitid": commitid,
+            "keep_one": keep_one,
+            "dry_run": dry_run,
+            "user": user,
+        },
+        name=f"redis_admin.unacked_clear_job.{job_id[:8]}",
+        daemon=True,
+    )
+    with _unacked_clear_job_threads_lock:
+        _unacked_clear_job_threads[job_id] = thread
+    thread.start()
+    return job_id
+
+
+def get_unacked_clear_job(job_id: str) -> dict[str, str] | None:
+    """Read the unacked job's state hash from cache redis.
+    Returns `None` when the hash is absent (unknown id, or the
+    24h TTL elapsed).
+    """
+
+    cache = _conn.get_connection(kind="default")
+    raw = cache.hgetall(_unacked_job_key(job_id))
+    if not raw:
+        return None
+    return _decode_job_hash(raw)
+
+
+def request_cancel_unacked_clear_job(job_id: str) -> bool:
+    """Set `cancel_requested=1` on the unacked job hash.
+    Idempotent: re-cancelling a cancelled or terminal job is a
+    no-op. Returns `True` when the hash existed, `False`
+    otherwise.
+    """
+
+    cache = _conn.get_connection(kind="default")
+    key = _unacked_job_key(job_id)
+    if not cache.exists(key):
+        return False
+    cache.hset(
+        key,
+        mapping={
+            "cancel_requested": "1",
+            "updated_at": _utc_now_iso(),
+        },
+    )
+    return True
+
+
+def _run_unacked_clear_job(
+    *,
+    job_id: str,
+    routing_key: str | None,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+    keep_one: bool,
+    dry_run: bool,
+    user,
+) -> None:
+    """Daemon-thread worker for `start_unacked_clear_job`.
+
+    Mirrors `_run_celery_broker_clear_job` but uses the
+    HASH-native streaming clear. Owns the lifecycle: flips
+    `status` to `running`, calls `_streaming_unacked_clear` with
+    a callback that updates the progress hash and polls
+    `cancel_requested`, then writes the terminal `status` and
+    audit row.
+
+    Exceptions are swallowed and surfaced through the job hash's
+    `error` field instead of crashing the gunicorn worker.
+    """
+
+    try:
+        _run_unacked_clear_job_body(
+            job_id=job_id,
+            routing_key=routing_key,
+            task_name=task_name,
+            repoid=repoid,
+            commitid=commitid,
+            keep_one=keep_one,
+            dry_run=dry_run,
+            user=user,
+        )
+    finally:
+        with _unacked_clear_job_threads_lock:
+            _unacked_clear_job_threads.pop(job_id, None)
+        close_old_connections()
+
+
+def _run_unacked_clear_job_body(
+    *,
+    job_id: str,
+    routing_key: str | None,
+    task_name: str | None,
+    repoid: int | None,
+    commitid: str | None,
+    keep_one: bool,
+    dry_run: bool,
+    user,
+) -> None:
+    """Inner body of the worker, separated from
+    `_run_unacked_clear_job` so the wrapper can own the
+    test-handle cleanup in a `finally` block. Same split rationale
+    as `_run_celery_broker_clear_job_body`.
+    """
+
+    cache = _conn.get_connection(kind="default")
+    key = _unacked_job_key(job_id)
+    cache.hset(key, "status", "running")
+    cache.hset(key, "updated_at", _utc_now_iso())
+
+    filter_tuples = frozenset(
+        {_substitute_filter_any_unacked(routing_key, task_name, repoid, commitid)}
+    )
+
+    def _progress_callback(snapshot: _UnackedChunkProgress) -> bool:
+        try:
+            pipe = cache.pipeline(transaction=False)
+            if snapshot.processed_delta:
+                pipe.hincrby(key, "processed", snapshot.processed_delta)
+            if snapshot.matched_delta:
+                pipe.hincrby(key, "matched", snapshot.matched_delta)
+            # ZREM count is reported as a delta on the same
+            # cadence as HDEL; we recover it here by computing
+            # the cumulative-vs-stored difference. Avoids
+            # threading another delta through the snapshot
+            # type.
+            pipe.hset(key, "zrem_removed", str(snapshot.total_zrem))
+            pipe.hset(
+                key,
+                mapping={
+                    "passes_run": str(snapshot.pass_num),
+                    "updated_at": _utc_now_iso(),
+                },
+            )
+            pipe.execute()
+        except Exception:  # pragma: no cover - cache outage shouldn't kill clear
+            log.exception(
+                "redis_admin.unacked_clear_job(%s): failed to write progress",
+                job_id,
+            )
+        try:
+            cancel_raw = cache.hget(key, "cancel_requested")
+        except Exception:  # pragma: no cover - cache outage
+            return False
+        if cancel_raw is None:
+            return False
+        if isinstance(cancel_raw, bytes):
+            return cancel_raw == b"1"
+        return cancel_raw == "1"
+
+    error_str: str | None = None
+    stats: _UnackedClearStats | None = None
+    try:
+        broker = _conn.get_connection(kind="broker")
+        stats = _streaming_unacked_clear(
+            broker,
+            filter_tuples,
+            keep_one=keep_one,
+            dry_run=dry_run,
+            progress_callback=_progress_callback,
+        )
+    except Exception as exc:
+        log.exception("redis_admin.unacked_clear_job(%s): worker failed", job_id)
+        error_str = str(exc)
+
+    finalise: dict[str, str] = {
+        "completed_at": _utc_now_iso(),
+        "updated_at": _utc_now_iso(),
+    }
+    if error_str is not None:
+        finalise["status"] = "failed"
+        finalise["error"] = error_str
+    elif stats is not None and stats.cancelled:
+        finalise["status"] = "cancelled"
+    else:
+        finalise["status"] = "completed"
+    try:
+        cache.hset(key, mapping=finalise)
+    except Exception:  # pragma: no cover - cache outage at finalise
+        log.exception(
+            "redis_admin.unacked_clear_job(%s): failed to write terminal state",
+            job_id,
+        )
+
+    if dry_run:
+        mode = "chunked-dry-run"
+    elif keep_one:
+        mode = "chunked-all-but-first"
+    else:
+        mode = "chunked-all-from-bucket"
+    sample = (f"unacked#filter:{routing_key or '*'}",)
+    families = ("unacked",)
+    extra: dict[str, Any] = {
+        "mode": mode,
+        "job_id": job_id,
+        "cancelled": bool(stats and stats.cancelled),
+    }
+    if stats is not None:
+        extra.update(
+            {
+                "passes_run": stats.passes_run,
+                "total_hdel": stats.total_hdel,
+                "total_zrem": stats.total_zrem,
+                "total_found": stats.total_found,
+            }
+        )
+        count = stats.total_found if dry_run else stats.total_hdel
+    else:
+        count = 0
+    if error_str is not None:
+        extra["error"] = error_str
+    _record_audit(
+        user=user,
+        scope="unacked_clear",
         count=count,
         refused=(),
         sample=sample,

--- a/apps/codecov-api/redis_admin/static/redis_admin/js/unacked_clear_progress.js
+++ b/apps/codecov-api/redis_admin/static/redis_admin/js/unacked_clear_progress.js
@@ -1,0 +1,204 @@
+// Polls the chunked unacked clear job's status JSON endpoint,
+// updates the progress bar + counters, and hijacks the cancel form
+// to fire via fetch(). Same shape as celery_clear_progress.js (and
+// reuses the celery_clear_progress.css stylesheet) but reads the
+// HASH-native counter `zrem_removed` instead of the celery-specific
+// `drifted`. Loaded as an external file (not inline) so the
+// production CSP — `'self'` + a single fixed sha256 hash for inline
+// scripts — does not block it. See settings_base.py CSP_DEFAULT_SRC.
+//
+// The element IDs reuse the `celery-clear-*` prefix so we can share
+// the celery_clear_progress.css stylesheet without duplicating its
+// theme-aware rules; the JS is forked rather than parameterised
+// because the field rename was not worth a runtime conditional.
+(function () {
+  'use strict';
+
+  var TERMINAL_STATES = { completed: 1, cancelled: 1, failed: 1 };
+  var POLL_INTERVAL_OK_MS = 1000;
+  var POLL_BACKOFF_STEPS_MS = [1000, 2000, 5000];
+  var POLL_BACKOFF_MAX_MS = 5000;
+  var STATE_CLASSES = [
+    'celery-clear-status-pending',
+    'celery-clear-status-running',
+    'celery-clear-status-completed',
+    'celery-clear-status-cancelled',
+    'celery-clear-status-failed'
+  ];
+
+  function $(id) { return document.getElementById(id); }
+
+  function getCsrfToken(form) {
+    if (!form) return '';
+    var input = form.querySelector('input[name=csrfmiddlewaretoken]');
+    return input ? input.value : '';
+  }
+
+  function setText(id, value) {
+    var el = $(id);
+    if (el) el.textContent = value;
+  }
+
+  function setStatusPill(status) {
+    var pill = $('celery-clear-status-pill');
+    if (!pill) return;
+    pill.textContent = status;
+    pill.dataset.status = status;
+    for (var i = 0; i < STATE_CLASSES.length; i += 1) {
+      pill.classList.remove(STATE_CLASSES[i]);
+    }
+    pill.classList.add('celery-clear-status-' + status);
+  }
+
+  function updateProgress(snapshot) {
+    var bar = $('celery-clear-progress-bar');
+    var pct = $('celery-clear-progress-pct');
+    var total = snapshot.total_estimated || 0;
+    var processed = snapshot.processed || 0;
+    if (bar) {
+      bar.value = processed;
+      bar.max = total > 0 ? total : 1;
+    }
+    if (pct) {
+      if (total > 0) {
+        var p = Math.min(100, Math.floor((processed / total) * 100));
+        pct.textContent = p + '%';
+      } else {
+        pct.textContent = '—';
+      }
+    }
+    setText('celery-clear-matched', snapshot.matched);
+    setText('celery-clear-processed', snapshot.processed);
+    setText('celery-clear-total-estimated', snapshot.total_estimated);
+    setText('celery-clear-zrem', snapshot.zrem_removed);
+    setText('celery-clear-passes', snapshot.passes_run);
+    setText('celery-clear-started-at', snapshot.started_at || '—');
+    setText('celery-clear-updated-at', snapshot.updated_at || '—');
+    setText('celery-clear-completed-at', snapshot.completed_at || '—');
+    var errorEl = $('celery-clear-error');
+    var errorRow = $('celery-clear-error-row');
+    if (errorEl && errorRow) {
+      if (snapshot.error) {
+        errorEl.textContent = snapshot.error;
+        errorRow.classList.remove('celery-clear-hidden');
+      } else {
+        errorEl.textContent = '';
+        errorRow.classList.add('celery-clear-hidden');
+      }
+    }
+  }
+
+  function isTerminal(status) {
+    return Object.prototype.hasOwnProperty.call(TERMINAL_STATES, status);
+  }
+
+  function setTerminalUI(status) {
+    var cancelBtn = $('celery-clear-cancel-button');
+    if (cancelBtn) {
+      cancelBtn.disabled = true;
+      cancelBtn.textContent = (
+        status === 'cancelled' ? 'Cancelled'
+          : status === 'failed' ? 'Failed'
+            : 'Done'
+      );
+    }
+    var back = $('celery-clear-back-link');
+    if (back) back.classList.remove('celery-clear-disabled-link');
+  }
+
+  function init() {
+    var root = $('celery-clear-progress-root');
+    if (!root) return;
+    var statusUrl = root.dataset.statusUrl;
+    var cancelUrl = root.dataset.cancelUrl;
+    if (!statusUrl) return;
+
+    var initialStatus = root.dataset.initialStatus || 'pending';
+    var initialTerminal = root.dataset.isTerminal === '1';
+    if (initialTerminal) {
+      setTerminalUI(initialStatus);
+      return;
+    }
+
+    var backoffStep = 0;
+    var pollTimer = null;
+    var inFlight = false;
+
+    function scheduleNextPoll(intervalMs) {
+      if (pollTimer) clearTimeout(pollTimer);
+      pollTimer = setTimeout(poll, intervalMs);
+    }
+
+    function poll() {
+      if (inFlight) return;
+      inFlight = true;
+      fetch(statusUrl, { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+        .then(function (r) {
+          if (!r.ok) {
+            throw new Error('status HTTP ' + r.status);
+          }
+          return r.json();
+        })
+        .then(function (snapshot) {
+          backoffStep = 0;
+          updateProgress(snapshot);
+          var status = snapshot.status || 'pending';
+          setStatusPill(status);
+          var cancelBtn = $('celery-clear-cancel-button');
+          if (cancelBtn && snapshot.cancel_requested && !isTerminal(status)) {
+            cancelBtn.textContent = 'Cancelling…';
+            cancelBtn.disabled = true;
+          }
+          if (isTerminal(status)) {
+            setTerminalUI(status);
+            return;
+          }
+          scheduleNextPoll(POLL_INTERVAL_OK_MS);
+        })
+        .catch(function () {
+          var step = backoffStep < POLL_BACKOFF_STEPS_MS.length
+            ? POLL_BACKOFF_STEPS_MS[backoffStep]
+            : POLL_BACKOFF_MAX_MS;
+          backoffStep += 1;
+          scheduleNextPoll(step);
+        })
+        .then(function () { inFlight = false; });
+    }
+
+    var cancelForm = $('celery-clear-cancel-form');
+    if (cancelForm && cancelUrl) {
+      cancelForm.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var cancelBtn = $('celery-clear-cancel-button');
+        if (cancelBtn) {
+          if (cancelBtn.disabled) return;
+          cancelBtn.disabled = true;
+          cancelBtn.textContent = 'Cancelling…';
+        }
+        fetch(cancelUrl, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'X-CSRFToken': getCsrfToken(cancelForm),
+            'Accept': 'application/json'
+          }
+        })
+          .then(function () { /* poll will pick up the new state */ })
+          .catch(function () {
+            if (cancelBtn) {
+              cancelBtn.disabled = false;
+              cancelBtn.textContent = 'Cancel clear';
+            }
+          });
+      });
+    }
+
+    poll();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/_frequency_chart.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/_frequency_chart.html
@@ -1,0 +1,209 @@
+{% load admin_urls %}
+
+{% comment %}
+Frequency chart for the unacked drill-down page.
+
+Shape (mirrors the celery_broker chart, with one extra
+`routing_key` column since the unacked HASH spans every queue):
+
+* `chart.routing_key` — the routing_key we drilled into.
+* `chart.total_visible` — total messages in the snapshot the
+  chart was computed from.
+* `chart.total_depth` — `HLEN(unacked)` at chart-build time.
+  When > `total_visible` we surface a "showing top N of M"
+  banner so operators know percentages are over the visible
+  window, not the whole HASH.
+* `chart.buckets` — list of view-model dicts shaped as
+  `{routing_key, task_name, repoid, repo_display,
+  repo_change_url, commitid, count, pct}`. Already sorted;
+  rendered top-to-bottom.
+* `chart.clear_by_filter_url` — base URL for the row-level
+  "Clear" form action; we GET it with `routing_key` /
+  `task_name` / `repoid` / `commitid` plus four display-only
+  count hints so the preview page can render an approximate
+  "will clear ~X messages (~Y%)" callout without an HSCAN
+  sweep on the GET render.
+* `chart.can_clear` — boolean toggling the "Clear" button
+  (superuser-only).
+{% endcomment %}
+
+<div class="module" id="celery-frequency-chart" style="margin-bottom: 16px;">
+  <h2>Top {{ chart.buckets|length }} (routing_key, repoid, commitid, task) tuples in
+    unacked</h2>
+  {% if chart.total_depth > chart.total_visible %}
+    <p class="help">
+      Showing top {{ chart.buckets|length }} of
+      {{ chart.total_visible }} sampled messages
+      (HASH depth: {{ chart.total_depth }}). Percentages are over
+      the sampled window, not the full HASH.
+    </p>
+  {% else %}
+    <p class="help">
+      Showing top {{ chart.buckets|length }} of
+      {{ chart.total_visible }} message(s).
+    </p>
+  {% endif %}
+  <table class="celery-frequency">
+    <thead>
+      <tr>
+        <th scope="col">routing key</th>
+        <th scope="col">repoid</th>
+        <th scope="col">commitid</th>
+        <th scope="col">task</th>
+        <th scope="col" class="num">count</th>
+        <th scope="col">share</th>
+        {% if chart.can_clear %}
+          <th scope="col">action</th>
+        {% endif %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for bucket in chart.buckets %}
+        <tr>
+          <td>
+            {% if bucket.routing_key %}
+              <code>{{ bucket.routing_key }}</code>
+            {% else %}
+              —
+            {% endif %}
+          </td>
+          <td>
+            {% if bucket.repoid is not None %}
+              {% if bucket.repo_change_url %}
+                <a href="{{ bucket.repo_change_url }}" title="repoid={{ bucket.repoid }}">{{ bucket.repo_display|default:bucket.repoid }}</a>
+              {% else %}
+                <span title="repoid={{ bucket.repoid }}">{{ bucket.repo_display|default:bucket.repoid }}</span>
+              {% endif %}
+            {% else %}
+              —
+            {% endif %}
+          </td>
+          <td>
+            {% if bucket.commitid %}
+              <span title="{{ bucket.commitid }}">{{ bucket.commitid|slice:":7" }}</span>
+            {% else %}
+              —
+            {% endif %}
+          </td>
+          <td>
+            {% if bucket.task_name %}
+              <span class="celery-task-cell" title="{{ bucket.task_name }}">{{ bucket.task_name }}</span>
+            {% else %}
+              —
+            {% endif %}
+          </td>
+          <td class="num">{{ bucket.count }}</td>
+          <td>
+            <div class="celery-bar-track" aria-label="{{ bucket.pct|floatformat:1 }}% of sampled messages">
+              <div class="celery-bar-fill" style="width: {{ bucket.pct|floatformat:1 }}%;"></div>
+              <span class="celery-bar-pct">{{ bucket.pct|floatformat:1 }}%</span>
+            </div>
+          </td>
+          {% if chart.can_clear %}
+            <td class="celery-actions">
+              {% comment %}
+              Single "Clear" button per row. The form GETs the
+              `clear_by_filter` preview page rather than POSTing,
+              same pattern as the celery_broker chart: the four
+              `bucket_*` / `total_*` hints below are display-only
+              (non-secret, idempotent, bookmarkable) and the
+              preview page does ZERO Redis I/O on its GET render.
+              {% endcomment %}
+              <form method="get" action="{{ chart.clear_by_filter_url }}" class="celery-action-form">
+                {% if bucket.routing_key %}
+                  <input type="hidden" name="routing_key" value="{{ bucket.routing_key }}">
+                {% elif chart.routing_key %}
+                  <input type="hidden" name="routing_key" value="{{ chart.routing_key }}">
+                {% endif %}
+                {% if bucket.task_name %}
+                  <input type="hidden" name="task_name" value="{{ bucket.task_name }}">
+                {% endif %}
+                {% if bucket.repoid is not None %}
+                  <input type="hidden" name="repoid" value="{{ bucket.repoid }}">
+                {% endif %}
+                {% if bucket.commitid %}
+                  <input type="hidden" name="commitid" value="{{ bucket.commitid }}">
+                {% endif %}
+                <input type="hidden" name="bucket_count" value="{{ bucket.count }}">
+                <input type="hidden" name="bucket_pct" value="{{ bucket.pct }}">
+                <input type="hidden" name="total_depth" value="{{ chart.total_depth }}">
+                <input type="hidden" name="total_visible" value="{{ chart.total_visible }}">
+                <button type="submit" class="button celery-clear-queue-btn">
+                  Clear&hellip;
+                </button>
+              </form>
+            </td>
+          {% endif %}
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  /* Reuse the celery_broker chart's theme-safe styles. We share
+     the `#celery-frequency-chart` ID with the celery_broker
+     chart fragment so a single static stylesheet covers both
+     surfaces; rules below are scoped under that ID. */
+  #celery-frequency-chart table.celery-frequency {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  #celery-frequency-chart table.celery-frequency th,
+  #celery-frequency-chart table.celery-frequency td {
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border-color, var(--hairline-color, #ccc));
+    vertical-align: middle;
+  }
+  #celery-frequency-chart table.celery-frequency th.num,
+  #celery-frequency-chart table.celery-frequency td.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  #celery-frequency-chart table.celery-frequency td.celery-actions {
+    white-space: nowrap;
+  }
+  #celery-frequency-chart .celery-action-form {
+    display: inline-flex;
+    margin: 0;
+  }
+  #celery-frequency-chart .celery-action-form button {
+    margin: 0;
+  }
+  #celery-frequency-chart table.celery-frequency .celery-task-cell {
+    display: inline-block;
+    max-width: 28em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
+  }
+  #celery-frequency-chart .celery-bar-track {
+    position: relative;
+    height: 14px;
+    width: 100%;
+    min-width: 120px;
+    background: var(--darkened-bg, var(--body-bg, transparent));
+    border: 1px solid var(--border-color, var(--hairline-color, #ccc));
+    border-radius: 2px;
+  }
+  #celery-frequency-chart .celery-bar-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    background: var(--primary, currentColor);
+    opacity: 0.65;
+    border-radius: 2px;
+  }
+  #celery-frequency-chart .celery-bar-pct {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 0 6px;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/change_list.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/change_list.html
@@ -1,0 +1,45 @@
+{% extends "admin/change_list.html" %}
+{% load admin_urls %}
+{% load static %}
+
+{% comment %}
+Unacked drill-down: when `routing_key` is set we inject a lazy
+frequency chart above the result list. Same loader pattern as
+the celery_broker drill-down — the chart is fetched async from
+`chart_fragment_view` so the changelist renders immediately
+regardless of the unacked HASH's depth.
+
+The fetch helper + loader styles are the same external assets
+used by the celery_broker chart (`celery_chart_fragment.js` /
+`celery_chart_fragment.css`); they key on the
+`#celery-chart-fragment` element id rather than anything
+celery-specific, so reusing them keeps CSP setup minimal
+(production admin allows `'self'` + a single fixed sha256 for
+inline scripts) and avoids a second copy of the same fetch
+dance.
+
+In summary mode (no `routing_key`) the block renders nothing
+extra — the summary changelist has one row carrying
+`HLEN(unacked)` and there's no per-routing-key axis to chart.
+{% endcomment %}
+{% block extrastyle %}
+  {{ block.super }}
+  {% if routing_key %}
+    <link rel="stylesheet" href="{% static 'redis_admin/css/celery_chart_fragment.css' %}">
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+  {% if routing_key %}
+    <div id="celery-chart-fragment"
+         data-fragment-url="{% url 'admin:unackedqueueitem-chart-fragment' routing_key=routing_key %}">
+      <div class="celery-chart-loader" role="status" aria-live="polite">
+        <div class="celery-chart-loader__spinner" aria-hidden="true"></div>
+        <p class="celery-chart-loader__label">Loading frequency chart&hellip;</p>
+        <p class="celery-chart-loader__hint">Sampling up to {{ scan_limit_label|default:"20,000" }} unacked messages for routing key <code>{{ routing_key }}</code> &mdash; this can take a few seconds on a deep HASH.</p>
+      </div>
+    </div>
+    <script src="{% static 'redis_admin/js/celery_chart_fragment.js' %}" defer></script>
+  {% endif %}
+  {{ block.super }}
+{% endblock %}

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/change_list.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/change_list.html
@@ -3,11 +3,11 @@
 {% load static %}
 
 {% comment %}
-Unacked drill-down: when `routing_key` is set we inject a lazy
-frequency chart above the result list. Same loader pattern as
-the celery_broker drill-down — the chart is fetched async from
-`chart_fragment_view` so the changelist renders immediately
-regardless of the unacked HASH's depth.
+Unacked drill-down: when a specific `routing_key` is set we
+inject a lazy frequency chart above the result list. Same
+loader pattern as the celery_broker drill-down — the chart is
+fetched async from `chart_fragment_view` so the changelist
+renders immediately regardless of the unacked HASH's depth.
 
 The fetch helper + loader styles are the same external assets
 used by the celery_broker chart (`celery_chart_fragment.js` /
@@ -21,6 +21,14 @@ dance.
 In summary mode (no `routing_key`) the block renders nothing
 extra — the summary changelist has one row carrying
 `HLEN(unacked)` and there's no per-routing-key axis to chart.
+
+In `view_all=1` mode (the summary's drill-in flag) we also
+omit the chart: the chart-fragment URL requires a specific
+`routing_key` kwarg and aggregating the chart across every
+routing_key at once would mix unrelated queues into the same
+buckets. The operator instead clicks a specific
+`routing_key` from the sidebar filter to see the chart for
+that queue.
 {% endcomment %}
 {% block extrastyle %}
   {{ block.super }}

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/clear_by_filter.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/clear_by_filter.html
@@ -1,0 +1,248 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{{ changelist_url }}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; Clear by filter
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+  <p>
+    Clears every Kombu unacked message whose decoded envelope matches
+    the <em>(routing_key, task_name, repoid, commitid)</em> filter
+    below. Each match resolves to a paired
+    <code>HDEL unacked &lt;delivery_tag&gt;</code> +
+    <code>ZREM unacked_index &lt;delivery_tag&gt;</code> in a Redis
+    pipeline; skipping the ZREM would leave a phantom in
+    <code>unacked_index</code> that points at a non-existent HASH
+    field and break Kombu's restore-loop, so the pairing is
+    enforced unconditionally.
+  </p>
+  <p>
+    Three actions are available below. <strong>Dry-run</strong> is
+    the safe first move &mdash; it writes a <code>LogEntry</code>
+    under <code>scope=&quot;unacked_clear&quot;</code> but leaves
+    the HASH untouched. The two destructive actions both gate on
+    the typed-confirmation field; both also write the same audit
+    log entry on success. All three fan out to a chunked
+    background-job worker that streams the HASH and reports exact
+    match counts as it scans &mdash; this preview page itself does
+    no Redis I/O.
+  </p>
+
+  {# ---- Filter rows: routing_key, task, repoid (linked), commit (truncated) ---- #}
+  <fieldset class="module">
+    <h2>Filter</h2>
+    <table class="celery-clear-filter">
+      <tr>
+        <th scope="row">Routing key</th>
+        <td>
+          {% if routing_key %}<code>{{ routing_key }}</code>{% else %}<em>(any &mdash; spans every queue)</em>{% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th scope="row">Task</th>
+        <td>
+          {% if task_name %}<code>{{ task_name }}</code>{% else %}<em>(any)</em>{% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th scope="row">Repo</th>
+        <td>
+          {% if repoid is not None %}
+            {% if repo_change_url %}
+              <a href="{{ repo_change_url }}" title="repoid={{ repoid }}"><code>{{ repoid }}</code></a>
+            {% else %}
+              <code>{{ repoid }}</code>
+            {% endif %}
+          {% else %}
+            <em>(any)</em>
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th scope="row">Commit</th>
+        <td>
+          {% if commitid %}
+            <code title="{{ commitid }}">{{ commitid|slice:":7" }}</code>
+          {% else %}
+            <em>(any)</em>
+          {% endif %}
+        </td>
+      </tr>
+    </table>
+  </fieldset>
+
+  {# ---- Approximate-count callout (no Redis call; values come from the chart) ---- #}
+  {#
+    The chart already has the bucket count and HLEN from its
+    HSCAN snapshot, so the approximate "will clear ~X" string is
+    derived in pure Python in the view (`approx` dict). When any
+    of the four hints is missing we render the "not available"
+    fallback instead of computing a misleading number. The
+    chunked background-job worker computes the exact match count
+    as it walks so the audit log stays precise.
+  #}
+  <fieldset class="module">
+    <h2>Approximate impact</h2>
+    {% if approx %}
+      <p class="celery-approx-callout">
+        Will clear approximately
+        <strong>{{ approx.count|default_if_none:"&mdash;" }}</strong>
+        message(s)
+        {% if approx.pct is not None %}
+          (<strong>~{{ approx.pct|floatformat:1 }}%</strong> of the
+          unacked HASH at depth ~{{ approx.depth }}).
+        {% else %}
+          (HASH depth ~{{ approx.depth }}).
+        {% endif %}
+      </p>
+      <p class="help">
+        Approximation derived from the chart's sampled-window
+        bucket size projected onto the live HASH depth; the
+        chunked clear will compute the exact match count as it
+        scans.
+      </p>
+    {% else %}
+      <p class="celery-approx-callout celery-approx-unknown">
+        <em>Approximate count not available</em> &mdash; the
+        chunked clear will compute the exact match count as it
+        scans.
+      </p>
+    {% endif %}
+  </fieldset>
+
+  <form method="post" novalidate>
+    {% csrf_token %}
+    {% if routing_key %}<input type="hidden" name="routing_key" value="{{ routing_key }}">{% endif %}
+    {% if task_name %}<input type="hidden" name="task_name" value="{{ task_name }}">{% endif %}
+    {% if repoid is not None %}<input type="hidden" name="repoid" value="{{ repoid }}">{% endif %}
+    {% if commitid %}<input type="hidden" name="commitid" value="{{ commitid }}">{% endif %}
+    {# Round-trip the chart's display hints so a typed-confirm
+       failure doesn't drop the approximate-count callout. Same
+       pattern as the celery_broker preview. #}
+    {% if bucket_count_hint %}<input type="hidden" name="bucket_count" value="{{ bucket_count_hint }}">{% endif %}
+    {% if bucket_pct_hint %}<input type="hidden" name="bucket_pct" value="{{ bucket_pct_hint }}">{% endif %}
+    {% if total_visible_hint %}<input type="hidden" name="total_visible" value="{{ total_visible_hint }}">{% endif %}
+    {% if total_depth_hint %}<input type="hidden" name="total_depth" value="{{ total_depth_hint }}">{% endif %}
+
+    <fieldset class="module">
+      <h2>Confirm and clear</h2>
+      <div class="form-row{% if confirm_error %} errors{% endif %}">
+        <div>
+          {% if confirm_error %}<ul class="errorlist"><li>{{ confirm_error }}</li></ul>{% endif %}
+          <label for="id_typed_confirm">Type <code>{{ expected_confirm }}</code> to confirm:</label>
+          <input type="text" name="typed_confirm" id="id_typed_confirm" value="{{ typed_confirm }}" autocomplete="off">
+          <div class="help">
+            Re-type the value above to enable the destructive
+            actions on the right. Dry-run does not require it.
+            {% if not routing_key %}
+            (When the routing_key filter is unset, the typed
+            confirmation is the literal <code>unacked</code>
+            because the clear spans every queue.)
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
+      {% comment %}
+      Three submit buttons share the form. Server-side dispatch
+      on the `action` value:
+
+      * `dry_run` &mdash; neutral / `default` styling. Spawns the
+        chunked worker with `dry_run=True`; HASH untouched.
+        Writes a `LogEntry` on completion.
+      * `clear_keep_one` &mdash; destructive. Clears every match
+        EXCEPT the one with the lowest `ZSCORE` from
+        `unacked_index` (i.e. the message Kombu is most likely
+        to re-enqueue first via its restore-loop). "Drop the
+        duplicate retries but leave one in flight so the
+        operator's debug tooling can catch it."
+      * `clear_all` &mdash; destructive. Clears every match.
+      {% endcomment %}
+      <div class="submit-row celery-clear-actions">
+        <button type="submit" name="action" value="dry_run" class="default">
+          Dry-run (audit only, no mutations)
+        </button>
+        <div class="celery-destructive-actions">
+          <button type="submit" name="action" value="clear_keep_one"
+                  class="button celery-destructive-button celery-clear-keep-one">
+            Clear all but lowest-deadline
+          </button>
+          <button type="submit" name="action" value="clear_all"
+                  class="button celery-destructive-button celery-clear-all">
+            Clear all matching unacked messages
+          </button>
+        </div>
+      </div>
+    </fieldset>
+
+    <p>
+      <a href="{{ changelist_url }}">&larr; back to unacked messages</a>
+    </p>
+  </form>
+
+</div>
+
+<style>
+  /* Mirrors the celery_broker preview's theme-safe styles. */
+  .celery-clear-filter {
+    border-collapse: collapse;
+  }
+  .celery-clear-filter th,
+  .celery-clear-filter td {
+    padding: 4px 12px 4px 0;
+    text-align: left;
+    vertical-align: top;
+  }
+  .celery-clear-filter th {
+    width: 8em;
+    font-weight: 600;
+    color: var(--body-quiet-color, inherit);
+  }
+  .celery-approx-callout {
+    font-size: 1.05em;
+    margin: 0.25em 0;
+  }
+  .celery-approx-unknown {
+    color: var(--body-quiet-color, inherit);
+  }
+  .celery-clear-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em 1em;
+    align-items: flex-start;
+  }
+  .celery-destructive-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75em;
+    margin-left: auto;
+    padding-left: 1em;
+    border-left: 1px solid var(--border-color, var(--hairline-color, #ccc));
+  }
+  .celery-destructive-button {
+    color: var(--error-fg, #ba2121);
+    font-weight: 600;
+  }
+  .celery-destructive-button:hover,
+  .celery-destructive-button:focus {
+    color: var(--error-fg, #ba2121);
+    text-decoration: underline;
+  }
+  .celery-destructive-actions > .celery-clear-all {
+    margin-top: 0.25em;
+    border-top: 1px dashed var(--border-color, var(--hairline-color, #ccc));
+    padding-top: 0.75em;
+  }
+</style>
+{% endblock %}

--- a/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/clear_by_filter_progress.html
+++ b/apps/codecov-api/redis_admin/templates/admin/redis_admin/unackedqueueitem/clear_by_filter_progress.html
@@ -1,0 +1,154 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% comment %}
+Progress page for a chunked unacked clear job. Mirrors the
+celery_broker progress template but reports the HASH-native
+counter `zrem_removed` (the number of `unacked_index` ZSET
+entries we removed alongside the matching HASH fields) rather
+than the celery-specific `drifted` (LSET out-of-range count).
+
+CSP-compliant: all JS / CSS loads via {% static %} from
+`redis_admin/static/redis_admin/...`. The CSS file is shared
+with the celery_broker progress page (rules are theme-safe and
+field-name-agnostic); the JS is forked because it reads
+`zrem_removed` from the status JSON.
+
+The initial server-side render is informative even before JS
+loads: it surfaces the job's status, filter shape, and current
+counters so an operator on a flaky network or with JS disabled
+still sees the run is happening.
+{% endcomment %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list celery-clear-progress{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'redis_admin/css/celery_clear_progress.css' %}">
+{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{{ changelist_url }}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; Clear progress
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+  <div id="celery-clear-progress-root"
+       class="celery-clear-progress-root"
+       data-job-id="{{ job_id }}"
+       data-status-url="{{ status_url }}"
+       data-cancel-url="{{ cancel_url }}"
+       data-changelist-url="{{ changelist_url }}"
+       data-initial-status="{{ status }}"
+       data-is-terminal="{{ is_terminal|yesno:'1,0' }}">
+
+    <fieldset class="module">
+      <h2>
+        Clearing <code>unacked</code>{% if routing_key %} (routing key <code>{{ routing_key }}</code>){% endif %}
+        <span class="celery-clear-job-id" title="{{ job_id }}">{{ job_id|slice:":8" }}…</span>
+      </h2>
+      <p class="celery-clear-summary">
+        Status:
+        <span id="celery-clear-status-pill"
+              class="celery-clear-status-pill celery-clear-status-{{ status }}"
+              data-status="{{ status }}">{{ status }}</span>
+        {% if dry_run %}<span class="celery-clear-dry-run-tag">dry-run</span>{% endif %}
+        {% if keep_one %}<span class="celery-clear-keep-one-tag">keep-one</span>{% endif %}
+      </p>
+
+      <p>
+        Filter:
+        Routing key: {% if filter_routing_key %}<code>{{ filter_routing_key }}</code>{% else %}<em>(any)</em>{% endif %} ·
+        Task: {% if filter_task %}<code>{{ filter_task }}</code>{% else %}<em>(any)</em>{% endif %} ·
+        Repo: {% if filter_repoid %}<code>{{ filter_repoid }}</code>{% else %}<em>(any)</em>{% endif %} ·
+        Commit: {% if filter_commitid %}<code title="{{ filter_commitid }}">{{ filter_commitid|slice:":7" }}</code>{% else %}<em>(any)</em>{% endif %}
+      </p>
+    </fieldset>
+
+    <fieldset class="module celery-clear-progress-card">
+      <h2>Progress</h2>
+
+      <div class="celery-clear-progress-bar-wrap">
+        <progress id="celery-clear-progress-bar"
+                  class="celery-clear-progress-bar"
+                  value="{{ processed }}"
+                  max="{{ total_estimated|default:1 }}"></progress>
+        <span id="celery-clear-progress-pct" class="celery-clear-progress-pct">
+          {% if total_estimated > 0 %}
+            {% widthratio processed total_estimated 100 %}%
+          {% else %}
+            —
+          {% endif %}
+        </span>
+      </div>
+
+      <dl class="celery-clear-counters">
+        <div class="celery-clear-counter">
+          <dt>HDEL matched</dt>
+          <dd id="celery-clear-matched">{{ matched }}</dd>
+        </div>
+        <div class="celery-clear-counter">
+          <dt>Processed</dt>
+          <dd>
+            <span id="celery-clear-processed">{{ processed }}</span>
+            <span class="celery-clear-counter-denom">
+              / <span id="celery-clear-total-estimated">{{ total_estimated }}</span>
+            </span>
+          </dd>
+        </div>
+        <div class="celery-clear-counter">
+          <dt>ZREM removed</dt>
+          <dd id="celery-clear-zrem">{{ zrem_removed }}</dd>
+        </div>
+        <div class="celery-clear-counter">
+          <dt>Pass</dt>
+          <dd id="celery-clear-passes">{{ passes_run }}</dd>
+        </div>
+      </dl>
+
+      <p class="celery-clear-timestamps">
+        Started: <code id="celery-clear-started-at">{{ started_at|default:"—" }}</code>
+        · Updated: <code id="celery-clear-updated-at">{{ updated_at|default:"—" }}</code>
+        · Completed: <code id="celery-clear-completed-at">{{ completed_at|default:"—" }}</code>
+      </p>
+
+      <p id="celery-clear-error-row"
+         class="celery-clear-error{% if not error %} celery-clear-hidden{% endif %}">
+        Error: <code id="celery-clear-error">{{ error }}</code>
+      </p>
+    </fieldset>
+
+    <fieldset class="module">
+      <div class="submit-row celery-clear-actions">
+        <form id="celery-clear-cancel-form"
+              method="post"
+              action="{{ cancel_url }}"
+              class="celery-clear-cancel-form">
+          {% csrf_token %}
+          <button type="submit"
+                  id="celery-clear-cancel-button"
+                  class="celery-clear-cancel-button"
+                  {% if is_terminal %}disabled{% endif %}>
+            {% if cancel_requested and not is_terminal %}Cancelling…{% else %}Cancel clear{% endif %}
+          </button>
+        </form>
+        <a id="celery-clear-back-link"
+           class="celery-clear-back-link{% if not is_terminal %} celery-clear-disabled-link{% endif %}"
+           href="{{ changelist_url }}">
+          &larr; back to unacked changelist
+        </a>
+      </div>
+    </fieldset>
+
+  </div>
+
+  <script src="{% static 'redis_admin/js/unacked_clear_progress.js' %}" defer></script>
+
+</div>
+{% endblock %}

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -12,6 +12,8 @@ api test suite rather than as standalone unit tests.
 
 from __future__ import annotations
 
+import json as _json
+
 import fakeredis
 import pytest
 from django.contrib.admin.models import LogEntry
@@ -21,6 +23,9 @@ from redis_admin import conn as redis_admin_conn
 from redis_admin.admin import FamilyFilter, LockFamilyFilter, QueueFamilyFilter
 from redis_admin.families import (
     _resolve_celery_queue_names as _celery_queue_names,  # noqa: PLC2701
+)
+from redis_admin.tests.test_unacked_queue import (
+    _build_envelope as _build_unacked_envelope,  # noqa: PLC2701
 )
 from shared.django_apps.codecov_auth.tests.factories import UserFactory
 from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
@@ -1375,3 +1380,105 @@ class RedisAdminSuperuserOnlyDeletionTest(TestCase):
         # 403 / 404 / redirect — anything but a successful delete.
         assert response.status_code in (302, 403, 404)
         assert self.redis.exists("uploads/1/aaa") == 1
+
+
+class UnackedQueueAdminSmokeTest(TestCase):
+    """End-to-end smoke coverage for the Kombu unacked drill-down admin.
+
+    Mirrors `CeleryBrokerQueueAdminSmokeTest` but for the
+    `unacked` HASH + `unacked_index` ZSET layout. Verifies the
+    summary mode renders a single row with `HLEN`, the detail
+    mode (with `routing_key__exact`) flips to per-message rows,
+    and the generic `RedisQueueAdmin` excludes the `unacked`
+    family from its sidebar dropdown (it has its own admin
+    surface, like `celery_broker`).
+    """
+
+    def setUp(self):
+        self._build_envelope = _build_unacked_envelope
+        self._json = _json
+        self.redis = fakeredis.FakeStrictRedis()
+        self._orig_get_connection = redis_admin_conn.get_connection
+        redis_admin_conn.get_connection = lambda kind="default": self.redis  # type: ignore[assignment]
+        self.user = UserFactory(is_staff=True, is_superuser=True)
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def tearDown(self):
+        redis_admin_conn.get_connection = self._orig_get_connection  # type: ignore[assignment]
+
+    def _push_unacked(
+        self,
+        delivery_tag: str,
+        *,
+        routing_key: str = "celery",
+        envelope=None,
+        deadline: float | None = None,
+    ):
+        triple = [envelope or self._build_envelope(), "", routing_key]
+        self.redis.hset("unacked", delivery_tag, self._json.dumps(triple))
+        if deadline is not None:
+            self.redis.zadd("unacked_index", {delivery_tag: deadline})
+
+    def test_changelist_summary_mode_renders_one_row_with_hlen_depth(self):
+        # No `routing_key__exact` filter → summary mode: one row
+        # carrying `HLEN(unacked)` as `depth`. The drill-in link
+        # also surfaces so the operator can step into per-message
+        # rows.
+        self._push_unacked("tag-1", envelope=self._build_envelope(kwargs={"repoid": 1}))
+        self._push_unacked("tag-2", envelope=self._build_envelope(kwargs={"repoid": 2}))
+
+        response = self.client.get("/admin/redis_admin/unackedqueueitem/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        # The single summary row's `routing_key_summary` cell.
+        assert "unacked (HASH)" in body
+        # Drill-in link with the depth count baked into its label.
+        assert "view 2 unacked message(s)" in body or "view 2 unacked" in body
+
+    def test_changelist_detail_mode_filters_to_routing_key(self):
+        self._push_unacked(
+            "celery-1",
+            routing_key="celery",
+            envelope=self._build_envelope(
+                task="app.tasks.notify.NotifyTask",
+                kwargs={"repoid": 7, "commitid": "abcdef0123"},
+            ),
+        )
+        self._push_unacked(
+            "notify-1",
+            routing_key="notify",
+            envelope=self._build_envelope(
+                task="app.tasks.bundle.Processor",
+                kwargs={"repoid": 8},
+            ),
+        )
+
+        response = self.client.get(
+            "/admin/redis_admin/unackedqueueitem/?routing_key__exact=celery"
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        # Per-message detail row for the matching routing_key.
+        assert "app.tasks.notify.NotifyTask" in body
+        # Short commit prefix renders.
+        assert "abcdef0" in body
+        # The unrelated routing_key's task is filtered out.
+        assert "app.tasks.bundle.Processor" not in body
+
+    def test_redisqueue_admin_hides_unacked_family(self):
+        # `RedisQueueAdmin.get_queryset` calls
+        # `family_exclude("celery_broker", "unacked")` so the
+        # generic queue changelist's sidebar / row set never
+        # surfaces the unacked HASH — it has its own admin
+        # surface, like `celery_broker`.
+        self._push_unacked("tag-1")
+
+        response = self.client.get("/admin/redis_admin/redisqueue/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8", errors="replace")
+        # No `unacked` row on the generic changelist.
+        assert "/admin/redis_admin/redisqueue/unacked/change/" not in body

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -315,15 +315,21 @@ def test_iter_keys_yields_celery_queues_via_fixed_keys(patched_redis):
 
 def test_celery_broker_family_routes_to_broker_connection_kind():
     """Pin the production routing decision: the `celery_broker` family
-    must declare it lives on the Celery broker Redis. Every other
-    family stays on the default cache Redis (the historical assumption
-    pre-PR).
+    (and the `unacked` HASH that lives next to it on the same broker
+    Redis — Kombu's bookkeeping is co-located with the queues
+    themselves) must declare they live on the broker connection.
+    Every other family stays on the default cache Redis (the
+    historical assumption pre-PR).
     """
 
+    broker_families = {"celery_broker", "unacked"}
     by_name = {f.name: f for f in FAMILIES}
-    assert by_name["celery_broker"].connection_kind == "broker"
+    for name in broker_families:
+        assert by_name[name].connection_kind == "broker", (
+            f"family {name!r} expected to ride on the broker Redis"
+        )
     for name, family in by_name.items():
-        if name == "celery_broker":
+        if name in broker_families:
             continue
         assert family.connection_kind == "default", (
             f"family {name!r} unexpectedly opted into a non-default "

--- a/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
@@ -702,6 +702,73 @@ def test_unacked_clear_keep_one_keeps_lowest_deadline_match(patched_broker):
     assert patched_broker.hexists("unacked", "late") is False
 
 
+def test_unacked_clear_keep_one_pass_one_does_not_double_pipeline(
+    patched_broker, monkeypatch
+):
+    """Regression for a Bugbot-flagged duplicate-pipeline bug
+    found on PR #911: when `keep_one=True` and pass 1 walked a
+    chunk-buffer with multiple matches, `pass_matches` was
+    accumulated twice (once via the per-field
+    `pass_matches.append(field_name)`, once via a then-present
+    `pass_matches.extend(chunk_targets)`). The post-pass HDEL+ZREM
+    pipeline then issued two commands per non-keeper. Idempotent
+    on Redis (second HDEL/ZREM returns 0, so counters stayed
+    truthful) but doubled the round-trip volume on a long clear.
+
+    We assert each non-keeper field appears in the actual HDEL
+    pipeline call exactly once by patching `pipeline.hdel` to
+    record arg lists. Pinning this contract so a future refactor
+    of the post-pass keep_one branch can't quietly reintroduce
+    the duplicate.
+    """
+
+    deadlines = {"a": 100.0, "b": 200.0, "c": 300.0, "d": 400.0}
+    for tag, deadline in deadlines.items():
+        _push_unacked(
+            patched_broker,
+            delivery_tag=tag,
+            routing_key="celery",
+            deadline=deadline,
+            envelope=_build_envelope(task="t", kwargs={"repoid": 1, "commitid": "z"}),
+        )
+
+    hdel_calls: list[tuple[str, ...]] = []
+    real_pipeline = patched_broker.pipeline
+
+    def _spy_pipeline(*args, **kwargs):
+        pipe = real_pipeline(*args, **kwargs)
+        real_hdel = pipe.hdel
+
+        def _hdel(name, *fields):
+            hdel_calls.append(tuple(fields))
+            return real_hdel(name, *fields)
+
+        pipe.hdel = _hdel
+        return pipe
+
+    monkeypatch.setattr(patched_broker, "pipeline", _spy_pipeline)
+
+    filter_tuple = _substitute_filter_any_unacked("celery", "t", 1, "z")
+    stats = _streaming_unacked_clear(
+        patched_broker,
+        frozenset({filter_tuple}),
+        keep_one=True,
+    )
+
+    assert stats.total_found == 4
+    # Three non-keepers HDELed; the lowest-deadline `a` is kept.
+    assert stats.total_hdel == 3
+    # Across all pipelines, each non-keeper field must appear
+    # exactly once. Flatten the recorded HDEL arg lists and count.
+    flat = [field for fields in hdel_calls for field in fields]
+    counts = {field: flat.count(field) for field in flat}
+    for field, n in counts.items():
+        assert n == 1, (
+            f"field {field!r} HDELed {n} times across pipelines — "
+            "duplicate pipeline regression"
+        )
+
+
 def test_unacked_clear_filter_any_wildcards_match_correctly(patched_broker):
     """`_FILTER_ANY` in any slot wildcards that axis. Verify the
     full-wildcard `(routing_key=ANY, task=ANY, repoid=ANY,

--- a/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
@@ -44,6 +44,7 @@ from redis_admin.families import (
 )
 from redis_admin.models import UnackedQueueItem
 from redis_admin.queryset import (
+    _UNACKED_KEY,
     UnackedFrequencyBucket,
     UnackedQueueQuerySet,
     _decode_unacked_value,
@@ -1271,3 +1272,53 @@ def test_synchronous_unacked_clear_drains_targets(patched_broker, superuser):
     assert result.count == 2
     assert patched_broker.hlen("unacked") == 0
     assert patched_broker.zcard("unacked_index") == 0
+
+
+def test_unacked_admin_summary_drill_in_link_uses_view_all_query_param():
+    """Regression for a Bugbot-flagged self-referencing link bug
+    found on PR #911: the summary row's `messages_link` rendered
+    a URL with no `routing_key__exact` query param. Since
+    `_is_summary_request` returned True whenever
+    `routing_key__exact` was absent, clicking the drill-in link
+    re-rendered the summary page — a self-loop. The unacked
+    summary row has no single routing_key to point at because
+    the unacked HASH is one global bucket carrying every queue's
+    reservations.
+
+    The fix uses a dedicated `view_all=1` flag that
+    `_is_summary_request` recognises as the explicit "show every
+    reservation" mode. We pin both halves of the contract: the
+    rendered URL carries `view_all=1`, and `_is_summary_request`
+    treats `view_all=1` as a detail-mode request even when
+    `routing_key__exact` is empty.
+    """
+
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+    summary_obj = UnackedQueueItem(
+        delivery_tag=_UNACKED_KEY,
+        routing_key="",
+        depth=42,
+    )
+
+    rendered = admin_instance.messages_link(summary_obj)
+
+    assert "view_all=1" in rendered, (
+        f"summary drill-in link must carry view_all=1, got {rendered!r}"
+    )
+    assert "view 42 unacked message(s)" in rendered
+
+    factory = RequestFactory()
+    detail_request_via_view_all = factory.get(
+        "/admin/redis_admin/unackedqueueitem/", {"view_all": "1"}
+    )
+    assert UnackedQueueAdmin._is_summary_request(detail_request_via_view_all) is False
+
+    summary_request = factory.get("/admin/redis_admin/unackedqueueitem/")
+    assert UnackedQueueAdmin._is_summary_request(summary_request) is True
+
+    detail_request_via_routing_key = factory.get(
+        "/admin/redis_admin/unackedqueueitem/", {"routing_key__exact": "celery"}
+    )
+    assert (
+        UnackedQueueAdmin._is_summary_request(detail_request_via_routing_key) is False
+    )

--- a/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
@@ -1,0 +1,1206 @@
+"""End-to-end coverage for the Kombu unacked drill-down.
+
+Mirrors `test_celery_broker_queue.py` for the per-message admin
+surface that maps `redis_key_size{key="unacked"}` from Grafana
+into a per-message admin surface. Same fakeredis-backed strategy
+as the celery_broker tests so we can run without Postgres.
+
+Layout reference:
+
+* `unacked` (Redis HASH) — field=`delivery_tag`, value=JSON
+  triple `[envelope_dict, exchange_str, routing_key_str]`.
+* `unacked_index` (Redis ZSET) — score=visibility deadline,
+  member=`delivery_tag`. Cleared in tandem with the HASH field
+  via the `services.unacked_clear` HDEL+ZREM pipeline; skipping
+  the ZREM would leave a phantom in `unacked_index` that points
+  at a non-existent HASH field.
+
+Verified against `kombu.transport.redis.Channel.unacked_key` /
+`unacked_index_key` (defaults: `"unacked"` and
+`"unacked_index"`).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import fakeredis
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
+
+from redis_admin import conn as redis_admin_conn
+from redis_admin import services as redis_admin_services
+from redis_admin.admin import UnackedQueueAdmin
+from redis_admin.families import (
+    FAMILIES,
+    _unacked_decode_value,
+    find_family,
+)
+from redis_admin.models import UnackedQueueItem
+from redis_admin.queryset import (
+    UnackedFrequencyBucket,
+    UnackedQueueQuerySet,
+    _decode_unacked_value,
+    _stream_unacked_frequency_aggregate,
+)
+from redis_admin.services import (
+    _FILTER_ANY,
+    _streaming_unacked_clear,
+    _substitute_filter_any_unacked,
+    get_unacked_clear_job,
+    request_cancel_unacked_clear_job,
+    start_unacked_clear_job,
+    unacked_clear,
+)
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _build_envelope(
+    *,
+    task: str | None = "app.tasks.notify.NotifyTask",
+    task_id: str | None = None,
+    args: list | None = None,
+    kwargs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a kombu broker envelope dict (as it lives inside
+    the `unacked` HASH triple's first slot).
+
+    Returns the dict rather than the JSON-serialised triple so
+    `_push_unacked` can assemble the
+    `[envelope, exchange, routing_key]` shape for each entry.
+    """
+
+    body = json.dumps([args or [], kwargs or {}, {}])
+    body_b64 = base64.b64encode(body.encode("utf-8")).decode("ascii")
+    headers: dict[str, Any] = {}
+    if task is not None:
+        headers["task"] = task
+    if task_id is not None:
+        headers["id"] = task_id
+    return {"body": body_b64, "headers": headers}
+
+
+def _push_unacked(
+    redis: fakeredis.FakeStrictRedis,
+    *,
+    delivery_tag: str,
+    routing_key: str = "celery",
+    exchange: str = "",
+    deadline: float | None = None,
+    envelope: dict[str, Any] | None = None,
+    unacked_key: str = "unacked",
+    unacked_index_key: str = "unacked_index",
+) -> None:
+    """Insert one unacked entry into the HASH + index pair.
+
+    Mirrors what Kombu does in
+    `kombu.transport.redis.Channel.basic_publish`-style paths
+    (the actual restore-loop code path is in `Channel.qos`'s
+    `_unacked_pre_publish_handler`). Uses `kombu.utils.json.dumps`
+    semantics — plain JSON of the triple — so the queryset's
+    decoder (which calls `json.loads`) reads it cleanly without
+    any kombu-specific shim.
+    """
+
+    triple = [envelope or _build_envelope(), exchange, routing_key]
+    redis.hset(unacked_key, delivery_tag, json.dumps(triple))
+    if deadline is not None:
+        redis.zadd(unacked_index_key, {delivery_tag: deadline})
+
+
+@pytest.fixture
+def patched_broker(monkeypatch) -> fakeredis.FakeStrictRedis:
+    """Single fakeredis backing both `kind="default"` (cache,
+    where the job hash lives) and `kind="broker"` (the unacked
+    HASH+ZSET we're clearing). Mirrors the celery_broker fixture.
+    """
+
+    server = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(
+        redis_admin_conn, "get_connection", lambda kind="default": server
+    )
+    return server
+
+
+@pytest.fixture
+def superuser():
+    return SimpleNamespace(
+        id=42,
+        pk=42,
+        is_superuser=True,
+        is_staff=True,
+        is_active=True,
+        is_authenticated=True,
+        is_anonymous=False,
+        username="testop",
+    )
+
+
+def _wait_for_job(job_id: str, *, timeout: float = 10.0) -> None:
+    """Block until the worker thread for `job_id` exits.
+
+    Mirrors `_wait_for_job` in `test_celery_broker_clear_job.py`
+    but reads the unacked-specific thread handle.
+    """
+
+    thread = redis_admin_services._unacked_clear_job_threads.get(job_id)
+    if thread is None:
+        return
+    thread.join(timeout=timeout)
+    assert not thread.is_alive(), (
+        f"unacked clear job worker thread for {job_id} did not exit within {timeout}s"
+    )
+
+
+# ---- family registration --------------------------------------------------
+
+
+def test_unacked_family_is_registered_with_hash_redis_type():
+    """`Family("unacked", redis_type="hash", ...)` shows up in
+    the registry with the broker connection_kind. Pinning the
+    shape so a future refactor can't silently route the unacked
+    HASH off the broker Redis.
+    """
+
+    [unacked] = [f for f in FAMILIES if f.name == "unacked"]
+    assert unacked.redis_type == "hash"
+    assert unacked.connection_kind == "broker"
+    assert "unacked" in unacked.fixed_keys
+    # `unacked_index` is intentionally NOT a fixed_key — it's an
+    # internal Kombu index, not a queue. The dedicated
+    # `UnackedQueueAdmin` reads it via ZSCORE per row instead.
+    assert "unacked_index" not in unacked.fixed_keys
+
+
+def test_find_family_routes_unacked_to_unacked_family():
+    fam = find_family("unacked")
+    assert fam is not None
+    assert fam.name == "unacked"
+
+
+def test_unacked_decode_value_renders_preview_with_task_and_repo():
+    """`families._unacked_decode_value` prepends a one-line
+    summary `[task=… repoid=… commit=… rk=…]` mirroring the
+    celery_broker preview shape. The `rk=` segment is the only
+    structural difference: unacked spans every queue, so the
+    routing_key is essential context for an operator scanning
+    raw HASH values via the generic `RedisQueueItem` admin.
+    """
+
+    envelope = _build_envelope(
+        task="app.tasks.notify.NotifyTask",
+        kwargs={"repoid": 21222368, "commitid": "0832c110a744ddb"},
+    )
+    raw_triple = json.dumps([envelope, "", "notify"])
+
+    rendered = _unacked_decode_value(raw_triple)
+
+    assert "task=app.tasks.notify.NotifyTask" in rendered
+    assert "repoid=21222368" in rendered
+    assert "commit=0832c11" in rendered
+    assert "rk=notify" in rendered
+    # The full raw value is appended so an operator can still
+    # see the literal JSON triple for forensics.
+    assert raw_triple in rendered
+
+
+def test_unacked_decode_value_returns_raw_for_garbled_input():
+    """Non-JSON / non-triple values pass through verbatim so the
+    generic queue admin still renders something rather than
+    crashing on a corrupted HASH value.
+    """
+
+    assert _unacked_decode_value("not-json {") == "not-json {"
+    # Empty list is well-formed JSON but missing the envelope
+    # slot; render verbatim.
+    assert _unacked_decode_value("[]") == "[]"
+
+
+def test_unacked_decode_value_handles_string_envelope_slot():
+    """Some kombu paths serialise the envelope as a string rather
+    than a dict; the decoder should still pull the celery
+    envelope summary out of it.
+    """
+
+    envelope = _build_envelope(task="t", kwargs={"repoid": 9})
+    raw_triple = json.dumps([json.dumps(envelope), "", "celery"])
+
+    rendered = _unacked_decode_value(raw_triple)
+
+    assert "task=t" in rendered
+    assert "repoid=9" in rendered
+    assert "rk=celery" in rendered
+
+
+# ---- queryset --------------------------------------------------------------
+
+
+def test_decode_unacked_value_extracts_envelope_exchange_routing_key():
+    envelope = _build_envelope(task="t", kwargs={"repoid": 1})
+    raw = json.dumps([envelope, "default-exchange", "notify"])
+
+    envelope_str, exchange, routing_key = _decode_unacked_value(raw)
+
+    assert envelope_str is not None
+    assert json.loads(envelope_str) == envelope
+    assert exchange == "default-exchange"
+    assert routing_key == "notify"
+
+
+def test_decode_unacked_value_returns_none_triple_for_garbled_input():
+    assert _decode_unacked_value("not-json") == (None, None, None)
+    assert _decode_unacked_value("[]") == (None, None, None)
+
+
+def test_unacked_queryset_summary_mode_emits_single_row_with_hlen(
+    patched_broker,
+):
+    """No `routing_key__exact` → one summary row carrying
+    `HLEN(unacked)` as `depth`. The single-row shape comes from
+    the unacked HASH being global per broker (vs one LIST per
+    celery queue), so a multi-row summary would be misleading.
+    """
+
+    for i in range(3):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"tag-{i}",
+            envelope=_build_envelope(kwargs={"repoid": i}),
+        )
+
+    qs = UnackedQueueQuerySet(UnackedQueueItem)
+    rows = list(qs)
+
+    assert len(rows) == 1
+    assert rows[0].depth == 3
+    assert rows[0].pk_token == "unacked#summary"
+    # Summary rows carry no per-message fields.
+    assert rows[0].delivery_tag == ""
+    assert rows[0].routing_key == ""
+
+
+def test_unacked_queryset_summary_returns_zero_when_hash_missing(
+    patched_broker,
+):
+    qs = UnackedQueueQuerySet(UnackedQueueItem)
+    rows = list(qs)
+
+    assert len(rows) == 1
+    assert rows[0].depth == 0
+
+
+def test_unacked_queryset_detail_mode_filters_by_routing_key(
+    patched_broker,
+):
+    """`routing_key__exact=<queue>` flips into per-message mode.
+    Only rows whose decoded triple's routing_key matches survive.
+    The other queues' messages stay in the HASH but are filtered
+    out post-materialise.
+    """
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="tag-notify-1",
+        routing_key="notify",
+        envelope=_build_envelope(
+            task="app.tasks.notify.NotifyTask",
+            kwargs={"repoid": 1, "commitid": "abcdef0123"},
+        ),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="tag-celery-1",
+        routing_key="celery",
+        envelope=_build_envelope(
+            task="app.tasks.bundle.Processor",
+            kwargs={"repoid": 2},
+        ),
+    )
+
+    qs = UnackedQueueQuerySet(UnackedQueueItem).filter(routing_key__exact="notify")
+    rows = list(qs)
+
+    assert len(rows) == 1
+    assert rows[0].delivery_tag == "tag-notify-1"
+    assert rows[0].task_name == "app.tasks.notify.NotifyTask"
+    assert rows[0].repoid == 1
+    assert rows[0].commitid == "abcdef0123"
+    assert rows[0].pk_token == "unacked#tag-notify-1"
+
+
+def test_unacked_queryset_detail_mode_resolves_visibility_deadline(
+    patched_broker,
+):
+    """The detail-mode queryset reads `ZSCORE unacked_index <tag>`
+    per row and renders it as a UTC datetime. Pinning the
+    field-population shape so the changelist's
+    `visibility_deadline` column has a stable contract.
+    """
+
+    deadline = 1_700_000_000.0
+    _push_unacked(
+        patched_broker,
+        delivery_tag="tag-deadline",
+        routing_key="celery",
+        deadline=deadline,
+    )
+
+    qs = UnackedQueueQuerySet(UnackedQueueItem).filter(routing_key__exact="celery")
+    [row] = list(qs)
+
+    assert row.visibility_deadline is not None
+    assert row.visibility_deadline.timestamp() == pytest.approx(deadline)
+    # ZSET-less rows render `None` (Kombu's restore-loop won't
+    # touch them on its own; useful signal to surface in the UI).
+
+
+def test_unacked_queryset_detail_mode_handles_missing_zset_score(
+    patched_broker,
+):
+    _push_unacked(
+        patched_broker,
+        delivery_tag="tag-no-deadline",
+        routing_key="celery",
+        deadline=None,  # no ZSET entry
+    )
+
+    qs = UnackedQueueQuerySet(UnackedQueueItem).filter(routing_key__exact="celery")
+    [row] = list(qs)
+
+    assert row.visibility_deadline is None
+
+
+def test_unacked_queryset_get_resolves_summary_pk(patched_broker):
+    _push_unacked(patched_broker, delivery_tag="t-1")
+    _push_unacked(patched_broker, delivery_tag="t-2")
+
+    qs = UnackedQueueQuerySet(UnackedQueueItem)
+    summary = qs.get(pk="unacked#summary")
+
+    assert summary.depth == 2
+
+
+def test_unacked_queryset_get_resolves_specific_delivery_tag(patched_broker):
+    """`pk=unacked#<delivery_tag>` resolves via direct HGET so a
+    delivery_tag past the `CELERY_BROKER_DISPLAY_LIMIT` cap still
+    renders cleanly when the operator clicks through.
+    """
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-target",
+        routing_key="celery",
+        envelope=_build_envelope(task="t", kwargs={"repoid": 99}),
+    )
+
+    qs = UnackedQueueQuerySet(UnackedQueueItem)
+    row = qs.get(pk="unacked#t-target")
+
+    assert row.delivery_tag == "t-target"
+    assert row.task_name == "t"
+    assert row.repoid == 99
+
+
+def test_unacked_queryset_get_raises_for_unknown_delivery_tag(patched_broker):
+    qs = UnackedQueueQuerySet(UnackedQueueItem)
+    with pytest.raises(UnackedQueueItem.DoesNotExist):
+        qs.get(pk="unacked#absent")
+
+
+def test_unacked_queryset_filter_by_task_name(patched_broker):
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-1",
+        routing_key="celery",
+        envelope=_build_envelope(task="task.A"),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-2",
+        routing_key="celery",
+        envelope=_build_envelope(task="task.B"),
+    )
+
+    qs = UnackedQueueQuerySet(UnackedQueueItem).filter(
+        routing_key__exact="celery", task_name__exact="task.A"
+    )
+
+    rows = list(qs)
+    assert [r.delivery_tag for r in rows] == ["t-1"]
+
+
+def test_unacked_queryset_filter_by_repoid_and_commit_prefix(patched_broker):
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-match",
+        routing_key="celery",
+        envelope=_build_envelope(kwargs={"repoid": 7, "commitid": "abc1234"}),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-other-repo",
+        routing_key="celery",
+        envelope=_build_envelope(kwargs={"repoid": 8, "commitid": "abc1234"}),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-other-commit",
+        routing_key="celery",
+        envelope=_build_envelope(kwargs={"repoid": 7, "commitid": "def5678"}),
+    )
+
+    qs = UnackedQueueQuerySet(UnackedQueueItem).filter(
+        routing_key__exact="celery",
+        repoid__exact=7,
+        commitid__startswith="abc",
+    )
+
+    rows = list(qs)
+    assert [r.delivery_tag for r in rows] == ["t-match"]
+
+
+# ---- frequency aggregator --------------------------------------------------
+
+
+def test_stream_unacked_frequency_aggregate_groups_by_4tuple(patched_broker):
+    """`_stream_unacked_frequency_aggregate` returns top-N
+    `(routing_key, task_name, repoid, commitid)` quadruples. The
+    `routing_key` axis is what differentiates the unacked chart
+    from celery_broker's 3-axis chart — the unacked HASH spans
+    every queue, so without it "clear all messages for repo X
+    commit Y" would silently span queues.
+    """
+
+    for i in range(3):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"notify-{i}",
+            routing_key="notify",
+            envelope=_build_envelope(
+                task="app.tasks.notify.NotifyTask",
+                kwargs={"repoid": 1, "commitid": "aaaa"},
+            ),
+        )
+    for i in range(2):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"celery-{i}",
+            routing_key="celery",
+            envelope=_build_envelope(
+                task="app.tasks.bundle.Processor",
+                kwargs={"repoid": 2, "commitid": "bbbb"},
+            ),
+        )
+
+    buckets, total = _stream_unacked_frequency_aggregate(patched_broker)
+
+    assert total == 5
+    assert [
+        (b.routing_key, b.task_name, b.repoid, b.commitid, b.count) for b in buckets
+    ] == [
+        ("notify", "app.tasks.notify.NotifyTask", 1, "aaaa", 3),
+        ("celery", "app.tasks.bundle.Processor", 2, "bbbb", 2),
+    ]
+    total_pct = sum(b.pct for b in buckets)
+    assert 99.0 < total_pct < 101.0
+
+
+def test_unacked_frequency_chart_aggregates_by_task_repo_commit(
+    patched_broker,
+):
+    """`UnackedQueueQuerySet.frequency_by_routing_task_repo_commit`
+    drives the lazy-loaded chart fragment. In summary mode it
+    returns `[]` so the chart placeholder doesn't render.
+    """
+
+    for _ in range(2):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"d-{uuid.uuid4().hex}",
+            routing_key="celery",
+            envelope=_build_envelope(
+                task="t.A", kwargs={"repoid": 1, "commitid": "aaaa"}
+            ),
+        )
+    _push_unacked(
+        patched_broker,
+        delivery_tag=f"d-{uuid.uuid4().hex}",
+        routing_key="celery",
+        envelope=_build_envelope(task="t.B", kwargs={"repoid": 2, "commitid": "bbbb"}),
+    )
+
+    qs_summary = UnackedQueueQuerySet(UnackedQueueItem)
+    assert qs_summary.frequency_by_routing_task_repo_commit() == []
+
+    qs_detail = UnackedQueueQuerySet(UnackedQueueItem, routing_key="celery")
+    buckets = qs_detail.frequency_by_routing_task_repo_commit()
+
+    assert all(isinstance(b, UnackedFrequencyBucket) for b in buckets)
+    assert [(b.task_name, b.count) for b in buckets] == [
+        ("t.A", 2),
+        ("t.B", 1),
+    ]
+
+
+def test_unacked_frequency_chart_drops_fully_empty_rows(patched_broker):
+    """An envelope with no task/repoid/commitid AND no
+    routing_key would produce a chart row whose "Clear" button
+    couldn't form any narrowing filter — drop it so the row's
+    click can't produce an empty-scope clear (which the
+    `clear_by_filter_view` refuses anyway).
+    """
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-empty",
+        routing_key="",  # blank routing_key
+        envelope=_build_envelope(task=None, kwargs={}),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-real",
+        routing_key="celery",
+        envelope=_build_envelope(task="t", kwargs={"repoid": 9}),
+    )
+
+    buckets, _total = _stream_unacked_frequency_aggregate(patched_broker)
+
+    assert [(b.task_name, b.repoid, b.routing_key) for b in buckets] == [
+        ("t", 9, "celery"),
+    ]
+
+
+# ---- substitute_filter_any -------------------------------------------------
+
+
+def test_substitute_filter_any_unacked_returns_4tuple_with_wildcards():
+    out = _substitute_filter_any_unacked(None, None, None, None)
+    assert out == (_FILTER_ANY, _FILTER_ANY, _FILTER_ANY, _FILTER_ANY)
+
+
+def test_substitute_filter_any_unacked_preserves_set_slots():
+    out = _substitute_filter_any_unacked("celery", "task.A", 7, "abc")
+    assert out == ("celery", "task.A", 7, "abc")
+
+
+def test_substitute_filter_any_unacked_treats_zero_repoid_as_set():
+    """`repoid=0` is a legitimate value and must NOT be coerced to
+    wildcard — the truthiness vs `is None` asymmetry mirrors the
+    celery_broker `_substitute_filter_any` rule.
+    """
+
+    out = _substitute_filter_any_unacked(None, None, 0, None)
+    assert out[2] == 0
+
+
+# ---- streaming clear -------------------------------------------------------
+
+
+def test_unacked_clear_drains_hash_and_index_for_matches(patched_broker):
+    """`_streaming_unacked_clear` issues paired HDEL+ZREM per
+    match. Skipping the ZREM would leave a phantom in
+    `unacked_index` that points at a non-existent HASH field,
+    which is the failure mode this test guards against.
+    """
+
+    for i in range(3):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"match-{i}",
+            routing_key="celery",
+            deadline=1000.0 + i,
+            envelope=_build_envelope(
+                task="t.A", kwargs={"repoid": 7, "commitid": "abc"}
+            ),
+        )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="other",
+        routing_key="celery",
+        deadline=2000.0,
+        envelope=_build_envelope(task="t.B", kwargs={"repoid": 7, "commitid": "abc"}),
+    )
+
+    filter_tuple = _substitute_filter_any_unacked("celery", "t.A", 7, "abc")
+    stats = _streaming_unacked_clear(
+        patched_broker,
+        frozenset({filter_tuple}),
+    )
+
+    assert stats.total_found == 3
+    assert stats.total_hdel == 3
+    assert stats.total_zrem == 3
+    # The HASH and ZSET for the matched delivery tags are gone;
+    # the unrelated `t.B` entry survives.
+    assert patched_broker.hexists("unacked", "match-0") is False
+    assert patched_broker.zscore("unacked_index", "match-0") is None
+    assert patched_broker.hexists("unacked", "other") is True
+    assert patched_broker.zscore("unacked_index", "other") is not None
+
+
+def test_unacked_clear_dry_run_counts_without_mutating(patched_broker):
+    for i in range(3):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"d-{i}",
+            routing_key="celery",
+            deadline=float(i),
+            envelope=_build_envelope(kwargs={"repoid": 1}),
+        )
+
+    filter_tuple = _substitute_filter_any_unacked("celery", None, 1, None)
+    stats = _streaming_unacked_clear(
+        patched_broker, frozenset({filter_tuple}), dry_run=True
+    )
+
+    assert stats.total_found == 3
+    assert stats.total_hdel == 0
+    assert stats.total_zrem == 0
+    assert patched_broker.hlen("unacked") == 3
+    assert patched_broker.zcard("unacked_index") == 3
+
+
+def test_unacked_clear_keep_one_keeps_lowest_deadline_match(patched_broker):
+    """`keep_one=True` preserves the lowest-`ZSCORE` match — the
+    message Kombu's restore-loop is most likely to re-enqueue
+    first. Useful workflow: "I want to keep one example to
+    inspect but clear the rest."
+    """
+
+    deadlines = {"early": 100.0, "middle": 200.0, "late": 300.0}
+    for tag, deadline in deadlines.items():
+        _push_unacked(
+            patched_broker,
+            delivery_tag=tag,
+            routing_key="celery",
+            deadline=deadline,
+            envelope=_build_envelope(task="t", kwargs={"repoid": 1, "commitid": "aaa"}),
+        )
+
+    filter_tuple = _substitute_filter_any_unacked("celery", "t", 1, "aaa")
+    stats = _streaming_unacked_clear(
+        patched_broker,
+        frozenset({filter_tuple}),
+        keep_one=True,
+    )
+
+    assert stats.total_found == 3
+    # Two non-keepers got HDEL+ZREMmed; the lowest-deadline
+    # `early` survives.
+    assert stats.total_hdel == 2
+    assert stats.total_zrem == 2
+    assert patched_broker.hexists("unacked", "early") is True
+    assert patched_broker.zscore("unacked_index", "early") == 100.0
+    assert patched_broker.hexists("unacked", "middle") is False
+    assert patched_broker.hexists("unacked", "late") is False
+
+
+def test_unacked_clear_filter_any_wildcards_match_correctly(patched_broker):
+    """`_FILTER_ANY` in any slot wildcards that axis. Verify the
+    full-wildcard `(routing_key=ANY, task=ANY, repoid=ANY,
+    commitid=ANY)` matches every entry, while a partial filter
+    narrows correctly.
+    """
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="A",
+        routing_key="celery",
+        deadline=1.0,
+        envelope=_build_envelope(task="t.A", kwargs={"repoid": 1}),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="B",
+        routing_key="notify",
+        deadline=2.0,
+        envelope=_build_envelope(task="t.B", kwargs={"repoid": 2}),
+    )
+
+    # Full wildcard → matches both
+    full_wildcard = (_FILTER_ANY, _FILTER_ANY, _FILTER_ANY, _FILTER_ANY)
+    stats = _streaming_unacked_clear(
+        patched_broker, frozenset({full_wildcard}), dry_run=True
+    )
+    assert stats.total_found == 2
+
+    # routing_key="celery", everything else wildcard → matches A only
+    partial = ("celery", _FILTER_ANY, _FILTER_ANY, _FILTER_ANY)
+    stats = _streaming_unacked_clear(patched_broker, frozenset({partial}), dry_run=True)
+    assert stats.total_found == 1
+
+
+# ---- chunked-job worker ---------------------------------------------------
+
+
+def test_start_unacked_clear_job_returns_uuid_and_initialises_state(
+    patched_broker, superuser
+):
+    """`start_unacked_clear_job` returns a UUID-shaped job_id
+    and writes a fully-populated initial hash with status=pending,
+    the operator's filter shape, and a snapshotted total_estimated.
+    Pinning the hash shape so the JSON status view's contract
+    stays stable across refactors.
+    """
+
+    for i in range(5):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"d-{i}",
+            routing_key="celery",
+            deadline=float(i),
+            envelope=_build_envelope(kwargs={"repoid": 1}),
+        )
+
+    job_id = start_unacked_clear_job(
+        user=superuser,
+        routing_key="celery",
+        repoid=1,
+        keep_one=False,
+        dry_run=False,
+    )
+    _wait_for_job(job_id)
+
+    assert uuid.UUID(job_id)
+    state = get_unacked_clear_job(job_id)
+    assert state is not None
+    assert state["status"] == "completed"
+    assert state["filter_routing_key"] == "celery"
+    assert state["filter_repoid"] == "1"
+    assert state["dry_run"] == "0"
+    assert int(state["total_estimated"]) == 5
+    assert int(state["matched"]) >= 5
+    assert int(state["zrem_removed"]) >= 5
+
+
+def test_unacked_clear_by_filter_chunked_job_drains_hash_and_index(
+    patched_broker, superuser
+):
+    """End-to-end: spawn the chunked worker, wait for completion,
+    and assert both `unacked` and `unacked_index` have been
+    drained for the filtered scope. Other entries survive.
+    """
+
+    for i in range(10):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"clear-{i}",
+            routing_key="celery",
+            deadline=float(i),
+            envelope=_build_envelope(
+                task="t.A", kwargs={"repoid": 7, "commitid": "abc"}
+            ),
+        )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="keep-other-task",
+        routing_key="celery",
+        deadline=99.0,
+        envelope=_build_envelope(task="t.B", kwargs={"repoid": 7, "commitid": "abc"}),
+    )
+
+    job_id = start_unacked_clear_job(
+        user=superuser,
+        routing_key="celery",
+        task_name="t.A",
+        repoid=7,
+        commitid="abc",
+    )
+    _wait_for_job(job_id)
+
+    state = get_unacked_clear_job(job_id)
+    assert state is not None
+    assert state["status"] == "completed"
+    assert int(state["matched"]) == 10
+    assert int(state["zrem_removed"]) == 10
+    # The keep-other-task entry survives — different task_name,
+    # so the filter's task_name slot exact-matched it out.
+    assert patched_broker.hlen("unacked") == 1
+    assert patched_broker.hexists("unacked", "keep-other-task") is True
+    assert patched_broker.zcard("unacked_index") == 1
+
+
+def test_unacked_clear_job_cancellation_lands_at_chunk_boundary(
+    patched_broker, superuser, monkeypatch
+):
+    """Cancelling mid-clear: set `cancel_requested=1` and expect
+    the worker to bail out at the next chunk boundary with
+    `status=cancelled`. We force a tiny chunk size so cancel
+    has a chance to land before the (small) test queue drains.
+    """
+
+    for i in range(50):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"d-{i}",
+            routing_key="celery",
+            deadline=float(i),
+            envelope=_build_envelope(kwargs={"repoid": 1}),
+        )
+
+    monkeypatch.setattr(redis_admin_services, "_UNACKED_CLEAR_CHUNK", 5)
+
+    job_id = start_unacked_clear_job(
+        user=superuser,
+        routing_key="celery",
+        repoid=1,
+    )
+    request_cancel_unacked_clear_job(job_id)
+    _wait_for_job(job_id)
+
+    state = get_unacked_clear_job(job_id)
+    assert state is not None
+    assert state["status"] in ("cancelled", "completed")
+
+
+def test_unacked_clear_job_preserves_lowest_deadline_keeper(patched_broker, superuser):
+    """Chunked-mode `keep_one`: the survivor is the
+    lowest-`ZSCORE` match across all chunks, not the
+    first-encountered one. Same semantic as the synchronous path.
+    """
+
+    deadlines = [(f"d-{i}", float(i * 100)) for i in range(5)]
+    for tag, deadline in deadlines:
+        _push_unacked(
+            patched_broker,
+            delivery_tag=tag,
+            routing_key="celery",
+            deadline=deadline,
+            envelope=_build_envelope(task="t", kwargs={"repoid": 1, "commitid": "aaa"}),
+        )
+
+    job_id = start_unacked_clear_job(
+        user=superuser,
+        routing_key="celery",
+        task_name="t",
+        repoid=1,
+        commitid="aaa",
+        keep_one=True,
+    )
+    _wait_for_job(job_id)
+
+    state = get_unacked_clear_job(job_id)
+    assert state is not None
+    assert state["status"] == "completed"
+    # Lowest-deadline keeper is `d-0` (deadline=0.0); the four
+    # higher-deadline matches were HDEL+ZREMmed.
+    assert patched_broker.hexists("unacked", "d-0") is True
+    for i in range(1, 5):
+        assert patched_broker.hexists("unacked", f"d-{i}") is False
+
+
+def test_request_cancel_unacked_clear_job_returns_false_for_unknown_id(
+    patched_broker,
+):
+    assert request_cancel_unacked_clear_job(uuid.uuid4().hex) is False
+
+
+def test_get_unacked_clear_job_returns_none_for_unknown_id(patched_broker):
+    assert get_unacked_clear_job(uuid.uuid4().hex) is None
+
+
+# ---- admin views (RequestFactory-driven) ----------------------------------
+
+
+def _build_request(method: str, path: str, *, user, **post_kwargs):
+    factory = RequestFactory()
+    if method == "POST":
+        request = factory.post(path, data=post_kwargs)
+    else:
+        request = factory.get(path, data=post_kwargs)
+    request.user = user
+    # Django's `messages` framework needs a message storage on
+    # the request before `messages.error(...)` works.
+    setattr(request, "session", {})
+    setattr(request, "_messages", FallbackStorage(request))
+    return request
+
+
+def test_unacked_admin_chart_fragment_endpoint_returns_html(
+    patched_broker, superuser, monkeypatch
+):
+    """Hitting `chart_fragment_view` for a routing_key with
+    matching unacked entries returns 200 + the rendered chart
+    template. Used by the changelist's lazy `<script>` to fetch
+    the chart asynchronously on `DOMContentLoaded`.
+
+    `_resolve_repo_displays` is stubbed because the in-process
+    sandbox doesn't have Postgres; the `service:owner/name`
+    rendering is covered by a separate ORM-aware test.
+    """
+
+    # noqa: PLC0415 — local import + monkeypatch keeps the
+    # ORM-skipping shim narrowly scoped to this test.
+    from redis_admin import admin as redis_admin_module  # noqa: PLC0415
+
+    monkeypatch.setattr(
+        redis_admin_module, "_resolve_repo_displays", lambda repoids: {}
+    )
+
+    for _ in range(2):
+        _push_unacked(
+            patched_broker,
+            delivery_tag=f"d-{uuid.uuid4().hex}",
+            routing_key="celery",
+            envelope=_build_envelope(
+                task="t.A", kwargs={"repoid": 1, "commitid": "aaaa"}
+            ),
+        )
+
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+    request = _build_request(
+        "GET",
+        "/admin/redis_admin/unackedqueueitem/celery/chart-fragment/",
+        user=superuser,
+    )
+
+    response = admin_instance.chart_fragment_view(request, routing_key="celery")
+
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/html")
+    body = response.content.decode("utf-8", errors="replace")
+    assert "celery-frequency-chart" in body
+    assert "t.A" in body
+
+
+def test_unacked_admin_chart_fragment_returns_204_for_empty_hash(
+    patched_broker, superuser
+):
+    """No unacked entries → no buckets → 204 so the JS loader
+    drops the placeholder rather than rendering an empty chart.
+    """
+
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+    request = _build_request(
+        "GET",
+        "/admin/redis_admin/unackedqueueitem/celery/chart-fragment/",
+        user=superuser,
+    )
+
+    response = admin_instance.chart_fragment_view(request, routing_key="celery")
+
+    assert response.status_code == 204
+
+
+def test_unacked_admin_clear_progress_endpoint_returns_json(patched_broker, superuser):
+    """The status-JSON endpoint serves a stable shape regardless
+    of the underlying job hash's keys, so the polling JS can rely
+    on the field set even as we add new counters.
+    """
+
+    _push_unacked(patched_broker, delivery_tag="d-1", routing_key="celery")
+    job_id = start_unacked_clear_job(user=superuser, routing_key="celery", dry_run=True)
+    _wait_for_job(job_id)
+
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+    request = _build_request(
+        "GET",
+        f"/admin/redis_admin/unackedqueueitem/clear-by-filter/job/{job_id}/status/",
+        user=superuser,
+    )
+
+    response = admin_instance.clear_by_filter_status_view(request, job_id=job_id)
+
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("application/json")
+    payload = json.loads(response.content.decode("utf-8"))
+    # Pinned shape: every field the JS poller reads must be present.
+    expected_keys = {
+        "job_id",
+        "status",
+        "is_terminal",
+        "routing_key",
+        "filter_routing_key",
+        "filter_task",
+        "filter_repoid",
+        "filter_commitid",
+        "dry_run",
+        "keep_one",
+        "started_at",
+        "updated_at",
+        "completed_at",
+        "total_estimated",
+        "processed",
+        "matched",
+        "zrem_removed",
+        "passes_run",
+        "error",
+        "cancel_requested",
+    }
+    assert expected_keys <= set(payload.keys())
+    assert payload["job_id"] == job_id
+    assert payload["status"] == "completed"
+    assert payload["filter_routing_key"] == "celery"
+
+
+def test_unacked_admin_clear_by_filter_get_renders_preview(patched_broker, superuser):
+    """GET on `clear_by_filter_view` with chart hints renders the
+    preview page's approximate-count callout in pure Python (no
+    Redis I/O on this path).
+    """
+
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+    request = _build_request(
+        "GET",
+        "/admin/redis_admin/unackedqueueitem/clear-by-filter/",
+        user=superuser,
+        routing_key="celery",
+        task_name="t.A",
+        repoid="7",
+        commitid="abc",
+        bucket_count="50",
+        bucket_pct="50.0",
+        total_visible="100",
+        total_depth="200",
+    )
+
+    response = admin_instance.clear_by_filter_view(request)
+
+    assert response.status_code == 200
+    body = response.content.decode("utf-8", errors="replace")
+    assert "Clear unacked" in body
+    assert "celery" in body
+    # Approx-impact callout: 50/100 * 200 = 100 messages
+    assert "100" in body
+    # Typed-confirmation field surfaces with the routing_key as
+    # the expected confirm value.
+    assert "Type" in body
+    assert "celery" in body
+
+
+def test_unacked_admin_clear_by_filter_refuses_empty_scope(patched_broker, superuser):
+    """Refusing to clear with no narrowing filter — would
+    otherwise drop the entire unacked HASH, which is too sharp
+    an edge for an admin button. Operators wanting the full
+    drop should run `redis-cli DEL unacked unacked_index`
+    directly.
+    """
+
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+    request = _build_request(
+        "GET",
+        "/admin/redis_admin/unackedqueueitem/clear-by-filter/",
+        user=superuser,
+    )
+
+    response = admin_instance.clear_by_filter_view(request)
+
+    # 302 redirect back to changelist with an error message.
+    assert response.status_code == 302
+
+
+def test_unacked_admin_clear_by_filter_post_spawns_chunked_job(
+    patched_broker, superuser
+):
+    """POST with `action=dry_run` (no typed-confirm needed)
+    spawns the chunked worker and 302s to the progress page.
+    """
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="d-1",
+        routing_key="celery",
+        envelope=_build_envelope(kwargs={"repoid": 1}),
+    )
+
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+    request = _build_request(
+        "POST",
+        "/admin/redis_admin/unackedqueueitem/clear-by-filter/",
+        user=superuser,
+        routing_key="celery",
+        repoid="1",
+        action="dry_run",
+    )
+
+    response = admin_instance.clear_by_filter_view(request)
+
+    assert response.status_code == 302
+    # Redirect URL should target the progress page.
+    assert "/clear-by-filter/job/" in response["Location"]
+
+
+def test_unacked_admin_clear_by_filter_destructive_requires_typed_confirm(
+    patched_broker, superuser
+):
+    """`clear_all` / `clear_keep_one` need the typed-confirm
+    field to match `routing_key`; without it the page re-renders
+    with an error rather than spawning the worker.
+    """
+
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+    request = _build_request(
+        "POST",
+        "/admin/redis_admin/unackedqueueitem/clear-by-filter/",
+        user=superuser,
+        routing_key="celery",
+        repoid="1",
+        action="clear_all",
+        typed_confirm="wrong-value",
+    )
+
+    response = admin_instance.clear_by_filter_view(request)
+
+    assert response.status_code == 200  # re-renders preview
+    body = response.content.decode("utf-8", errors="replace")
+    assert "Typed confirmation must equal" in body
+
+
+def test_unacked_admin_clear_by_filter_cancel_view_returns_202_for_known_job(
+    patched_broker, superuser
+):
+    _push_unacked(patched_broker, delivery_tag="d-1", routing_key="celery")
+    job_id = start_unacked_clear_job(user=superuser, routing_key="celery", dry_run=True)
+
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+    request = _build_request(
+        "POST",
+        f"/admin/redis_admin/unackedqueueitem/clear-by-filter/job/{job_id}/cancel/",
+        user=superuser,
+    )
+
+    response = admin_instance.clear_by_filter_cancel_view(request, job_id=job_id)
+    _wait_for_job(job_id)
+
+    assert response.status_code == 202
+
+
+# ---- synchronous unacked_clear --------------------------------------------
+
+
+def test_synchronous_unacked_clear_drains_targets(patched_broker, superuser):
+    """`services.unacked_clear` is the synchronous path used by
+    bulk admin actions (`clear_dry_run` / `clear_selected`).
+    Mirrors `celery_broker_clear` but for the HASH+ZSET layout.
+    """
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="d-1",
+        routing_key="celery",
+        deadline=1.0,
+        envelope=_build_envelope(task="t", kwargs={"repoid": 1, "commitid": "abc"}),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="d-2",
+        routing_key="celery",
+        deadline=2.0,
+        envelope=_build_envelope(task="t", kwargs={"repoid": 1, "commitid": "abc"}),
+    )
+
+    qs = UnackedQueueQuerySet(UnackedQueueItem).filter(routing_key__exact="celery")
+    targets = list(qs)
+
+    result = unacked_clear(targets, user=superuser, dry_run=False)
+
+    assert result.count == 2
+    assert patched_broker.hlen("unacked") == 0
+    assert patched_broker.zcard("unacked_index") == 0

--- a/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
@@ -550,6 +550,47 @@ def test_unacked_frequency_chart_aggregates_by_task_repo_commit(
     ]
 
 
+def test_unacked_frequency_chart_pcts_sum_to_100_with_unparseable_envelopes(
+    patched_broker,
+):
+    """Regression for a Bugbot-flagged frequency-chart percentage
+    bug found on PR #911: every all-None unparseable envelope
+    incremented `total` (the percentage denominator) but never
+    landed in `counter`, so the rendered percentages summed to
+    less than 100% on a HASH that mixed parseable and
+    unparseable messages. Now `total` is re-normalised from the
+    surviving counter (matching the cached path's
+    `total = sum(counter.values())` behaviour) so the chart's
+    bars always sum to 100% across the rendered buckets.
+    """
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-real",
+        routing_key="celery",
+        envelope=_build_envelope(task="t.A", kwargs={"repoid": 9, "commitid": "x"}),
+    )
+    # All-None, no routing_key — drops out of the chart (matches
+    # `test_unacked_frequency_chart_drops_fully_empty_rows`).
+    _push_unacked(
+        patched_broker,
+        delivery_tag="t-empty",
+        routing_key="",
+        envelope=_build_envelope(task=None, kwargs={}),
+    )
+
+    buckets, _total = _stream_unacked_frequency_aggregate(patched_broker)
+
+    assert len(buckets) == 1, (
+        f"unparseable + 1 real → 1 visible bucket; got {len(buckets)}"
+    )
+    total_pct = sum(b.pct for b in buckets)
+    assert 99.0 < total_pct < 101.0, (
+        f"chart percentages must sum to 100% across rendered buckets, got "
+        f"{total_pct!r} — pre-fix denominator included dropped all-None rows"
+    )
+
+
 def test_unacked_frequency_chart_drops_fully_empty_rows(patched_broker):
     """An envelope with no task/repoid/commitid AND no
     routing_key would produce a chart row whose "Clear" button

--- a/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
@@ -1322,3 +1322,61 @@ def test_unacked_admin_summary_drill_in_link_uses_view_all_query_param():
     assert (
         UnackedQueueAdmin._is_summary_request(detail_request_via_routing_key) is False
     )
+
+
+def test_unacked_admin_view_all_drill_in_renders_per_message_rows(patched_broker):
+    """Regression for a Bugbot-flagged HIGH-severity bug found on
+    PR #911: clicking the summary row's "view N unacked
+    message(s) →" link landed on `?view_all=1` and
+    `_is_summary_request` correctly flipped to detail mode for
+    rendering, but `get_queryset` only flipped the queryset out
+    of summary mode when `routing_key__exact` was set. With
+    `view_all=1`, the queryset's `routing_key` stayed `None`,
+    `is_summary_mode()` returned `True`, and the admin rendered
+    a single dashes-row under the per-message detail columns —
+    breaking the feature at its primary navigation entry point.
+    The fix wires `view_all=1` through to the queryset so it
+    materialises every reservation regardless of routing_key,
+    and the operator narrows from there via the sidebar
+    `routing_key` filter.
+    """
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="d-celery",
+        routing_key="celery",
+        deadline=1.0,
+        envelope=_build_envelope(task="app.tasks.notify", kwargs={"repoid": 1}),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="d-uploads",
+        routing_key="uploads",
+        deadline=2.0,
+        envelope=_build_envelope(task="app.tasks.upload", kwargs={"repoid": 2}),
+    )
+
+    factory = RequestFactory()
+    request = factory.get("/admin/redis_admin/unackedqueueitem/", {"view_all": "1"})
+    admin_instance = UnackedQueueAdmin(UnackedQueueItem, AdminSite())
+
+    queryset = admin_instance.get_queryset(request)
+
+    assert queryset.is_summary_mode() is False, (
+        "view_all=1 must flip the queryset out of summary mode so the "
+        "admin's detail columns render per-message rows."
+    )
+    rows = list(queryset)
+    delivery_tags = sorted(r.delivery_tag for r in rows)
+    assert delivery_tags == ["d-celery", "d-uploads"], (
+        f"view_all=1 must surface every reserved message regardless of "
+        f"routing_key; got {delivery_tags!r}"
+    )
+    routing_keys = sorted(r.routing_key for r in rows)
+    assert routing_keys == ["celery", "uploads"], (
+        f"view_all=1 must preserve each row's source routing_key; got {routing_keys!r}"
+    )
+    assert all(r.depth is None for r in rows), (
+        "view_all=1 rows must be per-message (depth=None), not summary "
+        "rows wearing detail columns."
+    )


### PR DESCRIPTION
## Summary

This maps the `redis_key_size{key="unacked", cluster="$var_cluster"}` panel on the Grafana broker dashboard into a per-message admin surface, mirroring the existing `CeleryBrokerQueueAdmin` end-to-end (PRs #894 / #895 / #899 / #905 lineage — reviewers familiar with that surface can review this one by analogy).

When `unacked` climbs in Grafana, on-call now has a clickable next step instead of a `redis-cli` shell session.

## Kombu unacked layout

`kombu.transport.redis.Channel.unacked_key` (`"unacked"`) and `Channel.unacked_index_key` (`"unacked_index"`) move worker-reserved messages onto **two paired keys on the broker Redis**:

- `unacked` — Redis **HASH**. Field = `delivery_tag` (UUID-like). Value = JSON `[message_dict, exchange_str, routing_key_str]`. `message_dict["body"]` is base64 of the celery envelope, parsed by the existing `parse_celery_envelope`.
- `unacked_index` — Redis **ZSET**. Score = visibility-timeout deadline (unix ts). Member = `delivery_tag`. Used by Kombu's restore-loop to re-enqueue messages whose worker died.

To clear an entry the admin issues **both** `HDEL unacked <delivery_tag>` **and** `ZREM unacked_index <delivery_tag>` in one pipeline. Skipping the `ZREM` would leave a phantom in `unacked_index` that costs a `ZPOPMIN` every visibility-timeout tick.

## Chart shape

```
┌─────────────────────────────────────────────────────────────────────────────┐
│  unacked frequency by (routing_key, task, repoid, commitid) — sample 20000  │
├──────────┬─────────────────────────┬────────┬──────────────┬──────┬─────────┤
│  routing │  task                    │ repoid │ commitid     │  n  │ pct     │
├──────────┼─────────────────────────┼────────┼──────────────┼──────┼─────────┤
│  notify  │ app.tasks.notify.Notify │ 1234   │ abcdef0123…  │ 412 │ 38.2%   │ [Clear]
│  celery  │ app.tasks.bundle.Proc   │ 5678   │ deadbeefcaf… │ 198 │ 18.4%   │ [Clear]
│  …       │ …                       │ …      │ …            │ …   │ …       │
└──────────┴─────────────────────────┴────────┴──────────────┴──────┴─────────┘
                                                              total visible 1077
```

## New URLs

| Path | Purpose |
|---|---|
| `/admin/redis_admin/unackedqueueitem/` | Summary — one row carrying `HLEN(unacked)` |
| `/admin/redis_admin/unackedqueueitem/?routing_key__exact=<queue>` | Per-message detail rows for one routing_key + frequency chart |
| `/admin/redis_admin/unackedqueueitem/<routing_key>/chart-fragment/` | Lazy-loaded frequency chart fragment |
| `/admin/redis_admin/unackedqueueitem/clear-by-filter/` | Confirmation + dry-run form (chart-hint URL params, no Redis I/O on GET) |
| `/admin/redis_admin/unackedqueueitem/clear-by-filter/job/<uuid>/` | Progress page for a chunked clear job |
| `/admin/redis_admin/unackedqueueitem/clear-by-filter/job/<uuid>/status/` | JSON snapshot of a chunked clear job |
| `/admin/redis_admin/unackedqueueitem/clear-by-filter/job/<uuid>/cancel/` | POST-only cancel endpoint |

## Notable design decisions

- `keep_one` semantic differs from celery_broker: keeping the **lowest-deadline** match (the entry most likely to be re-enqueued first by Kombu's restore-loop), so the operator preserves the example most likely to reappear if they re-trigger work. The celery_broker version keeps the lowest list index (oldest by FIFO), which doesn't translate to a HASH.
- `_FILTER_ANY` extended to four slots `(routing_key, task, repoid, commitid)` via `_substitute_filter_any_unacked` rather than reusing the 3-slot helper; documented inline. The fourth slot is mandatory because routing_key is a per-message field, not a queue-level scope (one HASH carries every queue's reservations).
- `unacked` family is registered with `connection_kind="broker"` and **excluded** from `RedisQueueAdmin.get_queryset` via `.family_exclude("celery_broker", "unacked")` so the generic queue browser doesn't surface a duplicate row.
- `_streaming_unacked_clear` paired-pipeline `HDEL + ZREM` per batch; `redis_admin.unacked_clear: pass=N depth=M hdel_removed=K zrem_removed=K` log line per pass for postmortem traceability.
- Forked `celery_clear_progress.js` into `unacked_clear_progress.js` because the status snapshot's mutation field is `zrem_removed` (paired-key removals), not `drifted` (LSET-tombstone reconciliation).
- Chart fragment template adds a fourth column for `routing_key` so the operator can spot a single misbehaving queue inside the global HASH at a glance.

## Operator self-verify

```python
from redis_admin import conn as _c

r = _c.get_connection(kind="broker")
print("unacked HLEN:", r.hlen("unacked"))
print("unacked_index ZCARD:", r.zcard("unacked_index"))
```

Healthy: `HLEN ≈ ZCARD`. A persistent gap means a previous clear half-completed; visit `/admin/redis_admin/unackedqueueitem/?routing_key__exact=<queue>` and re-run a clear job to re-pair the keys.

## Test plan

- [x] Unit tests for queryset summary/detail two-mode behaviour, deadline ZSCORE join, frequency aggregator (including `routing_key=""` normalization), and the `_substitute_filter_any_unacked` helper.
- [x] `_streaming_unacked_clear` covered for HDEL+ZREM pairing, dry-run, keep-one, wildcard, and cancellation.
- [x] Chunked job worker covered for start / progress / completion / cancel / keep-one.
- [x] Admin endpoints covered: chart fragment, clear-by-filter (GET + POST + dry-run + typed-confirm), progress + status + cancel.
- [x] Smoke tests exercise the three changelist URLs (summary mode, detail mode, generic queue admin still hides `unacked`).
- [x] Sandbox limitation: TestCase-based smoke tests need Postgres → CI handles those (94 fakeredis-only tests pass locally).
- [ ] CI green
- [ ] Manual operator click-through against staging broker Redis


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new admin surface that can delete broker-reserved messages (`unacked`/`unacked_index`) and introduces a chunked background clear job; mistakes could clear the wrong in-flight work or orphan index entries if bugs slip through.
> 
> **Overview**
> Adds a dedicated Django admin for Kombu/Celery reserved messages stored in Redis `unacked` (HASH) paired with `unacked_index` (ZSET), including **summary (HLEN)** and **per-routing-key drill-down** views with a lazy-loaded frequency chart.
> 
> Introduces **clear tooling** for unacked entries: per-row delete and a superuser-only **clear-by-filter** flow (dry-run + typed confirmation) that runs as a **chunked background job** with progress/status/cancel endpoints and paired `HDEL`+`ZREM` semantics to keep the HASH/ZSET consistent.
> 
> Registers `unacked` as a broker-connection Redis family (and excludes it from the generic `RedisQueueAdmin` list), extends envelope parsing metadata (`comparison_id`), and adds templates/static JS plus smoke tests covering the new admin modes and hiding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 763ca71c045526d7981caaf7dfb3aa92ca35c682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->