### PR TITLE
feat(redis_admin): parse repo_id/commit_sha aliases + batch-resolve ComputeComparison repoid/commitid

### DIFF
--- a/apps/codecov-api/redis_admin/families.py
+++ b/apps/codecov-api/redis_admin/families.py
@@ -340,6 +340,15 @@ def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
     has repoid+commitid, sync_pull has repoid+pullid, sync_repos
     has ownerid only) so callers should treat every field as
     independently optional.
+
+    `UploadBreadcrumbTask` and a few sibling handlers
+    (`transplant_report`, `process_flakes`, `detect_flakes`) carry
+    `repo_id` / `commit_sha` instead of the canonical
+    `repoid` / `commitid`; both shapes are accepted so the admin
+    surfaces a structured `(repoid, commitid)` for those messages.
+    `ComputeComparisonTask` carries only `comparison_id` — the
+    queryset later batch-resolves that to a `(repoid, commitid)`
+    pair via `compare_commitcomparison`.
     """
 
     try:
@@ -378,16 +387,15 @@ def parse_celery_envelope(decoded: str) -> CeleryEnvelopeMeta:
         if isinstance(body, list) and len(body) >= 2 and isinstance(body[1], dict):
             kwargs = body[1]
             repoid = _coerce_int(kwargs.get("repoid"))
+            if repoid is None:
+                repoid = _coerce_int(kwargs.get("repo_id"))
             cid = kwargs.get("commitid")
+            if not (isinstance(cid, str) and cid):
+                cid = kwargs.get("commit_sha")
             if isinstance(cid, str) and cid:
                 commitid = cid
             ownerid = _coerce_int(kwargs.get("ownerid"))
             pullid = _coerce_int(kwargs.get("pullid"))
-            # `ComputeComparisonTask` carries only `comparison_id`
-            # in its kwargs — pull it into a dedicated field so the
-            # queryset's post-materialisation hydration path can
-            # batch-resolve it to a `(repoid, commitid)` pair via
-            # the `compare_commitcomparison` table.
             comparison_id = _coerce_int(kwargs.get("comparison_id"))
     return CeleryEnvelopeMeta(
         task=task,

--- a/apps/codecov-api/redis_admin/queryset.py
+++ b/apps/codecov-api/redis_admin/queryset.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
+import logging
 from collections import Counter
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -37,7 +38,108 @@ from .families import (
     _resolve_celery_queue_names as _celery_queue_names,  # noqa: PLC2701
 )
 
+log = logging.getLogger(__name__)
+
 _UNSET: Any = object()
+
+
+# `ComputeComparisonTask` envelopes carry only `comparison_id`; the
+# `(repoid, commitid)` pair the changelist filters and displays on
+# lives in the `compare_commitcomparison` row that id points at. The
+# helpers below batch-resolve those ids in one Django ORM query at
+# materialise time so the `repoid`/`commitid` pushdown still narrows
+# correctly on those messages.
+
+
+@sentry_sdk.trace
+def _resolve_comparison_repo_commits(
+    comparison_ids: Iterable[int],
+) -> dict[int, tuple[int | None, str | None]]:
+    """Batch-fetch `{comparison_id: (repoid, commitid)}` for `ids`.
+
+    Returns `{}` on any error so the changelist degrades to "show
+    bare comparison_id" rather than 500-ing.
+    """
+
+    ids = {cid for cid in comparison_ids if cid}
+    if not ids:
+        return {}
+    try:
+        from shared.django_apps.compare.models import (  # noqa: PLC0415
+            CommitComparison,
+        )
+    except Exception:  # pragma: no cover - defensive: missing app
+        log.warning(
+            "redis_admin: CommitComparison import failed; "
+            "ComputeComparison rows will not be hydrated"
+        )
+        return {}
+    try:
+        rows = CommitComparison.objects.filter(id__in=ids).values_list(
+            "id",
+            "compare_commit__repository_id",
+            "compare_commit__commitid",
+        )
+        return {row[0]: (row[1], row[2]) for row in rows}
+    except Exception:  # pragma: no cover - defensive: DB hiccup
+        log.warning(
+            "redis_admin: CommitComparison hydration failed; "
+            "falling back to bare comparison_id",
+            exc_info=True,
+        )
+        return {}
+
+
+def _hydrate_comparison_rows(rows: list) -> None:
+    """Patch `repoid` / `commitid` on rows whose envelope only carried
+    a `comparison_id`."""
+
+    pending_ids: set[int] = set()
+    for row in rows:
+        cid = getattr(row, "_comparison_id", None)
+        if cid and row.repoid is None:
+            pending_ids.add(cid)
+    if not pending_ids:
+        return
+    mapping = _resolve_comparison_repo_commits(pending_ids)
+    if not mapping:
+        return
+    for row in rows:
+        cid = getattr(row, "_comparison_id", None)
+        if not cid or row.repoid is not None:
+            continue
+        resolved = mapping.get(cid)
+        if not resolved:
+            continue
+        repoid, commitid = resolved
+        if repoid is not None:
+            row.repoid = repoid
+        if commitid:
+            row.commitid = commitid
+
+
+def _merge_comparison_counter_into_main(
+    comparison_counter: Counter[tuple[str | None, int]],
+    counter: Counter[tuple[str | None, int | None, str | None]],
+) -> None:
+    """Fold a `(task, comparison_id)` side-counter into the main
+    `(task, repoid, commitid)` chart counter via one batched lookup.
+
+    Resolutions that fail collapse into the `(task, None, None)`
+    bucket so we don't drop counts.
+    """
+
+    if not comparison_counter:
+        return
+    ids = {cid for _, cid in comparison_counter if cid}
+    mapping = _resolve_comparison_repo_commits(ids) if ids else {}
+    for (task, cid), count in comparison_counter.items():
+        resolved = mapping.get(cid)
+        if resolved is None:
+            counter[(task, None, None)] += count
+            continue
+        repoid, commitid = resolved
+        counter[(task, repoid, commitid or None)] += count
 
 
 def _ordering_key(obj: Any, attr: str) -> tuple:
@@ -1138,6 +1240,7 @@ def _stream_frequency_aggregate(
 
     cap = redis_admin_settings.CELERY_BROKER_SCAN_LIMIT
     counter: Counter[tuple[str | None, int | None, str | None]] = Counter()
+    comparison_counter: Counter[tuple[str | None, int]] = Counter()
     total = 0
 
     depth = int(redis.llen(queue_name) or 0)
@@ -1150,8 +1253,18 @@ def _stream_frequency_aggregate(
             if meta.task is None and meta.repoid is None and meta.commitid is None:
                 total += 1
                 continue
+            if (
+                meta.comparison_id is not None
+                and meta.repoid is None
+                and not meta.commitid
+            ):
+                comparison_counter[(meta.task, meta.comparison_id)] += 1
+                total += 1
+                continue
             counter[(meta.task, meta.repoid, meta.commitid)] += 1
             total += 1
+
+    _merge_comparison_counter_into_main(comparison_counter, counter)
 
     if not counter or total == 0:
         return [], 0
@@ -1439,6 +1552,7 @@ class CeleryBrokerQueueQuerySet:
             payload_preview="",
         )
         row._kwargs_for_preview = meta.kwargs
+        row._comparison_id = meta.comparison_id
         return row
 
     def _build_summary_row(self, queue: str, depth: int) -> Any:
@@ -1515,6 +1629,9 @@ class CeleryBrokerQueueQuerySet:
             decoded = _decode_value(raw)
             meta = parse_celery_envelope(decoded)
             rows.append(self._build_row(offset, meta))
+        # Hydrate before the per-request cache snapshot so a downstream
+        # `_clone()` reads already-resolved (repoid, commitid).
+        _hydrate_comparison_rows(rows)
         self._write_request_cache(rows)
         return rows
 

--- a/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
+++ b/apps/codecov-api/redis_admin/tests/test_celery_broker_queue.py
@@ -36,6 +36,7 @@ from django.test import Client as DjClient
 from django.test import TestCase
 
 from redis_admin import conn as redis_admin_conn
+from redis_admin import queryset as redis_admin_queryset
 from redis_admin import settings as redis_admin_settings
 from redis_admin.admin import CeleryBrokerQueueAdmin, _resolve_repo_displays
 from redis_admin.families import parse_celery_envelope
@@ -155,6 +156,373 @@ def test_parse_envelope_handles_string_int_repoid():
     meta = parse_celery_envelope(envelope)
 
     assert meta.repoid == 1234
+
+
+def test_parse_envelope_aliases_repo_id_and_commit_sha():
+    """`UploadBreadcrumbTask` carries snake_case `repo_id`/`commit_sha`
+    rather than the canonical `repoid`/`commitid`. Surface them so the
+    admin renders structured columns and accepts repoid/commitid
+    filters on those messages.
+    """
+
+    envelope = _build_envelope(
+        task="app.tasks.upload_breadcrumb.UploadBreadcrumbTask",
+        kwargs={
+            "repo_id": 18802842,
+            "commit_sha": "af73fb73310312d4d2633449e50e6e141191c28c",
+            "upload_ids": [],
+        },
+    )
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.repoid == 18802842
+    assert meta.commitid == "af73fb73310312d4d2633449e50e6e141191c28c"
+
+
+def test_parse_envelope_repoid_canonical_wins_over_alias():
+    """When both `repoid` and `repo_id` are present (defensive belt-and-
+    braces), prefer the canonical name so a task that sets both stays
+    consistent with every other call site.
+    """
+
+    envelope = _build_envelope(
+        kwargs={"repoid": 1, "repo_id": 2, "commitid": "abc", "commit_sha": "xyz"},
+    )
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.repoid == 1
+    assert meta.commitid == "abc"
+
+
+def test_parse_envelope_extracts_comparison_id():
+    """`ComputeComparisonTask` only carries `comparison_id` in kwargs;
+    the queryset's hydrate pass turns it into `(repoid, commitid)`,
+    but the parser surface keeps it on `CeleryEnvelopeMeta` so the
+    queryset has something to hydrate from.
+    """
+
+    envelope = _build_envelope(
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 7777},
+    )
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.comparison_id == 7777
+    assert meta.repoid is None
+    assert meta.commitid is None
+
+
+def test_parse_envelope_comparison_id_handles_string_int():
+    """JSON ints sometimes round-trip as strings; the comparison_id
+    coercion mirrors `repoid` so a stringified value is still picked
+    up by the chart hydration pass.
+    """
+
+    envelope = _build_envelope(kwargs={"comparison_id": "42"})
+
+    meta = parse_celery_envelope(envelope)
+
+    assert meta.comparison_id == 42
+
+
+# ---- ComputeComparison hydration ------------------------------------------
+
+
+def test_materialise_hydrates_comparison_rows_from_db(patched_broker, monkeypatch):
+    """A `ComputeComparisonTask` envelope only carries `comparison_id`,
+    but after `_materialise` the row should expose the resolved
+    `(repoid, commitid)` pair so the changelist can render and filter
+    on those columns.
+    """
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {7777: (4242, "deadbeef")},
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 7777},
+    )
+
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+
+    assert len(rows) == 1
+    assert rows[0].repoid == 4242
+    assert rows[0].commitid == "deadbeef"
+
+
+def test_materialise_comparison_filter_by_repoid_after_hydration(
+    patched_broker, monkeypatch
+):
+    """Hydration must run before `_matches_filters`, so a
+    `repoid__exact` filter pushed down from the changelist still
+    narrows ComputeComparisonTask rows whose envelope only carries
+    `comparison_id`.
+    """
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {1: (10, "aaa"), 2: (20, "bbb")},
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 1},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 2},
+    )
+
+    rows = list(
+        CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify").filter(
+            repoid__exact=20
+        )
+    )
+
+    assert {r.repoid for r in rows} == {20}
+    assert {r.commitid for r in rows} == {"bbb"}
+
+
+def test_materialise_uses_one_orm_call_for_full_window(patched_broker, monkeypatch):
+    """The hydrate helper must batch every comparison_id in the
+    materialised window into a single ORM lookup so a 100-deep
+    queue of ComputeComparison messages doesn't issue 100 queries.
+    """
+
+    call_count = {"n": 0}
+
+    def _fake_resolver(ids):
+        call_count["n"] += 1
+        return {cid: (100 + cid, f"sha-{cid}") for cid in ids}
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        _fake_resolver,
+    )
+
+    for cid in range(1, 11):
+        _push(
+            patched_broker,
+            "notify",
+            task="app.tasks.compute_comparison.ComputeComparison",
+            kwargs={"comparison_id": cid},
+        )
+
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+
+    assert len(rows) == 10
+    assert call_count["n"] == 1
+
+
+def test_materialise_skips_resolver_when_no_comparison_ids(patched_broker, monkeypatch):
+    """A queue carrying only ordinary repoid/commitid envelopes (i.e.
+    the hot path) must not pay the ORM round-trip — operators run
+    this admin without a CommitComparison-app deployment in some
+    tests.
+    """
+
+    call_count = {"n": 0}
+
+    def _fake_resolver(ids):
+        call_count["n"] += 1
+        return {}
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        _fake_resolver,
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.notify.NotifyTask",
+        kwargs={"repoid": 1, "commitid": "a"},
+    )
+
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+
+    assert len(rows) == 1
+    assert call_count["n"] == 0
+
+
+def test_materialise_keeps_comparison_id_when_resolution_returns_empty(
+    patched_broker, monkeypatch
+):
+    """If the lookup misses (id deleted, ORM unavailable), the row
+    falls back to bare `(None, None)` rather than crashing the
+    changelist render.
+    """
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {},
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 9999},
+    )
+
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+
+    assert len(rows) == 1
+    assert rows[0].repoid is None
+    assert rows[0].commitid is None
+    assert rows[0]._comparison_id == 9999
+
+
+def test_stream_frequency_aggregate_resolves_comparison_buckets(
+    patched_broker, monkeypatch
+):
+    """The chart aggregator must surface ComputeComparison messages
+    under their resolved `(task, repoid, commitid)` bucket rather
+    than collapsing every one into the all-None row.
+    """
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {1: (10, "aaa"), 2: (20, "bbb")},
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 1},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 1},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 2},
+    )
+
+    buckets, total = _stream_frequency_aggregate(patched_broker, "notify")
+
+    assert total == 3
+    keys = {(b.task_name, b.repoid, b.commitid) for b in buckets}
+    assert (
+        "app.tasks.compute_comparison.ComputeComparison",
+        10,
+        "aaa",
+    ) in keys
+    assert (
+        "app.tasks.compute_comparison.ComputeComparison",
+        20,
+        "bbb",
+    ) in keys
+
+
+def test_resolve_comparison_repo_commits_returns_empty_for_falsy_ids():
+    """Falsy ids (0 / None) must skip the ORM round-trip entirely so
+    `comparison_id=0` payloads don't pull a doomed empty IN()."""
+
+    from redis_admin.queryset import _resolve_comparison_repo_commits  # noqa: PLC0415
+
+    assert _resolve_comparison_repo_commits([]) == {}
+    assert _resolve_comparison_repo_commits([0, None]) == {}
+
+
+def test_resolve_comparison_repo_commits_batches_real_orm_call(monkeypatch):
+    """Happy path: the resolver calls `CommitComparison.objects.filter`
+    once and shapes `(id, repoid, commitid)` tuples into the
+    `{cid: (repoid, commitid)}` mapping the hydrate helpers consume.
+    """
+
+    from redis_admin.queryset import _resolve_comparison_repo_commits  # noqa: PLC0415
+    from shared.django_apps.compare import models as compare_models  # noqa: PLC0415
+
+    captured: dict[str, Any] = {}
+
+    class _FakeQuerySet:
+        def values_list(self, *fields):
+            captured["fields"] = fields
+            return [(1, 10, "aaa"), (2, 20, "bbb")]
+
+    class _FakeManager:
+        def filter(self, **kwargs):
+            captured["filter_kwargs"] = kwargs
+            return _FakeQuerySet()
+
+    monkeypatch.setattr(compare_models.CommitComparison, "objects", _FakeManager())
+
+    result = _resolve_comparison_repo_commits([1, 2, 0])
+
+    assert result == {1: (10, "aaa"), 2: (20, "bbb")}
+    assert captured["filter_kwargs"] == {"id__in": {1, 2}}
+    assert captured["fields"] == (
+        "id",
+        "compare_commit__repository_id",
+        "compare_commit__commitid",
+    )
+
+
+def test_hydrate_comparison_rows_skips_rows_with_repoid_already_set(
+    patched_broker, monkeypatch
+):
+    """Mixed page: ordinary `repoid`/`commitid` rows are left alone
+    (no resolver call for them) and a row whose `comparison_id` isn't
+    in the resolver mapping keeps its bare comparison_id rather than
+    spuriously getting nulled.
+    """
+
+    monkeypatch.setattr(
+        redis_admin_queryset,
+        "_resolve_comparison_repo_commits",
+        lambda ids: {1: (10, "aaa")},  # 9999 deliberately missing
+    )
+
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.notify.NotifyTask",
+        kwargs={"repoid": 7, "commitid": "preset"},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 1},
+    )
+    _push(
+        patched_broker,
+        "notify",
+        task="app.tasks.compute_comparison.ComputeComparison",
+        kwargs={"comparison_id": 9999},
+    )
+
+    rows = list(CeleryBrokerQueueQuerySet(CeleryBrokerQueue, queue_name="notify"))
+    by_idx = {r.index_in_queue: r for r in rows}
+
+    assert by_idx[0].repoid == 7 and by_idx[0].commitid == "preset"
+    assert by_idx[1].repoid == 10 and by_idx[1].commitid == "aaa"
+    assert by_idx[2].repoid is None and by_idx[2].commitid is None
+    assert by_idx[2]._comparison_id == 9999
 
 
 def test_parse_envelope_rejects_bool_in_int_fields():


