### PR TITLE
feat(redis_admin): live SCAN-based discovery of celery broker queues

### DIFF
--- a/apps/codecov-api/redis_admin/README.md
+++ b/apps/codecov-api/redis_admin/README.md
@@ -168,15 +168,32 @@ beyond the `BaseCeleryConfig` defaults:
 
 | Config key | Form | Purpose |
 |---|---|---|
-| `setup.redis_admin.celery_queues` | comma-separated string or list | Operator-supplied list of broker queue names (e.g. `uploads,notify,sync,...`). Reads via `shared.config.get_config("setup", "redis_admin", "celery_queues")`, so an env var like `SETUP__REDIS_ADMIN__CELERY_QUEUES=...` works on the API pod. The actual production list lives in private deployment config (it varies per environment), so this isn't shipped with defaults. Each name is `EXISTS`-checked before being yielded — listing a queue that doesn't exist is harmless. |
+| `setup.redis_admin.celery_queues` | comma-separated string or list | Operator-supplied list of broker queue names (e.g. `uploads,notify,sync,...`). Reads via `shared.config.get_config("setup", "redis_admin", "celery_queues")`, so an env var like `SETUP__REDIS_ADMIN__CELERY_QUEUES=...` works on the API pod. The actual production list lives in private deployment config (it varies per environment), so this isn't shipped with defaults. Each name is `EXISTS`-checked before being yielded — listing a queue that doesn't exist is harmless. Optional now that the celery_broker summary unions in live `SCAN ... TYPE list` discovery (see below); use it only when you want a known-but-currently-drained queue to render at `depth=0` even when the broker has never materialised it. |
 
-Without this set the admin's `celery_broker` family only sees
-`celery`, `healthcheck`, and whatever the `enterprise_*` SCAN
-matches; queues like `uploads` / `notify` / `sync` stay invisible
-even when the broker has them, because the API pod doesn't carry
-the worker-side `setup.tasks.*.queue` env vars and so
-`BaseCeleryConfig.task_routes` resolves every route to
-`task_default_queue`.
+The `celery_broker` summary changelist (and the `CeleryQueueFilter`
+sidebar that backs it) does **not** rely on the static enumeration
+alone. On every render it issues a `SCAN ... TYPE list` against the
+broker Redis and unions the result with `_resolve_celery_queue_names()`:
+
+* The broker is a dedicated Redis Memorystore in production
+  (`services.celery_broker`), so every list-typed top-level key on
+  it is a celery queue. Kombu-internal prefixes (`_kombu.*`) and the
+  redis_admin LSET-tombstone prefix are deny-listed.
+* Bounded by `REDIS_ADMIN_MAX_SCAN_KEYS` for the same reason
+  `iter_keys` is bounded; on broker outage / older Redis builds that
+  reject `SCAN ... TYPE`, the helper logs and returns `()` so the
+  summary falls back transparently to the static enumeration.
+* The resolved tuple is cached on the `HttpRequest` so the summary
+  changelist and the sidebar dropdown share one SCAN per page
+  render.
+
+The net effect is that on a typical production deploy the API pod
+sees every queue actually present on the broker — including the
+per-tenant `enterprise_*_dropbox` / `_mixpanel` / `_squareup`
+variants that aren't reachable from `BaseCeleryConfig` because
+worker-side `setup.tasks.*.queue` env vars don't ship to the API
+pod — without the operator having to maintain a static
+`setup.redis_admin.celery_queues` list.
 
 ## Celery broker admin
 
@@ -191,11 +208,11 @@ don't double up between the two admins.
 ### Summary mode (`/admin/redis_admin/celerybrokerqueue/`)
 
 The default landing page when an on-call engineer clicks through
-from Grafana. One row per known celery queue:
+from Grafana. One row per celery queue:
 
 | Column | Source |
 |---|---|
-| `queue_name` | `_resolve_celery_queue_names()` (`BaseCeleryConfig.task_routes` + `celery`/`healthcheck` defaults + operator-supplied `setup.redis_admin.celery_queues`) |
+| `queue_name` | `_resolve_summary_queue_names()` — union of `_resolve_celery_queue_names()` (static: `BaseCeleryConfig.task_routes` + `celery`/`healthcheck` defaults + operator-supplied `setup.redis_admin.celery_queues`) and `_discover_celery_queues_from_broker()` (live `SCAN ... TYPE list` against the broker, with kombu-internal prefixes deny-listed). |
 | `depth` | `LLEN(<queue>)` |
 | `messages` | Drill-in link "view N message(s) →" that re-renders the same admin with `?queue_name__exact=<queue>` |
 

