### PR TITLE
fix(bots): ensure deterministic ordering of GitHub app installations

### DIFF
--- a/apps/worker/database/models/core.py
+++ b/apps/worker/database/models/core.py
@@ -149,7 +149,7 @@ class Owner(CodecovBaseModel):
         foreign_keys="GithubAppInstallation.ownerid",
         cascade="all, delete",
         passive_deletes=True,
-        order_by="GithubAppInstallation.id",
+        order_by="GithubAppInstallation.id_",
     )
 
     # TODO: Create association between `User` and `Owner` mirroring `codecov-api`

--- a/apps/worker/database/models/core.py
+++ b/apps/worker/database/models/core.py
@@ -149,6 +149,7 @@ class Owner(CodecovBaseModel):
         foreign_keys="GithubAppInstallation.ownerid",
         cascade="all, delete",
         passive_deletes=True,
+        order_by="GithubAppInstallation.id",
     )
 
     # TODO: Create association between `User` and `Owner` mirroring `codecov-api`

--- a/libs/shared/shared/orms/owner_helper.py
+++ b/libs/shared/shared/orms/owner_helper.py
@@ -9,7 +9,7 @@ class DjangoSQLAlchemyOwnerWrapper:
     @staticmethod
     def get_github_app_installations(owner: Owner | Any):
         if _is_django_model(owner):
-            return owner.github_app_installations.all()
+            return owner.github_app_installations.order_by("id")
         else:
             return owner.github_app_installations
 

--- a/libs/shared/tests/unit/bots/test_github_apps.py
+++ b/libs/shared/tests/unit/bots/test_github_apps.py
@@ -18,6 +18,7 @@ from shared.django_apps.codecov_auth.models import (
 )
 from shared.django_apps.codecov_auth.tests.factories import OwnerFactory
 from shared.github import InvalidInstallationError
+from shared.orms.owner_helper import DjangoSQLAlchemyOwnerWrapper
 from shared.typings.torngit import GithubInstallationInfo
 
 
@@ -251,3 +252,26 @@ class TestGettingGitHubAppTokenSideEffect:
         installations[0].refresh_from_db()
         installations[1].refresh_from_db()
         assert all(installation.is_suspended == False for installation in installations)
+
+
+class TestGithubAppInstallationsOrdering:
+    @pytest.mark.django_db
+    def test_get_github_app_installations_returns_apps_in_id_order(self):
+        owner = OwnerFactory(service="github")
+        app_1 = GithubAppInstallation.objects.create(
+            owner=owner, installation_id=100, app_id=10, pem_path="pem1"
+        )
+        app_2 = GithubAppInstallation.objects.create(
+            owner=owner, installation_id=200, app_id=20, pem_path="pem2"
+        )
+        app_3 = GithubAppInstallation.objects.create(
+            owner=owner, installation_id=300, app_id=30, pem_path="pem3"
+        )
+        # Delete app_1 and recreate to get a higher ID, breaking natural insertion order
+        app_1.delete()
+        app_1_new = GithubAppInstallation.objects.create(
+            owner=owner, installation_id=100, app_id=10, pem_path="pem1"
+        )
+        expected = sorted([app_1_new, app_2, app_3], key=lambda x: x.id)
+        result = list(DjangoSQLAlchemyOwnerWrapper.get_github_app_installations(owner))
+        assert result == expected


### PR DESCRIPTION
## Summary

- `DjangoSQLAlchemyOwnerWrapper.get_github_app_installations` had no `ORDER BY`, so the DB could return installations in any order — making `app[0]` non-deterministic across calls
- Added `order_by("id")` to the Django path in `owner_helper.py`
- Added `order_by="GithubAppInstallation.id"` to the SQLAlchemy relationship in `core.py`

## Test plan

- [ ] New test in `TestGithubAppInstallationsOrdering` creates 3 apps, deletes and recreates one (forcing its ID higher than the others), and asserts the wrapper always returns them sorted by `id`
- [ ] All existing `test_github_apps.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds explicit ordering to ORM queries/relationships so callers no longer depend on database return order; main impact is making GitHub app selection deterministic when lists are iterated/indexed.
> 
> **Overview**
> Ensures **deterministic ordering** of `Owner.github_app_installations` across both ORM implementations.
> 
> Adds `ORDER BY id` for Django (`DjangoSQLAlchemyOwnerWrapper.get_github_app_installations`) and sets `order_by="GithubAppInstallation.id_"` on the SQLAlchemy `Owner.github_app_installations` relationship, plus a unit test that verifies the wrapper returns installations sorted by id even after delete/recreate changes row IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69eea4bffdb0195971756f2e894414f00178b1cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->