### PR DESCRIPTION
## Summary

The Redis-admin **celery_broker** changelist already extracts `(repoid, commitid)` from envelope kwargs for most worker tasks, but two task families were silently invisible to the columns and the `?repoid=` / `?commitid=` filters:

- **`UploadBreadcrumbTask`** (and `transplant_report` / `process_flakes` / `detect_flakes`) carry their repo + commit as `repo_id` / `commit_sha`. Sample payload from prod:

  ```json
  {
    "commit_sha": "af73fb73310312d4d2633449e50e6e141191c28c",
    "repo_id": 18802842,
    "breadcrumb_data": { "...": "..." },
    "upload_ids": [],
    "sentry_trace_id": "..."
  }
  ```

- **`ComputeComparisonTask`** carries only `comparison_id`; the `(repoid, commitid)` lives in the `compare_commitcomparison` row that id points at.

## Changes

- `families.py`: `parse_celery_envelope` accepts `repo_id` / `commit_sha` as aliases for `repoid` / `commitid` (canonical wins when both are present). `comparison_id` was already added to `CeleryEnvelopeMeta` by #911's `c0abd58`.
- `queryset.py`: New `_resolve_comparison_repo_commits` batch resolver. `CeleryBrokerQueueQuerySet._build_row` stashes `comparison_id`; `_materialise` calls `_hydrate_comparison_rows` once per page before the request-cache snapshot so a downstream `_clone()` (e.g. ChangeList's filter clone) reads already-resolved values and the `repoid` / `commitid` pushdown narrows correctly. `_stream_frequency_aggregate` uses a `(task, comparison_id)` side-counter that `_merge_comparison_counter_into_main` folds into the main `(task, repoid, commitid)` counter via one batched lookup so the chart matches the changelist. Resolver failures collapse to `(task, None, None)` so counts aren't dropped.
- `tests/test_celery_broker_queue.py`: 10 new tests covering parser aliases (canonical-wins precedence, string-int comparison_id), one ORM call per page, resolver skipped when no `comparison_id`s, fallback when the resolver returns `{}`, and chart bucket resolution.

The unacked-queue counterpart of this work (analogous helpers + tests) intentionally lives in #911 alongside the unacked drilldown surface, so this PR is scoped strictly to celery_broker.

## Stacked on

- #911 (`redis-admin/unacked-queue-drilldown`) — that branch added the `comparison_id` field on `CeleryEnvelopeMeta`. Once #911 lands, this PR rebases naturally onto main.

## Test plan

- [x] \`pytest redis_admin/tests/test_celery_broker_queue.py -k "comparison or alias or repo_id or commit_sha or parse_envelope or stream_frequency or hydrat"\` — 21 passed locally
- [ ] CI green
- [ ] Spot-check one breadcrumb message + one ComputeComparisonTask message in the celery_broker admin once #911 merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new Django ORM reads during admin materialization/chart aggregation and changes how celery envelope fields are interpreted, which could affect filtering/performance if misbehaving.
> 
> **Overview**
> The celery-broker redis-admin now recognizes `repo_id`/`commit_sha` kwargs as aliases for `repoid`/`commitid`, ensuring those task messages populate the structured columns and support existing filters.
> 
> For `ComputeComparison` messages that only include `comparison_id`, the queryset now batch-resolves `(repoid, commitid)` from `CommitComparison` during materialization and frequency aggregation (with safe fallbacks on import/DB errors), and the test suite adds coverage for alias precedence, hydration behavior, and single-query batching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1c9000ad76ffdc4a6e3587786fdb3c1462de0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->