### PR TITLE
feat(redis_admin): parse UploadBreadcrumb + ComputeComparison repoid/commitid in celery_broker admin

### DIFF
--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -293,6 +293,13 @@ class CeleryEnvelopeMeta:
     `kwargs` carries the raw decoded keyword-args dict (the second
     element of the kombu body list) when present, so the admin can
     render a `payload_preview` without re-parsing the envelope.
+
+    `comparison_id` is read from `ComputeComparisonTask` envelopes,
+    which only carry `comparison_id` (no repoid / commitid) in their
+    kwargs; the queryset later batch-resolves it to a `(repoid,
+    commitid)` pair via the `compare_commitcomparison` table so
+    operators can still filter those messages by repo or commit on
+    the changelist.
     """
 
     task: str | None = None
@@ -301,6 +308,7 @@ class CeleryEnvelopeMeta:
     commitid: str | None = None
     ownerid: int | None = None
     pullid: int | None = None
+    comparison_id: int | None = None
     kwargs: dict[str, Any] | None = None
 
 
@@ -332,6 +340,20 @@ def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
     has repoid+commitid, sync_pull has repoid+pullid, sync_repos
     has ownerid only) so callers should treat every field as
     independently optional.
+
+    A handful of worker tasks use snake_case kwarg names instead of
+    the codecov-historic `repoid`/`commitid` shape:
+
+    * `UploadBreadcrumbTask` (and `transplant_report`,
+      `process_flakes`, `detect_flakes`) carry `repo_id` /
+      `commit_sha`. We accept those as aliases so the admin still
+      surfaces a structured `(repoid, commitid)` for them without
+      each call site having to remember the right kwarg shape.
+    * `ComputeComparisonTask` carries only `comparison_id`. We pull
+      that into a dedicated field on `CeleryEnvelopeMeta`; the
+      queryset later batch-resolves it to a `(repoid, commitid)`
+      pair via the `compare_commitcomparison` table so filtering
+      and display still work on those messages.
     """
 
     try:
@@ -356,6 +378,7 @@ def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
     commitid: str | None = None
     ownerid: int | None = None
     pullid: int | None = None
+    comparison_id: int | None = None
     kwargs: dict[str, Any] | None = None
     body_b64 = envelope.get("body")
     if isinstance(body_b64, str) and body_b64:
@@ -368,12 +391,21 @@ def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
             body = None
         if isinstance(body, list) and len(body) >= 2 and isinstance(body[1], dict):
             kwargs = body[1]
+            # Prefer the canonical `repoid` / `commitid` shape, but fall
+            # through to the snake_case `repo_id` / `commit_sha` aliases
+            # used by `UploadBreadcrumbTask` and a few other newer tasks
+            # so a single envelope shape covers both conventions.
             repoid = _coerce_int(kwargs.get("repoid"))
+            if repoid is None:
+                repoid = _coerce_int(kwargs.get("repo_id"))
             cid = kwargs.get("commitid")
+            if not (isinstance(cid, str) and cid):
+                cid = kwargs.get("commit_sha")
             if isinstance(cid, str) and cid:
                 commitid = cid
             ownerid = _coerce_int(kwargs.get("ownerid"))
             pullid = _coerce_int(kwargs.get("pullid"))
+            comparison_id = _coerce_int(kwargs.get("comparison_id"))
     return CeleryEnvelopeMeta(
         task=task,
         task_id=task_id,
@@ -381,6 +413,7 @@ def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
         commitid=commitid,
         ownerid=ownerid,
         pullid=pullid,
+        comparison_id=comparison_id,
         kwargs=kwargs,
     )
 

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -36,6 +36,7 @@ from django.test import Client as DjClient
 from django.test import TestCase
 
 from redis_admin import conn as redis_admin_conn
+from redis_admin import queryset as redis_admin_queryset
 from redis_admin import settings as redis_admin_settings
 from redis_admin.admin import CeleryBrokerQueueAdmin, _resolve_repo_displays
 from redis_admin.families import parse_celery_envelope