--- a/apps/codecov-api/redis_admin/admin.py
+++ b/apps/codecov-api/redis_admin/admin.py
@@ -41,14 +41,12 @@ from core.models import Repository
 from . import conn as _conn
 from . import settings as redis_admin_settings
 from .families import FAMILIES, iter_families, iter_keys
-from .families import (
-    _resolve_celery_queue_names as _celery_queue_names,  # noqa: PLC2701 - reused for filter lookups
-)
 from .models import CeleryBrokerQueue, RedisLock, RedisQueue, RedisQueueItem
 from .queryset import (
     CeleryBrokerQueueQuerySet,
     RedisItemQuerySet,
     _build_redis_queue,
+    _resolve_summary_queue_names,  # noqa: PLC2701 - shared with summary changelist + sidebar pickers
     _stream_frequency_aggregate,
     resolve_payload_preview,
 )
@@ -445,20 +443,21 @@ class CeleryQueueFilter(admin.SimpleListFilter):
     otherwise have to either remember the exact key name or hand-type
     `family:celery_broker name:notify_celery` into the search bar.
 
-    This filter surfaces the same enumeration `families.celery_broker`
-    uses for its `fixed_keys`, so the picker is always in sync with the
-    queues the admin can actually inspect — adding a new queue to
-    `task_routes` automatically adds it to the filter on next request.
+    This filter surfaces the same union the summary changelist
+    materialises (`_resolve_summary_queue_names` =
+    `_resolve_celery_queue_names()` ∪ live `SCAN ... TYPE list` of
+    the broker), so the picker is always in sync with the queues
+    the admin can actually inspect: a new queue added to
+    `task_routes` shows up on the next request, and a per-tenant
+    `enterprise_*_dropbox` / `_mixpanel` / `_squareup` variant
+    surfaces the moment kombu materialises it on the broker —
+    even on deploys that never set
+    `setup.redis_admin.celery_queues`.
 
     Selecting a queue narrows the changelist to a single row
     (`family__exact=celery_broker AND name__exact=<queue>`); the
-    well-known queues are unique by name so this collapses cleanly to
-    "the row for that queue".
-
-    Dynamic `enterprise_*` queues aren't enumerable from configuration
-    and are intentionally excluded from the dropdown — operators who
-    need them can keep using the search bar (`family:celery_broker
-    enterprise_acme`) which already handles substring match.
+    queue names are unique by definition so this collapses cleanly
+    to "the row for that queue".
     """
 
     title = "celery queue"
@@ -466,10 +465,14 @@ class CeleryQueueFilter(admin.SimpleListFilter):
 
     def lookups(self, request, model_admin):
         # Re-resolved per request so a config change picks up without
-        # requiring a worker restart; `_celery_queue_names` itself
-        # falls back to `("celery", "healthcheck")` if the celery
-        # config import fails, so the dropdown is never empty.
-        return tuple((name, name) for name in _celery_queue_names())
+        # requiring a worker restart, and so a new `enterprise_*`
+        # queue that was just materialised on the broker appears in
+        # the dropdown immediately. The static fallback inside
+        # `_resolve_summary_queue_names` keeps the dropdown
+        # populated even when broker discovery fails.
+        broker = _conn.get_connection(kind="broker")
+        names = _resolve_summary_queue_names(broker, request=request)
+        return tuple((name, name) for name in names)
 
     def queryset(self, request, queryset):
         value = self.value()

--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -237,6 +237,14 @@ def _resolve_celery_queue_names() -> tuple[str, ...]:
     Falls back to just (1) + the hardcoded `("celery",
     "healthcheck")` defaults if `BaseCeleryConfig` can't be imported
     (e.g. minimal-env tests).
+
+    This is the *static* enumeration. The summary admin and the
+    `CeleryQueueFilter` sidebar union this with
+    `_discover_celery_queues_from_broker()` (a live SCAN of the
+    broker Redis) so deployments that haven't set
+    `setup.redis_admin.celery_queues` still see every queue that
+    actually exists, while empty-but-known queues never disappear
+    just because they happen to be drained at render time.
     """
 
     names: set[str] = set(_operator_configured_celery_queues())
@@ -263,6 +271,93 @@ def _resolve_celery_queue_names() -> tuple[str, ...]:
             if isinstance(queue_name, str) and queue_name:
                 names.add(queue_name)
     return tuple(sorted(names))
