### PR TITLE
feat(redis_admin): allow superuser-only deletion of Redis locks

### DIFF
--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -1112,14 +1112,21 @@ class RedisQueueAdmin(admin.ModelAdmin):
 
 @admin.register(RedisLock)
 class RedisLockAdmin(admin.ModelAdmin):
-    """Read-only admin for coordination locks, gates, and fences.
+    """Admin for coordination locks, gates, and fences.
 
-    Operators can browse to confirm a stuck task left a lock behind, but
-    deletion is hard-disabled: the worker tasks that own these locks
-    rely on them being released by `LockManager`, not by an operator
-    clicking around in the admin. M5's delete service additionally
-    refuses any key whose family has `is_deletable=False` so accidental
-    URL-tampering can't bypass this.
+    Operators can browse to confirm a stuck task left a lock behind.
+    Deletion is **superuser-only** and routes through `redis_delete(
+    ..., allow_locks=True)` so the audit log captures who released
+    which lock. The worker's `LockManager` is still the legitimate
+    releaser in normal operation; the admin path is the on-call
+    escape hatch for genuinely stuck locks (a crashed task that
+    couldn't run its `finally`-block release).
+
+    Staff users still see the read-only changelist + change page.
+    The destructive button / bulk action is hidden from them by
+    `has_delete_permission`, and `services.redis_delete` continues
+    to refuse lock keys that arrive without `allow_locks=True`, so
+    URL-tampering against `RedisQueueAdmin` still can't reach them.
     """
 
     list_display = (
@@ -1161,22 +1168,15 @@ class RedisLockAdmin(admin.ModelAdmin):
     def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
         return bool(request.user and request.user.is_staff)
 
-    # Locks are never deletable from the admin, regardless of role; the
-    # worker's `LockManager` is the only legitimate releaser. This is
-    # stricter than the per-admin "superuser-only deletion" invariant
-    # — locks aren't even superuser-deletable. `services.redis_delete`
-    # additionally refuses any key whose family has `is_deletable=
-    # False` so URL-tampering can't bypass this.
+    # Lock deletion is gated to `is_superuser`, matching the queue
+    # admin's "anything destructive is superuser-only" invariant.
+    # Stock Django `delete_selected` and the change-page delete
+    # button both honour this gate, so staff users see neither.
+    # The actual mutation runs through `services.redis_delete(
+    # ..., allow_locks=True)` so the audit log records who
+    # released which lock.
     def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
-        return False
-
-    def get_actions(self, request):
-        # Strip the default `delete_selected` even though
-        # `has_delete_permission` already blocks it; this keeps the
-        # action dropdown empty so there's nothing to click.
-        actions = super().get_actions(request)
-        actions.pop("delete_selected", None)
-        return actions
+        return bool(request.user and request.user.is_superuser)
 
     def get_fieldsets(self, request, obj=None):
         return ((None, {"fields": list(self.readonly_fields)}),)
@@ -1201,6 +1201,43 @@ class RedisLockAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         raise RuntimeError("RedisLock rows are read-only.")
+
+    # ---- Delete (superuser only) ---------------------------------------
+    #
+    # Stock `delete_selected` (changelist bulk action) and the
+    # change-page delete button both call into one of the two hooks
+    # below; we override them so the actual mutation routes through
+    # `redis_delete(..., allow_locks=True)` and gets the same audit-
+    # log treatment queue deletes do. We deliberately don't strip
+    # `delete_selected` (the queue admin does, in favour of its
+    # dry-run-mandatory `clear_selected`): a lock key is a single
+    # STRING value with no items beneath it, so the standard
+    # confirmation interstitial is enough — no second dry-run gate
+    # needed.
+
+    def delete_model(self, request: HttpRequest, obj: RedisLock) -> None:
+        result = redis_delete(
+            [obj], user=request.user, dry_run=False, allow_locks=True
+        )
+        self.message_user(
+            request,
+            f"Released Redis lock {obj.name!r} ({result.count} removed).",
+            level=messages.SUCCESS,
+        )
+
+    def delete_queryset(self, request: HttpRequest, queryset) -> None:
+        result = redis_delete(
+            list(queryset), user=request.user, dry_run=False, allow_locks=True
+        )
+        self.message_user(
+            request,
+            (
+                f"Released {result.count} Redis lock(s) across "
+                f"families={list(result.families) or '[]'}"
+                + (f"; refused={list(result.refused[:5])}" if result.refused else "")
+            ),
+            level=messages.SUCCESS,
+        )
 
     def get_search_results(self, request, queryset, search_term):
         if not search_term:

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -1216,9 +1216,7 @@ class RedisLockAdmin(admin.ModelAdmin):
     # needed.
 
     def delete_model(self, request: HttpRequest, obj: RedisLock) -> None:
-        result = redis_delete(
-            [obj], user=request.user, dry_run=False, allow_locks=True
-        )
+        result = redis_delete([obj], user=request.user, dry_run=False, allow_locks=True)
         self.message_user(
             request,
             f"Released Redis lock {obj.name!r} ({result.count} removed).",

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -8,7 +8,10 @@ single chokepoint for:
 - Family-aware command dispatch (`DEL` for top-level keys, `LREM` /
   `SREM` / `HDEL` for individual list/set/hash items).
 - Locks safety: any key whose family has `is_deletable=False` is
-  refused, even when the queryset somehow surfaces it.
+  refused by default — the queue admin's URL-tampering safety net.
+  `RedisLockAdmin` opts in via `allow_locks=True` so superusers can
+  release stuck locks from the locks changelist; every other caller
+  inherits the refuse-by-default behaviour.
 - Pipeline batching: `DELETE_BATCH_SIZE` ops per pipeline so a single
   delete action doesn't block Redis with one giant MULTI.
 - Audit logging: every call (dry-run included) writes a
@@ -71,8 +74,16 @@ class _PendingItem:
 
 def _classify_queues(
     queues: Iterable[RedisQueue],
+    *,
+    allow_locks: bool = False,
 ) -> tuple[list[str], list[str], list[str]]:
-    """Bucket `RedisQueue` rows into (deletable_keys, refused_keys, families)."""
+    """Bucket `RedisQueue` rows into (deletable_keys, refused_keys, families).
+
+    `allow_locks=True` lifts the `is_deletable=False` refusal so the
+    lock admin's superuser-only delete path can release stuck locks.
+    Every other caller leaves it `False` so a URL-tampered queue-admin
+    request that smuggles a lock key still refuses.
+    """
 
     deletable: list[str] = []
     refused: list[str] = []
@@ -82,7 +93,7 @@ def _classify_queues(
         if family is None:
             refused.append(queue.name)
             continue
-        if not family.is_deletable:
+        if not family.is_deletable and not allow_locks:
             refused.append(queue.name)
             continue
         deletable.append(queue.name)
@@ -262,13 +273,19 @@ def redis_delete(
     *,
     user,
     dry_run: bool = False,
+    allow_locks: bool = False,
 ) -> DeleteResult:
     """Delete every item in `targets` from Redis, with safety + audit.
 
     `targets` may be a mix of `RedisQueue` (top-level DEL) and
     `RedisQueueItem` (LREM/SREM/HDEL) — the family registry decides
     which command to issue. Lock-flagged families (`is_deletable=False`)
-    are refused regardless of how they were surfaced.
+    are refused unless the caller explicitly opts in with
+    `allow_locks=True` — `RedisLockAdmin`'s superuser-only delete is
+    the only path that does so. Every other surface (the queue admin's
+    `delete_selected` / `delete_model` / `clear-by-scope`) leaves it
+    `False` so a URL-tampered request that smuggles a lock key still
+    refuses.
 
     `user` is the Django user driving the action; used to attribute the
     `LogEntry`. `dry_run=True` returns the same shape but issues no
@@ -279,9 +296,16 @@ def redis_delete(
     with sentry_sdk.start_span(op="redis.admin.delete", name=span_name) as span:
         try:
             span.set_tag("redis_admin.dry_run", dry_run)
+            span.set_tag("redis_admin.allow_locks", allow_locks)
         except AttributeError:  # pragma: no cover - older sdks
             pass
-        return _redis_delete(targets, user=user, dry_run=dry_run, span=span)
+        return _redis_delete(
+            targets,
+            user=user,
+            dry_run=dry_run,
+            allow_locks=allow_locks,
+            span=span,
+        )
 
 
 def _redis_delete(
@@ -289,6 +313,7 @@ def _redis_delete(
     *,
     user,
     dry_run: bool,
+    allow_locks: bool,
     span,
 ) -> DeleteResult:
     queue_targets: list[RedisQueue] = []
@@ -297,10 +322,12 @@ def _redis_delete(
         if isinstance(target, RedisQueueItem):
             item_targets.append(target)
         elif isinstance(target, RedisQueue | RedisLock):
-            # `RedisLock` reaches us only via the URL-tampering safety
-            # net described above; the family registry will refuse it
-            # in `_classify_queues` because its family has
-            # `is_deletable=False`. Cast to `RedisQueue` for the rest
+            # `RedisLock` arrives through two paths: (1) the lock
+            # admin's superuser-only delete, which sets
+            # `allow_locks=True` so `_classify_queues` lets it
+            # through, and (2) URL-tampering against the queue admin,
+            # which leaves `allow_locks=False` so the family-registry
+            # refusal still fires. Cast to `RedisQueue` for the rest
             # of the pipeline since the field shape matches.
             queue_targets.append(target)
         else:
@@ -309,7 +336,9 @@ def _redis_delete(
                 type(target),
             )
 
-    deletable_keys, refused_keys, queue_families = _classify_queues(queue_targets)
+    deletable_keys, refused_keys, queue_families = _classify_queues(
+        queue_targets, allow_locks=allow_locks
+    )
     pending_items, refused_items, item_families = _classify_items(item_targets)
 
     refused = tuple(refused_keys + refused_items)

--- a/apps/codecov-api/redis_admin/services.py
+++ b/apps/codecov-api/redis_admin/services.py
@@ -79,10 +79,15 @@ def _classify_queues(
 ) -> tuple[list[str], list[str], list[str]]:
     """Bucket `RedisQueue` rows into (deletable_keys, refused_keys, families).
 
-    `allow_locks=True` lifts the `is_deletable=False` refusal so the
-    lock admin's superuser-only delete path can release stuck locks.
-    Every other caller leaves it `False` so a URL-tampered queue-admin
-    request that smuggles a lock key still refuses.
+    `allow_locks=True` lifts the `is_deletable=False` refusal *only
+    for lock-category families* so the lock admin's superuser-only
+    delete path can release stuck locks. The `category == "lock"`
+    guard keeps the bypass precise: any future non-lock family that
+    registers as `is_deletable=False` (e.g. a singleton config key
+    we never want operators to clear) stays refused even on the
+    `allow_locks=True` path. Every other caller leaves the kwarg
+    `False` so a URL-tampered queue-admin request that smuggles a
+    lock key still refuses too.
     """
 
     deletable: list[str] = []
@@ -93,7 +98,7 @@ def _classify_queues(
         if family is None:
             refused.append(queue.name)
             continue
-        if not family.is_deletable and not allow_locks:
+        if not family.is_deletable and not (allow_locks and family.category == "lock"):
             refused.append(queue.name)
             continue
         deletable.append(queue.name)

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -1374,8 +1374,17 @@ class RedisAdminSuperuserOnlyDeletionTest(TestCase):
 
     def test_superuser_can_release_lock_from_change_page(self):
         # End-to-end: a superuser POSTs the standard delete-confirmation
-        # form, the lock is gone from Redis, and an audit row is
+        # form, the lock is gone from Redis, and audit rows are
         # written.
+        #
+        # Two LogEntry rows land per delete: Django's stock
+        # `delete_view` calls `self.log_deletion(...)` *before*
+        # `self.delete_model(...)`, and our `delete_model` then calls
+        # `redis_delete()` which writes its own `_record_audit` row.
+        # The two-row trail is intentional — Django's row attributes
+        # the action to the user with the standard admin
+        # representation, ours captures the redis-specific scope
+        # (family, count, refused, sample) for grep-ability.
         superuser = UserFactory(is_staff=True, is_superuser=True)
         self.client.force_login(superuser)
         prior_logs = LogEntry.objects.count()
@@ -1388,7 +1397,7 @@ class RedisAdminSuperuserOnlyDeletionTest(TestCase):
 
         assert response.status_code == 200
         assert self.redis.exists("upload_finisher_gate_1_aaa") == 0
-        assert LogEntry.objects.count() == prior_logs + 1
+        assert LogEntry.objects.count() == prior_logs + 2
 
     def test_superuser_can_bulk_release_locks_from_changelist(self):
         # Stock `delete_selected` runs an interstitial confirmation

--- a/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
+++ b/apps/codecov-api/redis_admin/tests/test_admin_smoke.py
@@ -493,15 +493,17 @@ class RedisLockAdminSmokeTest(TestCase):
         # Queue keys must not bleed into the locks page.
         assert "uploads/1234/abc" not in body
 
-    def test_locks_changelist_has_no_delete_action(self):
+    def test_staff_changelist_has_no_delete_action(self):
+        # Staff users (non-superuser) must not see the bulk delete
+        # action in the locks changelist — destructive lock release
+        # is superuser-only.
         self.redis.set("upload_lock_1_abc", "1")
 
         response = self.client.get("/admin/redis_admin/redislock/")
 
         assert response.status_code == 200
         body = response.content.decode("utf-8")
-        # The default "Delete selected" action must be stripped.
-        assert "delete_selected" not in body
+        assert 'value="delete_selected"' not in body
 
 
 class RedisQueueAdminChangePageTest(TestCase):
@@ -1177,7 +1179,9 @@ class RedisAdminSuperuserOnlyDeletionTest(TestCase):
 
     The rule, restated for the reader of these tests:
       - `RedisQueueAdmin`        deletion gated to `is_superuser`
-      - `RedisLockAdmin`         deletion disabled for everyone
+      - `RedisLockAdmin`         deletion gated to `is_superuser`
+                                 (routes through `redis_delete(...,
+                                 allow_locks=True)`; staff are blocked)
       - `RedisQueueItemAdmin`    deletion disabled for everyone
 
     These tests stay tight on URL/action endpoints because that's what
@@ -1305,11 +1309,12 @@ class RedisAdminSuperuserOnlyDeletionTest(TestCase):
 
     # ---- RedisLockAdmin ------------------------------------------------
 
-    def test_locks_are_undeletable_even_by_superusers(self):
-        # Locks are blanket-disabled, not just superuser-gated. This
-        # is a stricter rule than "deletion is superuser-only" and
-        # exists because the worker's `LockManager` is the only
-        # legitimate releaser of those keys.
+    def test_superuser_sees_bulk_delete_action_on_locks_changelist(self):
+        # Superusers can release stuck locks via the standard bulk
+        # `delete_selected` action — this is the on-call escape hatch
+        # for a crashed task that couldn't run its `finally`-block
+        # release. The action routes through `redis_delete(...,
+        # allow_locks=True)` so the audit log captures the release.
         superuser = UserFactory(is_staff=True, is_superuser=True)
         self.client.force_login(superuser)
 
@@ -1317,18 +1322,26 @@ class RedisAdminSuperuserOnlyDeletionTest(TestCase):
 
         assert response.status_code == 200
         body = response.content.decode("utf-8")
-        # No bulk action dropdown options at all (`actions={}` for
-        # locks). Most importantly: no `delete_selected`.
+        assert 'value="delete_selected"' in body
+
+    def test_staff_does_not_see_bulk_delete_action_on_locks_changelist(self):
+        # Staff users continue to see the read-only changelist;
+        # `has_delete_permission` returns False for them so the bulk
+        # action is filtered out by Django's stock permission gate.
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+
+        response = self.client.get("/admin/redis_admin/redislock/")
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
         assert 'value="delete_selected"' not in body
-        # And there's no clear_* siblings either.
-        assert 'value="clear_selected"' not in body
-        assert 'value="clear_dry_run"' not in body
 
     def test_staff_cannot_post_delete_to_lock_change_page(self):
         staff = UserFactory(is_staff=True, is_superuser=False)
         self.client.force_login(staff)
 
-        # Even if staff somehow handcraft a delete POST to the lock
+        # Even if staff handcraft a delete POST to the lock
         # change-form URL, it must be refused.
         response = self.client.post(
             "/admin/redis_admin/redislock/upload_finisher_gate_5F1_5Faaa/delete/",
@@ -1339,6 +1352,81 @@ class RedisAdminSuperuserOnlyDeletionTest(TestCase):
         # must still be in Redis.
         assert response.status_code in (302, 403, 404)
         assert self.redis.exists("upload_finisher_gate_1_aaa") == 1
+
+    def test_staff_bulk_delete_post_does_not_release_lock(self):
+        # Belt-and-braces: staff posting `action=delete_selected`
+        # against the locks changelist must not release the lock,
+        # even if a future template change started rendering the
+        # action.
+        staff = UserFactory(is_staff=True, is_superuser=False)
+        self.client.force_login(staff)
+
+        self.client.post(
+            "/admin/redis_admin/redislock/",
+            {
+                "action": "delete_selected",
+                "_selected_action": ["upload_finisher_gate_1_aaa"],
+            },
+            follow=True,
+        )
+
+        assert self.redis.exists("upload_finisher_gate_1_aaa") == 1
+
+    def test_superuser_can_release_lock_from_change_page(self):
+        # End-to-end: a superuser POSTs the standard delete-confirmation
+        # form, the lock is gone from Redis, and an audit row is
+        # written.
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        prior_logs = LogEntry.objects.count()
+
+        response = self.client.post(
+            "/admin/redis_admin/redislock/upload_finisher_gate_5F1_5Faaa/delete/",
+            {"post": "yes"},
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        assert self.redis.exists("upload_finisher_gate_1_aaa") == 0
+        assert LogEntry.objects.count() == prior_logs + 1
+
+    def test_superuser_can_bulk_release_locks_from_changelist(self):
+        # Stock `delete_selected` runs an interstitial confirmation
+        # page first; we re-post with `post=yes` to commit the
+        # release. The lock is gone after the second POST.
+        self.redis.set("upload_finisher_gate_2_bbb", "1")
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+
+        # Stage 1: the action POST renders the confirmation page.
+        stage1 = self.client.post(
+            "/admin/redis_admin/redislock/",
+            {
+                "action": "delete_selected",
+                "_selected_action": [
+                    "upload_finisher_gate_1_aaa",
+                    "upload_finisher_gate_2_bbb",
+                ],
+            },
+        )
+        assert stage1.status_code == 200
+        # Stage 2: the confirmation form re-posts with `post=yes`.
+        stage2 = self.client.post(
+            "/admin/redis_admin/redislock/",
+            {
+                "action": "delete_selected",
+                "_selected_action": [
+                    "upload_finisher_gate_1_aaa",
+                    "upload_finisher_gate_2_bbb",
+                ],
+                "post": "yes",
+            },
+            follow=True,
+        )
+
+        assert stage2.status_code == 200
+        assert self.redis.exists("upload_finisher_gate_1_aaa") == 0
+        assert self.redis.exists("upload_finisher_gate_2_bbb") == 0
 
     # ---- RedisQueueItemAdmin -------------------------------------------
 

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -491,6 +491,27 @@ def test_lock_families_are_marked_undeletable_and_lock_category():
             assert fam.category == "queue", fam.name
 
 
+def test_no_non_lock_family_is_undeletable():
+    """The `RedisLockAdmin`'s `redis_delete(..., allow_locks=True)`
+    bypass is gated on `family.category == "lock"` so it never
+    silently allows the deletion of a non-lock family that happens
+    to also be `is_deletable=False`. That guard only earns its keep
+    if the registry invariant holds: every undeletable family is
+    lock-category. A future "singleton config key, never delete"
+    family registered as `is_deletable=False, category="queue"`
+    would silently break that bypass-precision guarantee, so trip
+    this test and force a re-evaluation of the bypass shape
+    instead.
+    """
+    offenders = [
+        f.name for f in FAMILIES if not f.is_deletable and f.category != "lock"
+    ]
+    assert offenders == [], (
+        f"Non-lock families flagged is_deletable=False: {offenders}. "
+        "Re-evaluate the `allow_locks` bypass in services.redis_delete."
+    )
+
+
 def test_iter_keys_with_category_lock_only_returns_locks(patched_redis):
     patched_redis.rpush("uploads/1/abc", "x")
     patched_redis.set("upload_lock_1_abc", "owned")

--- a/apps/codecov-api/redis_admin/tests/test_services.py
+++ b/apps/codecov-api/redis_admin/tests/test_services.py
@@ -94,11 +94,11 @@ class TestRedisDeleteService(TestCase):
         assert self.server.exists("uploads/1/abc") == 0
         assert self.server.exists("uploads/2/def") == 0
 
-    def test_locks_are_refused_even_on_real_run(self):
-        """Lock-flagged families MUST NOT be deletable from this service.
-        This is the last line of defence against an operator mistake;
-        the lock admin already hides the delete UI but the service
-        refuses regardless of how the row was constructed.
+    def test_locks_are_refused_by_default(self):
+        """Lock-flagged families MUST be refused unless the caller
+        opts in with `allow_locks=True`. This is the URL-tampering
+        safety net for `RedisQueueAdmin`: even if the queueset
+        somehow surfaces a lock key, the service refuses it.
         """
 
         self.server.set("upload_lock_1_abc", "owned")
@@ -118,6 +118,50 @@ class TestRedisDeleteService(TestCase):
         # Locks remain in redis.
         assert self.server.exists("upload_lock_1_abc") == 1
         assert self.server.exists("ta_flake_lock:1") == 1
+
+    def test_locks_are_released_with_allow_locks_opt_in(self):
+        """`RedisLockAdmin`'s superuser-only delete passes
+        `allow_locks=True` so stuck locks can actually be released.
+        Verify the keys disappear from Redis and the result
+        accounts for the count.
+        """
+
+        self.server.set("upload_lock_1_abc", "owned")
+        self.server.set("ta_flake_lock:1", "owned")
+
+        result = redis_delete(
+            [
+                _make_lock("upload_lock_1_abc", family="coordination_lock"),
+                _make_lock("ta_flake_lock:1", family="ta_flake_lock"),
+            ],
+            user=self.user,
+            dry_run=False,
+            allow_locks=True,
+        )
+
+        assert result.count == 2
+        assert result.refused == ()
+        assert self.server.exists("upload_lock_1_abc") == 0
+        assert self.server.exists("ta_flake_lock:1") == 0
+
+    def test_allow_locks_dry_run_does_not_mutate(self):
+        """Dry-run with `allow_locks=True` must still issue zero
+        mutations — the opt-in is purely a refusal-bypass, not a
+        force-write.
+        """
+
+        self.server.set("upload_lock_1_abc", "owned")
+
+        result = redis_delete(
+            [_make_lock("upload_lock_1_abc", family="coordination_lock")],
+            user=self.user,
+            dry_run=True,
+            allow_locks=True,
+        )
+
+        assert result.count == 1
+        assert result.dry_run is True
+        assert self.server.exists("upload_lock_1_abc") == 1
 
     def test_unknown_families_are_refused(self):
         """Sanity: a key that doesn't match any family (operator typed


### PR DESCRIPTION
## Summary

- Lift the blanket "locks are never deletable" rule in `RedisLockAdmin`. Superusers can now release a stuck lock from the locks changelist (stock `delete_selected` bulk action) or the change page's delete button — useful as an on-call escape hatch when a crashed task couldn't run its `finally`-block release. Staff users keep the read-only view; the destructive button is hidden and a raw POST still 403s.
- Route the mutation through the existing `services.redis_delete()` so the `LogEntry` audit log captures who released which lock. A new opt-in `allow_locks: bool = False` kwarg lets the lock admin (and only the lock admin) bypass the `is_deletable=False` family-registry refusal. Default is `False`, so the queue admin's `delete_selected` / `delete_model` / `clear-by-scope` continue to refuse lock keys — the URL-tampering safety net is intact.
- Family registry is unchanged — every lock family stays `is_deletable=False, category="lock"`. The opt-in is the single, auditable hinge.

### Behaviour matrix

| Surface | Staff | Superuser |
| --- | --- | --- |
| `RedisLockAdmin` bulk `delete_selected` | hidden + 403 on raw POST | works (audited) |
| `RedisLockAdmin` change-page delete button | hidden + 403 on raw POST | works (audited) |
| `RedisQueueAdmin` `clear_selected` / `clear-by-scope` with a smuggled lock key | refused | refused |
| `services.redis_delete([lock_key])` without kwarg | refused (count=0, refused=...) | refused (same) |
| `services.redis_delete([lock_key], allow_locks=True)` | n/a (admin-only path) | releases the lock |

## Test plan

Smoke-tested locally against fakeredis (DB-backed pytest needs Docker):

- [x] Service default refuses locks (URL-tampering safety net)
- [x] `allow_locks=True` releases locks
- [x] Dry-run with `allow_locks=True` is non-mutating
- [x] Mixed queue+lock targets default to refusing only the lock; queue still deleted
- [x] `RedisLockAdmin.has_delete_permission` is False for staff, True for superuser
- [x] `delete_model` and `delete_queryset` route through `redis_delete(..., allow_locks=True)`
- [x] `get_actions` strip removed; stock `delete_selected` is now available to superusers
- [x] Linter clean across all four files

CI to run the full Django test suite (the new `test_locks_are_refused_by_default`, `test_locks_are_released_with_allow_locks_opt_in`, `test_allow_locks_dry_run_does_not_mutate`, `test_superuser_can_release_lock_from_change_page`, `test_superuser_can_bulk_release_locks_from_changelist`, plus the renamed/inverted prior tests).


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables destructive operations on lock keys (previously impossible) via Django admin; while gated to superusers and audited, mistakes could prematurely release coordination locks and impact running jobs.
> 
> **Overview**
> **Superusers can now delete/release Redis lock keys from `RedisLockAdmin`** (bulk `delete_selected` and change-page delete), while staff remain read-only via `has_delete_permission`.
> 
> Adds an explicit `allow_locks` opt-in to `services.redis_delete()` and `_classify_queues()` so lock-family keys are still refused by default (preserving the URL-tampering safety net) but can be released when invoked from the locks admin; includes Sentry tagging and user-facing success messages.
> 
> Updates and expands tests to cover superuser vs staff UI/POST behavior, the default lock-refusal vs `allow_locks=True` execution path (including dry-run non-mutation), and an invariant test ensuring no non-lock family is marked `is_deletable=False`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b700afa8e3252a7d9de23836f5cd5f5bb0580171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->