@@ -237,8 +238,6 @@ def test_materialise_hydrates_comparison_rows_from_db(patched_broker, monkeypatc
     on those columns.
     """
 
-    from redis_admin import queryset as redis_admin_queryset
-
     monkeypatch.setattr(
         redis_admin_queryset,
         "_resolve_comparison_repo_commits",
@@ -252,9 +251,7 @@ def test_materialise_hydrates_comparison_rows_from_db(patched_broker, monkeypatc
         kwargs={"comparison_id": 7777},
     )
 
-    rows = list(
-        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
-    )
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
 
     assert len(rows) == 1
     assert rows[0].repoid == 4242
@@ -269,8 +266,6 @@ def test_materialise_comparison_filter_by_repoid_after_hydration(
     narrows ComputeComparisonTask rows whose envelope only carries
     `comparison_id`.
     """
-
-    from redis_admin import queryset as redis_admin_queryset
 
     monkeypatch.setattr(
         redis_admin_queryset,
@@ -301,15 +296,11 @@ def test_materialise_comparison_filter_by_repoid_after_hydration(
     assert {r.commitid for r in rows} == {"bbb"}
 
 
-def test_materialise_uses_one_orm_call_for_full_window(
-    patched_broker, monkeypatch
-):
+def test_materialise_uses_one_orm_call_for_full_window(patched_broker, monkeypatch):
     """The hydrate helper must batch every comparison_id in the
     materialised window into a single ORM lookup so a 100-deep
     queue of ComputeComparison messages doesn't issue 100 queries.
     """
-
-    from redis_admin import queryset as redis_admin_queryset
 
     call_count = {"n": 0}
 
@@ -331,24 +322,18 @@ def test_materialise_uses_one_orm_call_for_full_window(
             kwargs={"comparison_id": cid},
         )
 
-    rows = list(
-        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
-    )
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
 
     assert len(rows) == 10
     assert call_count["n"] == 1
 
 
-def test_materialise_skips_resolver_when_no_comparison_ids(
-    patched_broker, monkeypatch
-):
+def test_materialise_skips_resolver_when_no_comparison_ids(patched_broker, monkeypatch):
     """A queue carrying only ordinary repoid/commitid envelopes (i.e.
     the hot path) must not pay the ORM round-trip — operators run
     this admin without a CommitComparison-app deployment in some
     tests.
     """
-
-    from redis_admin import queryset as redis_admin_queryset
 
     call_count = {"n": 0}
 
@@ -369,9 +354,7 @@ def test_materialise_skips_resolver_when_no_comparison_ids(
         kwargs={"repoid": 1, "commitid": "a"},
     )
 
-    rows = list(
-        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
-    )
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
 
     assert len(rows) == 1
     assert call_count["n"] == 0
@@ -384,8 +367,6 @@ def test_materialise_keeps_comparison_id_when_resolution_returns_empty(
     falls back to bare `(None, None)` rather than crashing the
     changelist render.
     """
-
-    from redis_admin import queryset as redis_admin_queryset
 
     monkeypatch.setattr(
         redis_admin_queryset,
@@ -400,9 +381,7 @@ def test_materialise_keeps_comparison_id_when_resolution_returns_empty(
         kwargs={"comparison_id": 9999},
     )
 
-    rows = list(
-        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
-    )
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
 
     assert len(rows) == 1
     assert rows[0].repoid is None
@@ -417,8 +396,6 @@ def test_stream_frequency_aggregate_resolves_comparison_buckets(
     under their resolved `(task, repoid, commitid)` bucket rather
     than collapsing every one into the all-None row.
     """
-
-    from redis_admin import queryset as redis_admin_queryset
 
     monkeypatch.setattr(
         redis_admin_queryset,

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -157,6 +157,310 @@ def test_parse_envelope_handles_string_int_repoid():
     assert meta.repoid == 1234
 
 
+def test_parse_envelope_aliases_repo_id_and_commit_sha():
+    """`UploadBreadcrumbTask` carries snake_case `repo_id`/`commit_sha`
+    rather than the canonical `repoid`/`commitid`. Surface them so the
+    admin renders structured columns and accepts repoid/commitid
+    filters on those messages.
+    """
+
+    envelope = _build_envelope(
+        task="app.tasks.upload_breadcrumb.UploadBreadcrumbTask",
+        kwargs={
+            "repo_id": 18802842,
+            "commit_sha": "af73fb73310312d4d2633449e50e6e141191c28c",
+            "upload_ids": [],
+        },
+    )
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.repoid == 18802842
+    assert meta.commitid == "af73fb73310312d4d2633449e50e6e141191c28c"
+
+
+def test_parse_envelope_repoid_canonical_wins_over_alias():
+    """When both `repoid` and `repo_id` are present (defensive belt-and-
+    braces), prefer the canonical name so a task that sets both stays
+    consistent with every other call site.
+    """
+
+    envelope = _build_envelope(
+        kwargs={"repoid": 1, "repo_id": 2, "commitid": "abc", "commit_sha": "xyz"},
+    )
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.repoid == 1
+    assert meta.commitid == "abc"
+
+
+def test_parse_envelope_extracts_comparison_id():
+    """`ComputeComparisonTask` only carries `comparison_id` in kwargs;
+    the queryset's hydrate pass turns it into `(repoid, commitid)`,
+    but the parser surface keeps it on `CeleryEnvelopeMeta` so the
+    queryset has something to hydrate from.
+    """
+
+    envelope = _build_envelope(
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 7777},
+    )
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.comparison_id == 7777
+    assert meta.repoid is None
+    assert meta.commitid is None
+
+
+def test_parse_envelope_comparison_id_handles_string_int():
+    """JSON ints sometimes round-trip as strings; the comparison_id
+    coercion mirrors `repoid` so a stringified value is still picked
+    up by the chart hydration pass.
+    """
+
+    envelope = _build_envelope(kwargs={"comparison_id": "42"})
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.comparison_id == 42
+
+
+# ---- ComputeComparison hydration ------------------------------------------
+
+
+def test_materialise_hydrates_comparison_rows_from_db(patched_broker, monkeypatch):
+    """A `ComputeComparisonTask` envelope only carries `comparison_id`,
+    but after `_materialise` the row should expose the resolved
+    `(repoid, commitid)` pair so the changelist can render and filter
+    on those columns.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {7777: (4242, "deadbeef")},
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 7777},
+    )
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
+    )
+
+    assert len(rows) == 1
+    assert rows[0].repoid == 4242
+    assert rows[0].commitid == "deadbeef"
+
+
+def test_materialise_comparison_filter_by_repoid_after_hydration(
+    patched_broker, monkeypatch
+):
+    """Hydration must run before `_matches_filters`, so a
+    `repoid__exact` filter pushed down from the changelist still
+    narrows ComputeComparisonTask rows whose envelope only carries
+    `comparison_id`.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {1: (10, "aaa"), 2: (20, "bbb")},
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 1},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 2},
+    )
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+            repoid__exact=20
+        )
+    )
+
+    assert {r.repoid for r in rows} == {20}
+    assert {r.commitid for r in rows} == {"bbb"}
+
+
+def test_materialise_uses_one_orm_call_for_full_window(
+    patched_broker, monkeypatch
+):
+    """The hydrate helper must batch every comparison_id in the
+    materialised window into a single ORM lookup so a 100-deep
+    queue of ComputeComparison messages doesn't issue 100 queries.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    call_count = {"n": 0}
+
+    def _fake_resolver(ids):
+        call_count["n"] += 1
+        return {cid: (100 + cid, f"sha-{cid}") for cid in ids}
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        _fake_resolver,
+    )
+
+    for cid in range(1, 11):
+        _push(
+            patched_broker,
+            "notify",
+            task="app.tasks.compute_comparison.ComputeComparison",
+            kwargs={"comparison_id": cid},
+        )
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
+    )
+
+    assert len(rows) == 10
+    assert call_count["n"] == 1
+
+
+def test_materialise_skips_resolver_when_no_comparison_ids(
+    patched_broker, monkeypatch
+):
+    """A queue carrying only ordinary repoid/commitid envelopes (i.e.
+    the hot path) must not pay the ORM round-trip — operators run
+    this admin without a CommitComparison-app deployment in some
+    tests.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    call_count = {"n": 0}
+
+    def _fake_resolver(ids):
+        call_count["n"] += 1
+        return {}
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        _fake_resolver,
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.notify.NotifyTask",
+        kwargs={"repoid": 1, "commitid": "a"},
+    )
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
+    )
+
+    assert len(rows) == 1
+    assert call_count["n"] == 0
+
+
+def test_materialise_keeps_comparison_id_when_resolution_returns_empty(
+    patched_broker, monkeypatch
+):
+    """If the lookup misses (id deleted, ORM unavailable), the row
+    falls back to bare `(None, None)` rather than crashing the
+    changelist render.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {},
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 9999},
+    )
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify")
+    )
+
+    assert len(rows) == 1
+    assert rows[0].repoid is None
+    assert rows[0].commitid is None
+    assert rows[0]._comparison_id == 9999
+
+
+def test_stream_frequency_aggregate_resolves_comparison_buckets(
+    patched_broker, monkeypatch
+):
+    """The chart aggregator must surface ComputeComparison messages
+    under their resolved `(task, repoid, commitid)` bucket rather
+    than collapsing every one into the all-None row.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {1: (10, "aaa"), 2: (20, "bbb")},
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 1},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 1},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 2},
+    )
+
+    buckets, total = _stream_frequency_aggregate(patched_broker, "notify")
+
+    assert total == 3
+    keys = {(b.task_name, b.repoid, b.commitid) for b in buckets}
+    assert (
+        "app.tasks.compute_comparison.ComputeComparison",
+        10,
+        "aaa",
+    ) in keys
+    assert (
+        "app.tasks.compute_comparison.ComputeComparison",
+        20,
+        "bbb",
+    ) in keys
+
+
 def test_parse_envelope_rejects_bool_in_int_fields():
     """`bool` subclasses `int`; refuse to coerce True/False to 1/0."""
 