+
+
+# Top-level keys on the broker Redis that are list-typed but *not*
+# celery queues. Kombu's `unacked` (HASH) and `unacked_index` (ZSET)
+# live on the same broker but are filtered out by the SCAN's
+# `TYPE=list` guard already, so they don't need entries here. The
+# prefixes catch:
+#
+# * `__redis_admin_celery_tombstone__:<uuid>` — our own LSET
+#   tombstones for the celery_broker clear path
+#   (see `services._celery_clear_tombstone`). Tombstones live as
+#   *list elements* inside a queue, never as top-level keys, but
+#   we deny-list the prefix defensively in case a future cleanup
+#   path ever lands one at the key level.
+# * `_kombu.` — kombu's own bookkeeping keys. These are SET / HASH
+#   typed in current versions and would be filtered by `TYPE=list`,
+#   but kombu's internals have shifted before so the prefix match
+#   is cheap insurance against a future kombu release adding a
+#   list-typed bookkeeping key.
+_INTERNAL_BROKER_KEY_PREFIXES: tuple[str, ...] = (
+    "__redis_admin_celery_tombstone__",
+    "_kombu.",
+)
+
+
+def _is_internal_broker_key(name: str) -> bool:
+    """Return True if `name` looks like a kombu / redis_admin internal
+    list key on the broker rather than a celery queue.
+    """
+
+    return any(name.startswith(prefix) for prefix in _INTERNAL_BROKER_KEY_PREFIXES)
+
+
+@sentry_sdk.trace
+def _discover_celery_queues_from_broker(redis: Any) -> tuple[str, ...]:
+    """Live SCAN of the broker Redis for list-typed celery queue keys.
+
+    Production deploys put the celery broker on a dedicated Redis
+    Memorystore (see `redis_admin.conn._broker_connection`), so
+    virtually every list-typed top-level key on it IS a celery
+    queue. `SCAN ... TYPE list` (Redis 6.0+) filters server-side, so
+    we avoid a `TYPE` round-trip per key on top of the SCAN itself —
+    on a 12-base-queues × 4-enterprise-variants topology that's the
+    difference between one SCAN cursor sweep and ~50 extra round-trips.
+    Kombu-internal keys (`_kombu.*`) and our own LSET tombstone
+    prefix are skipped via `_is_internal_broker_key` so the summary
+    stays scoped to real queues.
+
+    Bounded by `MAX_SCAN_KEYS` for the same reason `iter_keys` is
+    bounded — a runaway scan on an unexpectedly large broker
+    keyspace can't pin the api process. On exception (older Redis
+    builds that don't accept the `TYPE` arg, broker outage, etc.)
+    we log and return `()`; the caller falls back to the static
+    `_resolve_celery_queue_names()` enumeration so the admin
+    landing page still renders something useful.
+
+    Returned tuple is sorted for deterministic ordering at the
+    callsite (the summary changelist and the
+    `CeleryQueueFilter` dropdown both render in stable order).
+    """
+
+    cap = redis_admin_settings.MAX_SCAN_KEYS
+    count = redis_admin_settings.SCAN_COUNT
+    discovered: set[str] = set()
+    try:
+        for raw in redis.scan_iter(match="*", count=count, _type="list"):
+            name = _decode(raw)
+            if not name or _is_internal_broker_key(name):
+                continue
+            discovered.add(name)
+            if len(discovered) >= cap:
+                log.warning(
+                    "redis_admin: hit MAX_SCAN_KEYS=%s during live broker "
+                    "queue discovery; truncating",
+                    cap,
+                )
+                break
+    except Exception:
+        # Older Redis builds (<6.0) reject `TYPE`; broker outage or a
+        # misbehaving fakeredis double can also surface here. Either
+        # way, fall back rather than crash the admin landing page.
+        log.exception(
+            "redis_admin: live broker queue discovery failed; "
+            "falling back to static queue enumeration"
+        )
+        return ()
+    return tuple(sorted(discovered))
 
 
 @dataclass(frozen=True)

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -27,6 +27,7 @@ from . import settings as redis_admin_settings
 from .families import (
     CeleryEnvelopeMeta,
     Family,
+    _discover_celery_queues_from_broker,  # noqa: PLC2701
     find_family,
     iter_keys,
     parse_celery_envelope,
@@ -1179,6 +1180,61 @@ def _stream_frequency_aggregate(
     return buckets, total
 
 
+# Per-request cache attribute name for the resolved summary queue
+# set. The summary changelist (`CeleryBrokerQueueQuerySet.
+# _materialise_summary`) and the sidebar `CeleryQueueFilter.lookups`
+# render on the same page in the admin and would otherwise each
+# trigger their own `SCAN ... TYPE list` against the broker. Stashing
+# the union on the request lets the second caller reuse the first
+# one's work for the duration of that request. See
+# `_REQUEST_CACHE_ATTR` on `CeleryBrokerQueueQuerySet` for the
+# matching pattern used by the LRANGE materialisation.
+_SUMMARY_QUEUE_NAMES_REQUEST_ATTR: str = "_celery_broker_summary_queue_names"
+
+
+def _resolve_summary_queue_names(
+    redis: Any,
+    *,
+    request: Any = None,
+) -> tuple[str, ...]:
+    """Return the sorted union of statically-known + live-discovered queues.
+
+    Combines `_celery_queue_names()` (the static enumeration from
+    `BaseCeleryConfig.task_routes` + operator config + the
+    `celery` / `healthcheck` defaults) with
+    `_discover_celery_queues_from_broker(redis)` (a live
+    `SCAN ... TYPE list` against the broker). The static side keeps
+    well-known but currently-drained queues visible (so an operator
+    investigating "did `healthcheck` get drained?" still sees the
+    `depth=0` row); the live side picks up every queue actually
+    present on the broker, including the per-tenant `enterprise_*`
+    variants that aren't reachable from the API pod's view of
+    `BaseCeleryConfig` because `setup.tasks.*.queue` env vars only
+    ship to worker pods.
+
+    When `request` is supplied, the resolved tuple is cached on it
+    via `_SUMMARY_QUEUE_NAMES_REQUEST_ATTR` so a second caller in
+    the same request (typically `CeleryQueueFilter.lookups` after
+    `_materialise_summary`) doesn't re-issue the SCAN.
+    """
+
+    if request is not None:
+        cached = getattr(request, _SUMMARY_QUEUE_NAMES_REQUEST_ATTR, None)
+        if cached is not None:
+            return cached
+    names: set[str] = set(_celery_queue_names())
+    names.update(_discover_celery_queues_from_broker(redis))
+    resolved = tuple(sorted(names))
+    if request is not None:
+        try:
+            setattr(request, _SUMMARY_QUEUE_NAMES_REQUEST_ATTR, resolved)
+        except (AttributeError, TypeError):  # pragma: no cover - defensive
+            # Some request stand-ins in tests are immutable; cache
+            # miss is fine, we just pay the SCAN twice.
+            pass
+    return resolved
+
+
 class CeleryBrokerQueueQuerySet:
     """Fake QuerySet over messages inside one celery_broker queue.
 
@@ -1468,24 +1524,45 @@ class CeleryBrokerQueueQuerySet:
 
     @sentry_sdk.trace
     def _materialise_summary(self) -> list:
-        """One row per known celery queue with `depth = LLEN(queue)`.
+        """One row per celery queue with `depth = LLEN(queue)`.
 
         Drives the `/admin/redis_admin/celerybrokerqueue/` landing
         page (no `queue_name` filter): operators see every queue and
         its current depth at a glance, then click through to the
-        per-message drill-down. The set of queues is the same one
-        `CeleryQueueFilter` enumerates, so the picker stays in sync
-        with the admin's other surfaces.
+        per-message drill-down.
 
-        Empty queues are kept in the list so an operator who knows a
-        queue exists but is currently drained doesn't lose the entry
-        point — `LLEN` returns 0 for both empty and missing keys, and
-        we treat them identically here.
+        The queue set is the union of:
+
+        * `_discover_celery_queues_from_broker()` — a live
+          `SCAN ... TYPE list` against the broker Redis. The broker
+          is a dedicated Memorystore in production (see
+          `redis_admin.conn`), so every list-typed key on it is a
+          celery queue (kombu internals + our LSET tombstones are
+          deny-listed). This is what surfaces `uploads`, `notify`,
+          `sync`, the per-tenant `enterprise_*_dropbox` /
+          `_mixpanel` / `_squareup` variants, etc. on a deploy that
+          never set `setup.redis_admin.celery_queues`.
+        * `_celery_queue_names()` — the static enumeration
+          (`BaseCeleryConfig.task_routes` queues + the well-known
+          `celery` / `healthcheck` defaults + operator-configured
+          `setup.redis_admin.celery_queues`). Unioning this with
+          live discovery means a queue that's known to the
+          deployment but currently drained still renders a
+          `depth=0` row instead of vanishing, so the entry point
+          stays visible. `LLEN` returns 0 for both empty and
+          missing keys, so empty/known/missing all render as
+          `depth=0` and we treat them identically.
         """
 
         redis = self._connection()
+        # Per-request cache: `CeleryQueueFilter.lookups` (the sidebar
+        # picker) renders on the same page and would otherwise issue
+        # its own `SCAN ... TYPE list` round-trip; sharing through
+        # the request stash collapses it to one. Standalone callers
+        # without a request just eat the per-call SCAN cost.
+        names = _resolve_summary_queue_names(redis, request=self._request)
         rows: list = []
-        for name in _celery_queue_names():
+        for name in names:
             try:
                 depth = int(redis.llen(name) or 0)
             except Exception:  # pragma: no cover - defensive

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -1699,6 +1699,203 @@ def test_queryset_summary_mode_lists_known_queues_with_depth(patched_broker):
     assert by_name["celery"].pk_token == "celery#summary"
 
 
+def test_queryset_summary_mode_unions_live_broker_scan_with_static_names(
+    patched_broker,
+):
+    """Summary mode must include queues discovered live on the broker
+    even when they aren't in `_celery_queue_names()`. This is the
+    production case the change fixes: on the API pod
+    `_resolve_celery_queue_names` returns only `("celery",
+    "healthcheck")` because `setup.tasks.*.queue` env vars don't
+    ship there, but the broker actually carries `uploads`, `notify`,
+    `sync`, and every per-tenant `enterprise_*` variant.
+
+    Push some of those directly onto the fake broker and confirm they
+    surface as summary rows with the correct `LLEN`-derived depth.
+    """
+
+    patched_broker.rpush("uploads", _build_envelope(kwargs={"repoid": 1}))
+    patched_broker.rpush("uploads", _build_envelope(kwargs={"repoid": 2}))
+    patched_broker.rpush("notify", _build_envelope(kwargs={}))
+    patched_broker.rpush("enterprise_uploads_dropbox", _build_envelope(kwargs={}))
+
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue)
+    rows = list(qs)
+
+    by_name = {r.queue_name: r for r in rows}
+    # Live-discovered queues land in the summary even though
+    # `_resolve_celery_queue_names()` doesn't know about them.
+    assert by_name["uploads"].depth == 2
+    assert by_name["notify"].depth == 1
+    assert by_name["enterprise_uploads_dropbox"].depth == 1
+    # Static defaults still render at depth=0 so a known-but-drained
+    # queue stays visible — `_celery_queue_names` returns
+    # `("celery", "healthcheck")` in the minimal test env.
+    assert by_name["healthcheck"].depth == 0
+
+
+def test_queryset_summary_mode_skips_kombu_internal_keys(patched_broker):
+    """The unacked HASH (`unacked`) and `unacked_index` ZSET live on
+    the same broker as the celery queues. The SCAN's `TYPE=list`
+    filter handles those today; the prefix deny-list catches future
+    list-typed kombu / redis_admin internals (e.g. `_kombu.binding.*`,
+    LSET tombstones). Confirm neither leaks into the summary.
+    """
+
+    patched_broker.rpush("uploads", _build_envelope(kwargs={}))
+    patched_broker.hset("unacked", "tag-1", "envelope")
+    patched_broker.zadd("unacked_index", {"tag-1": 1.0})
+    patched_broker.rpush("_kombu.binding.celery", "binding")
+    patched_broker.rpush(
+        "__redis_admin_celery_tombstone__:abc",
+        "stray-tombstone-as-key",
+    )
+
+    qs = CeleryBrokerQueueQuerySet(CeleryBrokerQueue)
+    rows = list(qs)
+
+    names = {r.queue_name for r in rows}
+    assert "uploads" in names
+    assert "unacked" not in names
+    assert "unacked_index" not in names
+    assert "_kombu.binding.celery" not in names
+    assert "__redis_admin_celery_tombstone__:abc" not in names
+
+
+def test_queryset_summary_mode_caches_discovery_on_request(patched_broker, monkeypatch):
+    """The summary changelist (`_materialise_summary`) and the
+    sidebar `CeleryQueueFilter.lookups` both render on the same
+    admin response. Without a per-request cache each one would
+    issue its own `SCAN ... TYPE list` against the broker. Confirm
+    a second materialisation against the same `request` reuses the
+    first one's discovery result.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset  # noqa: PLC0415
+
+    patched_broker.rpush("uploads", _build_envelope(kwargs={}))
+
+    call_count = 0
+    real_discover = redis_admin_queryset._discover_celery_queues_from_broker
+
+    def counting_discover(redis):
+        nonlocal call_count
+        call_count += 1
+        return real_discover(redis)
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_discover_celery_queues_from_broker",
+        counting_discover,
+    )
+
+    request = SimpleNamespace()
+    list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, request=request))
+    list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, request=request))
+
+    assert call_count == 1
+
+
+def test_queryset_summary_mode_no_request_skips_cache(patched_broker, monkeypatch):
+    """Standalone callers (no plumbed request) eat the per-call SCAN
+    cost. Confirm the cache short-circuit doesn't accidentally pin
+    state on the queryset object instead.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset  # noqa: PLC0415
+
+    patched_broker.rpush("uploads", _build_envelope(kwargs={}))
+
+    call_count = 0
+    real_discover = redis_admin_queryset._discover_celery_queues_from_broker
+
+    def counting_discover(redis):
+        nonlocal call_count
+        call_count += 1
+        return real_discover(redis)
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_discover_celery_queues_from_broker",
+        counting_discover,
+    )
+
+    list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue))
+    list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue))
+
+    assert call_count == 2
+
+
+# ---- Sidebar `CeleryQueueFilter` discovery ---------------------------------
+
+
+def test_celery_queue_filter_lookups_includes_live_broker_queues(patched_broker):
+    """The drill-down sidebar `CeleryQueueFilter` must surface the
+    same union the summary changelist materialises, so an operator
+    can pick a per-tenant `enterprise_*_dropbox` queue from the
+    dropdown without first knowing it exists. Pin that the picker
+    sees both static defaults and live-discovered queues.
+    """
+
+    from redis_admin.admin import CeleryQueueFilter  # noqa: PLC0415
+
+    patched_broker.rpush("uploads", _build_envelope(kwargs={}))
+    patched_broker.rpush("enterprise_uploads_dropbox", _build_envelope(kwargs={}))
+
+    # Construct the filter without going through Django's
+    # `SimpleListFilter.__init__` — we only need `lookups` here, and
+    # the base constructor expects a fully-shaped admin request that
+    # would otherwise need a live `RequestFactory` setup.
+    flt = CeleryQueueFilter.__new__(CeleryQueueFilter)
+    request = SimpleNamespace(GET={})
+    options = dict(flt.lookups(request, model_admin=None))
+
+    assert "uploads" in options
+    assert "enterprise_uploads_dropbox" in options
+    # Static defaults remain in the picker so a known-but-drained
+    # queue is still selectable from the sidebar.
+    assert "celery" in options
+    assert "healthcheck" in options
+
+
+def test_celery_queue_filter_lookups_reuses_request_cache(patched_broker, monkeypatch):
+    """Both the changelist (`_materialise_summary`) and the sidebar
+    (`CeleryQueueFilter.lookups`) render on the same admin response.
+    They must share the per-request discovery cache so we don't pay
+    two `SCAN ... TYPE list` round-trips per page render.
+    """
+
+    from redis_admin import queryset as redis_admin_queryset  # noqa: PLC0415
+    from redis_admin.admin import CeleryQueueFilter  # noqa: PLC0415
+
+    patched_broker.rpush("uploads", _build_envelope(kwargs={}))
+
+    call_count = 0
+    real_discover = redis_admin_queryset._discover_celery_queues_from_broker
+
+    def counting_discover(redis):
+        nonlocal call_count
+        call_count += 1
+        return real_discover(redis)
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_discover_celery_queues_from_broker",
+        counting_discover,
+    )
+
+    request = SimpleNamespace(GET={})
+
+    # Materialise the summary first (queryset path), then ask the
+    # sidebar filter for its lookups (admin path). The sidebar must
+    # hit the cache and not re-SCAN.
+    list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, request=request))
+    flt = CeleryQueueFilter.__new__(CeleryQueueFilter)
+    flt.lookups(request, model_admin=None)
+
+    assert call_count == 1
+
+
 # ---- Summary-mode default ordering ----------------------------------------
 
 

