### PR TITLE
fix(bundle-analysis): clean up temp files on load failure

### DIFF
--- a/libs/shared/shared/bundle_analysis/storage.py
+++ b/libs/shared/shared/bundle_analysis/storage.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import tempfile
 from enum import Enum
 
@@ -48,12 +49,15 @@ class BundleAnalysisReportLoader:
             repo_key=self.repo_key, report_key=report_key
         )
         _, db_path = tempfile.mkstemp(prefix="bundle_analysis_")
-
-        with open(db_path, "w+b") as f:
-            try:
+        try:
+            with open(db_path, "w+b") as f:
                 self.storage_service.read_file(self.bucket_name, path, file_obj=f)
-            except FileNotInStorageError:
-                return None
+        except FileNotInStorageError:
+            os.unlink(db_path)
+            return None
+        except Exception:
+            os.unlink(db_path)
+            raise
         return BundleAnalysisReport(db_path)
 
     @sentry_sdk.trace

--- a/libs/shared/shared/bundle_analysis/storage.py
+++ b/libs/shared/shared/bundle_analysis/storage.py
@@ -48,7 +48,8 @@ class BundleAnalysisReportLoader:
         path = StoragePaths.bundle_report.path(
             repo_key=self.repo_key, report_key=report_key
         )
-        _, db_path = tempfile.mkstemp(prefix="bundle_analysis_")
+        fd, db_path = tempfile.mkstemp(prefix="bundle_analysis_")
+        os.close(fd)
         try:
             with open(db_path, "w+b") as f:
                 self.storage_service.read_file(self.bucket_name, path, file_obj=f)

--- a/libs/shared/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/libs/shared/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 from unittest import TestCase
@@ -21,7 +22,7 @@ from shared.bundle_analysis.models import (
     Session,
     get_db_session,
 )
-from shared.storage.exceptions import PutRequestRateLimitError
+from shared.storage.exceptions import FileNotInStorageError, PutRequestRateLimitError
 
 sample_bundle_stats_path = (
     Path(__file__).parent.parent.parent / "samples" / "sample_bundle_stats.json"
@@ -433,6 +434,56 @@ def test_save_load_bundle_report(mock_storage):
     finally:
         created_report.cleanup()
         report.cleanup()
+
+
+def test_load_cleans_up_tempfile_on_file_not_found(mock_storage):
+    loader = BundleAnalysisReportLoader(None)
+    captured_path = []
+
+    real_mkstemp = tempfile.mkstemp
+
+    def capturing_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        captured_path.append(path)
+        return fd, path
+
+    with patch("tempfile.mkstemp", side_effect=capturing_mkstemp):
+        with patch(
+            "shared.storage.memory.MemoryStorageService.read_file",
+            side_effect=FileNotInStorageError(),
+        ):
+            result = loader.load("nonexistent-key")
+
+    assert result is None
+    assert len(captured_path) == 1
+    assert not os.path.exists(captured_path[0]), (
+        f"Temp file not cleaned up: {captured_path[0]}"
+    )
+
+
+def test_load_cleans_up_tempfile_on_unexpected_error(mock_storage):
+    loader = BundleAnalysisReportLoader(None)
+    captured_path = []
+
+    real_mkstemp = tempfile.mkstemp
+
+    def capturing_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        captured_path.append(path)
+        return fd, path
+
+    with patch("tempfile.mkstemp", side_effect=capturing_mkstemp):
+        with patch(
+            "shared.storage.memory.MemoryStorageService.read_file",
+            side_effect=RuntimeError("storage exploded"),
+        ):
+            with pytest.raises(RuntimeError, match="storage exploded"):
+                loader.load("some-key")
+
+    assert len(captured_path) == 1
+    assert not os.path.exists(captured_path[0]), (
+        f"Temp file not cleaned up: {captured_path[0]}"
+    )
 
 
 def test_reupload_bundle_report():


### PR DESCRIPTION
## Summary

- `BundleAnalysisReportLoader.load()` called `tempfile.mkstemp()` but never deleted the temp file on the `FileNotInStorageError` path (returned `None` without cleanup) or on any unexpected exception path
- Workers running many BA tasks accumulated SQLite temp files on disk until hitting `No space left on device` (WORKER-WNZ)
- Fix restructures the `try/except` so both error paths call `os.unlink(db_path)` before returning/re-raising; the happy path still transfers ownership to the returned `BundleAnalysisReport`, which has its own `cleanup()` method

## Test plan

- [x] `test_load_cleans_up_tempfile_on_file_not_found` — patches `mkstemp` to capture the path, asserts file no longer exists after `load()` returns `None`
- [x] `test_load_cleans_up_tempfile_on_unexpected_error` — same, but for an unexpected `RuntimeError` that should re-raise
- [x] `test_save_load_bundle_report` — existing happy-path test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow change to temporary-file lifecycle in `BundleAnalysisReportLoader.load`, plus targeted unit tests; only impacts failure paths and should reduce disk-leak incidents.
> 
> **Overview**
> Fixes `BundleAnalysisReportLoader.load()` to **always clean up the `mkstemp`-created SQLite temp file** when the report is missing (`FileNotInStorageError`) or when any unexpected exception occurs, instead of leaking files on disk.
> 
> Adds unit tests that assert the temp file is deleted on both *not found* and *unexpected error* paths, while keeping the existing save/load happy-path behavior intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2003b306a88380342bb5b0bba354eca7d059ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->