--- a/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
@@ -467,6 +467,187 @@ def test_unacked_queryset_filter_by_repoid_and_commit_prefix(patched_broker):
     assert [r.delivery_tag for r in rows] == ["t-match"]
 
 
+# ---- ComputeComparison hydration ------------------------------------------
+
+
+def test_unacked_queryset_hydrates_comparison_rows(patched_broker, monkeypatch):
+    """`ComputeComparisonTask` envelopes only carry `comparison_id`.
+    The unacked queryset hydrates `(repoid, commitid)` from the
+    `compare_commitcomparison` row before exposing the materialised
+    list, so the changelist columns and `repoid`/`commitid` filters
+    behave the same as for every other task.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {1: (10, "deadbeef")},
+    )
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="cc-1",
+        routing_key="celery",
+        envelope=_build_envelope(
+            task="app.tasks.compute_comparison.ComputeComparison",
+            kwargs={"comparison_id": 1},
+        ),
+    )
+
+    rows = list(
+        UnackedQueueQuerySet(UnackedQueueItem).filter(routing_key__exact="celery")
+    )
+
+    assert len(rows) == 1
+    assert rows[0].repoid == 10
+    assert rows[0].commitid == "deadbeef"
+
+
+def test_unacked_queryset_filter_by_repoid_after_comparison_hydration(
+    patched_broker, monkeypatch
+):
+    """A `repoid__exact` filter must narrow ComputeComparison rows
+    against the resolved `(repoid, commitid)`, not the raw
+    `comparison_id` — that's the point of running the hydrate pass
+    before `_matches_filters` walks the row list.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {1: (10, "aaa"), 2: (20, "bbb")},
+    )
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="cc-1",
+        routing_key="celery",
+        envelope=_build_envelope(
+            task="app.tasks.compute_comparison.ComputeComparison",
+            kwargs={"comparison_id": 1},
+        ),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="cc-2",
+        routing_key="celery",
+        envelope=_build_envelope(
+            task="app.tasks.compute_comparison.ComputeComparison",
+            kwargs={"comparison_id": 2},
+        ),
+    )
+
+    rows = list(
+        UnackedQueueQuerySet(UnackedQueueItem).filter(
+            routing_key__exact="celery",
+            repoid__exact=20,
+        )
+    )
+
+    assert [r.delivery_tag for r in rows] == ["cc-2"]
+    assert rows[0].commitid == "bbb"
+
+
+def test_unacked_queryset_get_hydrates_singleton_comparison_row(
+    patched_broker, monkeypatch
+):
+    """The `get(pk_token=...)` path bypasses `_materialise` for
+    delivery_tags outside the bounded display window. It must still
+    run the hydrate pass on the singleton row so the change_form
+    sees the resolved repoid/commitid.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {99: (4242, "feedface")},
+    )
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="cc-99",
+        routing_key="celery",
+        envelope=_build_envelope(
+            task="app.tasks.compute_comparison.ComputeComparison",
+            kwargs={"comparison_id": 99},
+        ),
+    )
+
+    row = UnackedQueueQuerySet(UnackedQueueItem).get(pk_token="unacked#cc-99")
+
+    assert row.repoid == 4242
+    assert row.commitid == "feedface"
+
+
+def test_stream_unacked_frequency_aggregate_resolves_comparison_buckets(
+    patched_broker, monkeypatch
+):
+    """The unacked chart's 4-tuple bucket key must surface
+    ComputeComparison messages under their resolved
+    `(routing_key, task, repoid, commitid)` instead of collapsing
+    every one into a single all-None row alongside the routing_key.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {1: (10, "aaa"), 2: (20, "bbb")},
+    )
+
+    _push_unacked(
+        patched_broker,
+        delivery_tag="cc-1a",
+        routing_key="celery",
+        envelope=_build_envelope(
+            task="app.tasks.compute_comparison.ComputeComparison",
+            kwargs={"comparison_id": 1},
+        ),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="cc-1b",
+        routing_key="celery",
+        envelope=_build_envelope(
+            task="app.tasks.compute_comparison.ComputeComparison",
+            kwargs={"comparison_id": 1},
+        ),
+    )
+    _push_unacked(
+        patched_broker,
+        delivery_tag="cc-2",
+        routing_key="celery",
+        envelope=_build_envelope(
+            task="app.tasks.compute_comparison.ComputeComparison",
+            kwargs={"comparison_id": 2},
+        ),
+    )
+
+    buckets, total = _stream_unacked_frequency_aggregate(patched_broker)
+
+    assert total == 3
+    keys = {(b.routing_key, b.task_name, b.repoid, b.commitid) for b in buckets}
+    assert (
+        "celery",
+        "app.tasks.compute_comparison.ComputeComparison",
+        10,
+        "aaa",
+    ) in keys
+    assert (
+        "celery",
+        "app.tasks.compute_comparison.ComputeComparison",
+        20,
+        "bbb",
+    ) in keys
+
+
 # ---- frequency aggregator --------------------------------------------------
 
 