--- a/apps/codecov-api/redis_admin/tests/test_families.py
+++ b/apps/codecov-api/redis_admin/tests/test_families.py
@@ -300,6 +300,117 @@ def test_resolve_celery_queue_names_unset_keeps_defaults(monkeypatch):
     assert "healthcheck" in names
 
 
+# ---- Live broker queue discovery -------------------------------------------
+
+
+def test_discover_celery_queues_from_broker_returns_only_list_keys():
+    """`_discover_celery_queues_from_broker` must SCAN with TYPE=list
+    so kombu's HASH (`unacked`) and ZSET (`unacked_index`) — which
+    live on the same broker Redis — never surface as queues.
+    """
+
+    from redis_admin.families import (  # noqa: PLC0415
+        _discover_celery_queues_from_broker,
+    )
+
+    broker = fakeredis.FakeStrictRedis()
+    broker.rpush("uploads", "x")
+    broker.rpush("notify", "y")
+    broker.rpush("enterprise_uploads_dropbox", "z")
+    broker.hset("unacked", "tag-1", "envelope")
+    broker.zadd("unacked_index", {"tag-1": 1.0})
+    broker.set("celery-task-meta-abc", "result")
+
+    discovered = _discover_celery_queues_from_broker(broker)
+
+    assert set(discovered) == {"uploads", "notify", "enterprise_uploads_dropbox"}
+
+
+def test_discover_celery_queues_from_broker_skips_kombu_internal_prefixes():
+    """List-typed kombu / redis_admin internal keys (e.g. `_kombu.*`,
+    LSET tombstone prefix) must be deny-listed even though the
+    TYPE=list filter would otherwise let them through. Future-proofs
+    against kombu releases that introduce list-typed bookkeeping
+    keys we don't want to surface as celery queues.
+    """
+
+    from redis_admin.families import (  # noqa: PLC0415
+        _discover_celery_queues_from_broker,
+    )
+
+    broker = fakeredis.FakeStrictRedis()
+    broker.rpush("uploads", "x")
+    broker.rpush("_kombu.binding.celery", "binding-1")
+    broker.rpush(
+        "__redis_admin_celery_tombstone__:abc123",
+        "tombstone-as-top-level-key",
+    )
+
+    discovered = _discover_celery_queues_from_broker(broker)
+
+    assert set(discovered) == {"uploads"}
+
+
+def test_discover_celery_queues_from_broker_returns_sorted_tuple():
+    """Stable ordering matters because the summary changelist and the
+    `CeleryQueueFilter` dropdown both render the names directly; an
+    unstable order would reshuffle the page on every refresh.
+    """
+
+    from redis_admin.families import (  # noqa: PLC0415
+        _discover_celery_queues_from_broker,
+    )
+
+    broker = fakeredis.FakeStrictRedis()
+    for name in ("zeta", "alpha", "mu"):
+        broker.rpush(name, "x")
+
+    discovered = _discover_celery_queues_from_broker(broker)
+
+    assert discovered == ("alpha", "mu", "zeta")
+
+
+def test_discover_celery_queues_from_broker_handles_scan_errors_gracefully():
+    """Older Redis builds reject `SCAN ... TYPE`, and a broker outage
+    can surface here too. The helper must log and return `()` so the
+    summary admin falls back to the static enumeration rather than
+    crashing the changelist render.
+    """
+
+    from redis_admin.families import (  # noqa: PLC0415
+        _discover_celery_queues_from_broker,
+    )
+
+    class _BrokenBroker:
+        def scan_iter(self, **_kwargs):
+            raise RuntimeError("ERR syntax error: TYPE not supported")
+
+    discovered = _discover_celery_queues_from_broker(_BrokenBroker())
+
+    assert discovered == ()
+
+
+def test_discover_celery_queues_from_broker_respects_max_scan_keys(monkeypatch):
+    """`MAX_SCAN_KEYS` bounds the discovery sweep so an unexpectedly
+    large broker keyspace can't pin the api process. Drop the cap to
+    a small number and confirm we stop early.
+    """
+
+    from redis_admin import settings as redis_admin_settings  # noqa: PLC0415
+    from redis_admin.families import (  # noqa: PLC0415
+        _discover_celery_queues_from_broker,
+    )
+
+    monkeypatch.setattr(redis_admin_settings, "MAX_SCAN_KEYS", 3)
+    broker = fakeredis.FakeStrictRedis()
+    for i in range(20):
+        broker.rpush(f"queue_{i:02d}", "x")
+
+    discovered = _discover_celery_queues_from_broker(broker)
+
+    assert len(discovered) == 3
+
+
 def test_iter_keys_yields_celery_queues_via_fixed_keys(patched_redis):
     patched_redis.rpush("celery", '{"task": "x"}')
     patched_redis.rpush("healthcheck", '{"task": "y"}')