--- a/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_unacked_queue.py
@@ -35,6 +35,7 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
 
 from redis_admin import conn as redis_admin_conn
+from redis_admin import queryset as redis_admin_queryset
 from redis_admin import services as redis_admin_services
 from redis_admin.admin import UnackedQueueAdmin
 from redis_admin.families import (
@@ -478,8 +479,6 @@ def test_unacked_queryset_hydrates_comparison_rows(patched_broker, monkeypatch):
     behave the same as for every other task.
     """
 
-    from redis_admin import queryset as redis_admin_queryset
-
     monkeypatch.setattr(
         redis_admin_queryset,
         "_resolve_comparison_repo_commits",
@@ -513,8 +512,6 @@ def test_unacked_queryset_filter_by_repoid_after_comparison_hydration(
     `comparison_id` — that's the point of running the hydrate pass
     before `_matches_filters` walks the row list.
     """
-
-    from redis_admin import queryset as redis_admin_queryset
 
     monkeypatch.setattr(
         redis_admin_queryset,
@@ -561,8 +558,6 @@ def test_unacked_queryset_get_hydrates_singleton_comparison_row(
     sees the resolved repoid/commitid.
     """
 
-    from redis_admin import queryset as redis_admin_queryset
-
     monkeypatch.setattr(
         redis_admin_queryset,
         "_resolve_comparison_repo_commits",
@@ -593,8 +588,6 @@ def test_stream_unacked_frequency_aggregate_resolves_comparison_buckets(
     `(routing_key, task, repoid, commitid)` instead of collapsing
     every one into a single all-None row alongside the routing_key.
     """
-
-    from redis_admin import queryset as redis_admin_queryset
 
     monkeypatch.setattr(
         redis_admin_queryset,


### PR DESCRIPTION
## Summary

The Redis-admin Celery broker / unacked queue changelists already extract `(repoid, commitid)` from envelope kwargs for most worker tasks, but two task families fall through that path:

- **`UploadBreadcrumbTask`** (and a few other handlers like `transplant_report` / `process_flakes` / `detect_flakes`) carry their repo + commit as `repo_id` / `commit_sha` instead of `repoid` / `commitid`. Example payload from prod:

  ```json
  {
    "commit_sha": "af73fb73310312d4d2633449e50e6e141191c28c",
    "repo_id": 18802842,
    "breadcrumb_data": { "...": "..." },
    "upload_ids": [],
    "sentry_trace_id": "..."
  }
  ```

  Result: the columns + `?repoid=` / `?commitid=` filters silently ignored those messages.

- **`ComputeComparisonTask`** carries only `comparison_id`. A single-pass parse can't fill `(repoid, commitid)` for it.

This PR teaches `parse_celery_envelope` (`apps/codecov-api/redis_admin/families.py`) to:

- accept `repo_id` / `commit_sha` as aliases for `repoid` / `commitid` (canonical names still win when both are present), and
- extract `comparison_id` (string-int tolerant) onto a new `CeleryEnvelopeMeta.comparison_id` field that the queryset hydration step on the base branch picks up to do the batched `compare_commitcomparison` lookup at materialise time.

Net effect: the admin changelist columns, search box, and `?repoid=` / `?commitid=` filters all work for breadcrumb + comparison messages, and the frequency chart buckets resolve to the correct repo/commit instead of collapsing every `ComputeComparisonTask` into a single all-`None` row.

## Stacked on

- #911 (`redis-admin/unacked-queue-drilldown`) — that branch has the queryset + admin plumbing (`_resolve_comparison_repo_commits` batch resolver, `_hydrate_comparison_rows` / `_hydrate_unacked_comparison_rows`, side-counter merge in the streaming aggregators). This PR is just the parser-side change + tests.

## Test plan

- [x] `pytest redis_admin/tests/test_celery_broker_queue.py redis_admin/tests/test_unacked_queue.py -k "comparison or alias or hydrat or repo_id or commit_sha or parse_envelope or stream_frequency or stream_unacked or unacked_queryset"` — 36 passed locally
- [ ] CI green
- [ ] Spot-check one breadcrumb message + one ComputeComparisonTask message in a staging admin once #911 merges

## Tests added

`apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py` — alias + canonical-wins precedence, `comparison_id` int+string parsing, `_materialise` runs the resolver exactly once per page, repoid filtering after hydration, resolver skipped when no `comparison_id`s, rows keep `comparison_id` if resolver returns nothing, `_stream_frequency_aggregate` resolves comparison buckets.

`apps/codecov-api/redis_admin/tests/test_unacked_queue.py` — same coverage on the unacked queryset, including `UnackedQueueQuerySet.get` hydrating a single row for the drill-down, and `_stream_unacked_frequency_aggregate` folding comparison buckets into the main 4-tuple counter.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to redis-admin Celery envelope parsing and test coverage, affecting only admin display/filtering paths and adding tolerant parsing for additional kwarg shapes.
> 
> **Overview**
> Improves redis-admin’s Celery envelope parsing so more task payloads surface usable `repoid`/`commitid` metadata in the `celery_broker` and `unacked` admin views.
> 
> `parse_celery_envelope` now accepts `repo_id`/`commit_sha` as aliases for `repoid`/`commitid` (with canonical names taking precedence) and extracts a new `comparison_id` field for `ComputeComparisonTask` messages so downstream queryset hydration can resolve and bucket them by repo/commit. Extensive tests were added to cover alias precedence, `comparison_id` int coercion, and the expected post-hydration filtering/aggregation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96365161451bca38c0dea53cdd779ac012c77bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->