### PR DESCRIPTION
## Summary

The `CeleryBrokerQueueAdmin` summary changelist (and the
`CeleryQueueFilter` sidebar that backs its drill-down picker)
previously sourced its queue list exclusively from
`_resolve_celery_queue_names()` — a *static* enumeration of
`BaseCeleryConfig.task_routes` plus the `celery` / `healthcheck`
defaults plus operator-configured `setup.redis_admin.celery_queues`.

That works on worker pods, but on the API pod (where the admin runs)
the worker-side `setup.tasks.*.queue` env vars don't ship, so
`BaseCeleryConfig.task_routes` resolves every route to
`task_default_queue` (`"celery"`) and the admin only sees the queues
an operator has explicitly declared. Per-tenant
`enterprise_*_dropbox` / `_mixpanel` / `_squareup` variants —
generated dynamically by `shared.celery_router` based on owner
config — never made it onto that static list, so they were silently
invisible in admin even when sitting on the broker with thousands of
messages.

This change makes the celery_broker summary the **union** of:

- `_discover_celery_queues_from_broker()` — a live `SCAN ... TYPE list`
  against the broker Redis. The broker is a dedicated Memorystore in
  production (`services.celery_broker`), so every list-typed
  top-level key on it is a celery queue. The server-side `TYPE`
  filter (Redis 6.0+) avoids a `TYPE` round-trip per key. Kombu
  internals (`_kombu.*`) and the `redis_admin` LSET-tombstone prefix
  are deny-listed so the summary stays scoped to real queues.
  Bounded by `MAX_SCAN_KEYS`; on broker outage / older Redis builds
  that reject the `TYPE` arg, the helper logs and returns `()` and
  the summary falls back transparently to the static enumeration.
- `_resolve_celery_queue_names()` — preserved for the existing
  contract: a known-but-currently-drained queue still renders a
  `depth=0` row instead of vanishing the moment kombu deletes its
  empty list.

The summary changelist (`CeleryBrokerQueueQuerySet._materialise_summary`)
and the sidebar filter (`CeleryQueueFilter.lookups`) both render on
the same admin response, so the resolved tuple is cached on the
`HttpRequest` via `_SUMMARY_QUEUE_NAMES_REQUEST_ATTR` — one SCAN per
page render rather than two.

Operators no longer need to maintain
`SETUP__REDIS_ADMIN__CELERY_QUEUES` on the API pod for the admin to
see the broker's queue topology, though the knob is still honoured
(now scoped to "render this drained-but-known queue at `depth=0`
even when the broker has never materialised it").

## Test plan

New unit + integration tests (all passing locally):

- [x] `test_discover_celery_queues_from_broker_returns_only_list_keys` — `TYPE=list` filter skips kombu's `unacked` HASH / `unacked_index` ZSET / unrelated string keys
- [x] `test_discover_celery_queues_from_broker_skips_kombu_internal_prefixes` — `_kombu.*` + `__redis_admin_celery_tombstone__:*` deny-list
- [x] `test_discover_celery_queues_from_broker_returns_sorted_tuple` — deterministic ordering for stable changelist render
- [x] `test_discover_celery_queues_from_broker_handles_scan_errors_gracefully` — falls back to `()` on broker outage / older Redis (no `TYPE` arg)
- [x] `test_discover_celery_queues_from_broker_respects_max_scan_keys` — `MAX_SCAN_KEYS` truncation
- [x] `test_queryset_summary_mode_unions_live_broker_scan_with_static_names` — summary contains both live-discovered (`uploads`, `notify`, `enterprise_*`) and static (`celery`, `healthcheck`) queues
- [x] `test_queryset_summary_mode_skips_kombu_internal_keys` — internal keys filtered end-to-end through the changelist
- [x] `test_queryset_summary_mode_caches_discovery_on_request` — second materialisation against the same `request` reuses the first SCAN
- [x] `test_queryset_summary_mode_no_request_skips_cache` — standalone callers without a `request` eat the per-call SCAN
- [x] `test_celery_queue_filter_lookups_includes_live_broker_queues` — sidebar dropdown surfaces both live + static queues
- [x] `test_celery_queue_filter_lookups_reuses_request_cache` — sidebar shares the per-request SCAN result with the changelist

```
$ pytest -q redis_admin/tests/test_families.py redis_admin/tests/test_celery_broker_queue.py \
    -k "discover or queryset_summary or celery_queue_filter"
14 passed, 154 deselected in 0.38s
```

Manual verification on staging recommended:

- [ ] Hit `/admin/redis_admin/celerybrokerqueue/` on a deploy with **no** `setup.redis_admin.celery_queues` set; confirm queues like `uploads`, `notify`, `sync`, and any `enterprise_*` variants show up with their live `LLEN` depths
- [ ] Hit the drill-down for one of those queues; confirm the sidebar `CeleryQueueFilter` dropdown lists the same queue set

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds live `SCAN ... TYPE list` calls against the Celery broker Redis on admin page renders; although bounded/cached with fallbacks, it changes operational visibility and could affect performance or behavior on older/broken Redis setups.
> 
> **Overview**
> **Celery broker queue discovery is now live.** The `CeleryBrokerQueueAdmin` summary and `CeleryQueueFilter` dropdown no longer rely solely on `_resolve_celery_queue_names()`; they union it with a new broker-side discovery helper that `SCAN`s for `TYPE=list` keys (with deny-listed internal prefixes) so dynamically materialised queues (including `enterprise_*` variants) appear automatically.
> 
> **Performance/safety guardrails were added.** Discovery is capped by `REDIS_ADMIN_MAX_SCAN_KEYS`, falls back to static enumeration on errors/unsupported Redis, and the resolved queue-name tuple is cached on the `HttpRequest` so the summary page and sidebar share a single broker scan per render. Tests and README were updated to cover and document the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773adde3bedb1298d67e07b51f2899b7edd9a123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->