### PR TITLE
fix(api): check org membership in updateBundleCacheConfig mutation

### DIFF
--- a/apps/codecov-api/core/commands/repository/interactors/tests/test_update_bundle_cache_config.py
+++ b/apps/codecov-api/core/commands/repository/interactors/tests/test_update_bundle_cache_config.py
@@ -2,7 +2,7 @@ import pytest
 from asgiref.sync import async_to_sync
 from django.test import TestCase
 
-from codecov.commands.exceptions import ValidationError
+from codecov.commands.exceptions import Unauthorized, ValidationError
 from shared.django_apps.bundle_analysis.models import CacheConfig
 from shared.django_apps.core.tests.factories import (
     OwnerFactory,
@@ -17,8 +17,12 @@ class UpdateBundleCacheConfigInteractorTest(TestCase):
 
     def setUp(self):
         self.org = OwnerFactory(username="test-org")
-        self.repo = RepositoryFactory(author=self.org, name="test-repo", active=True)
-        self.user = OwnerFactory(permission=[self.repo.pk])
+        self.repo = RepositoryFactory(
+            author=self.org, name="test-repo", active=True, private=False
+        )
+        self.user = OwnerFactory(
+            organizations=[self.org.ownerid], permission=[self.repo.pk]
+        )
 
     @async_to_sync
     def execute(self, owner, repo_name=None, cache_config=[]):
@@ -27,6 +31,15 @@ class UpdateBundleCacheConfigInteractorTest(TestCase):
             owner_username="test-org",
             cache_config=cache_config,
         )
+
+    def test_unauthorized_user_not_part_of_org(self):
+        random_user = OwnerFactory()
+        with pytest.raises(Unauthorized):
+            self.execute(
+                owner=random_user,
+                repo_name="test-repo",
+                cache_config=[{"bundle_name": "any", "toggle_caching": False}],
+            )
 
     def test_repo_not_found(self):
         with pytest.raises(ValidationError):

--- a/apps/codecov-api/core/commands/repository/interactors/update_bundle_cache_config.py
+++ b/apps/codecov-api/core/commands/repository/interactors/update_bundle_cache_config.py
@@ -1,7 +1,8 @@
 from asgiref.sync import sync_to_async
 
 from codecov.commands.base import BaseInteractor
-from codecov.commands.exceptions import ValidationError
+from codecov.commands.exceptions import Unauthorized, ValidationError
+from codecov_auth.helpers import current_user_part_of_org
 from core.models import Repository
 from shared.django_apps.bundle_analysis.models import CacheConfig
 from shared.django_apps.bundle_analysis.service.bundle_analysis import (
@@ -38,9 +39,12 @@ class UpdateBundleCacheConfigInteractor(BaseInteractor):
         repo_name: str,
         cache_config: list[dict[str, str | bool]],
     ) -> list[dict[str, str | bool]]:
-        _owner, repo = self.resolve_owner_and_repo(
+        owner, repo = self.resolve_owner_and_repo(
             owner_username, repo_name, only_viewable=True
         )
+
+        if not current_user_part_of_org(self.current_owner, owner):
+            raise Unauthorized()
 
         self.validate(repo, cache_config)
 

--- a/apps/codecov-api/graphql_api/tests/mutation/test_update_bundle_cache_config.py
+++ b/apps/codecov-api/graphql_api/tests/mutation/test_update_bundle_cache_config.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from graphql_api.tests.helper import GraphQLTestHelper
-from shared.django_apps.core.tests.factories import OwnerFactory
+from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
 
 query = """
 mutation($input: ActivateMeasurementsInput!) {
@@ -37,6 +37,9 @@ mutation UpdateBundleCacheConfig(
             ... on UnauthenticatedError {
                 message
             }
+            ... on UnauthorizedError {
+                message
+            }
             ... on ValidationError {
                 message
             }
@@ -48,7 +51,9 @@ mutation UpdateBundleCacheConfig(
 
 class UpdateBundleCacheConfigTestCase(GraphQLTestHelper, TestCase):
     def setUp(self):
-        self.owner = OwnerFactory()
+        self.org = OwnerFactory(username="codecov")
+        self.repo = RepositoryFactory(author=self.org, name="test-repo", private=False)
+        self.owner = OwnerFactory(organizations=[self.org.ownerid])
 
     def test_when_unauthenticated(self):
         data = self.gql_request(
@@ -62,6 +67,22 @@ class UpdateBundleCacheConfigTestCase(GraphQLTestHelper, TestCase):
         assert (
             data["updateBundleCacheConfig"]["error"]["__typename"]
             == "UnauthenticatedError"
+        )
+
+    def test_when_unauthorized_user_not_part_of_org(self):
+        random_user = OwnerFactory()
+        data = self.gql_request(
+            query,
+            owner=random_user,
+            variables={
+                "owner": "codecov",
+                "repoName": "test-repo",
+                "bundles": [{"bundleName": "pr_bundle1", "toggleCaching": False}],
+            },
+        )
+        assert (
+            data["updateBundleCacheConfig"]["error"]["__typename"]
+            == "UnauthorizedError"
         )
 
     @patch(

--- a/apps/codecov-api/graphql_api/types/mutation/update_bundle_cache_config/update_bundle_cache_config.graphql
+++ b/apps/codecov-api/graphql_api/types/mutation/update_bundle_cache_config/update_bundle_cache_config.graphql
@@ -1,4 +1,4 @@
-union UpdateBundleCacheConfigError = UnauthenticatedError | ValidationError
+union UpdateBundleCacheConfigError = UnauthenticatedError | UnauthorizedError | ValidationError
 
 type UpdateBundleCacheConfigResult {
   bundleName: String


### PR DESCRIPTION
## Summary

Fixes CCMRG-2142 / VULN-1336 (bug bounty IDOR).

`updateBundleCacheConfig` resolved the repo with `only_viewable=True` but never verified the calling user was a member of the owning org. Any authenticated user could modify bundle cache settings for repos they can view but don't own.

**The fix:** Add `current_user_part_of_org` check in the interactor, matching the pattern established in `RegenerateRepositoryTokenInteractor` (#777). Also adds `UnauthorizedError` to the `UpdateBundleCacheConfigError` union, which was missing.

## POC

Pre-fix: calling the mutation as a non-org-member against a viewable repo would reach `validate()` and return `ValidationError` — auth was never checked.

Post-fix: the mutation immediately returns `UnauthorizedError` before validation runs.

## Changes

- `update_bundle_cache_config.py` — add org membership check before `validate()`
- `update_bundle_cache_config.graphql` — add `UnauthorizedError` to the error union
- Both test files updated with `test_unauthorized_user_not_part_of_org` coverage

## Test plan

- [x] `test_unauthorized_user_not_part_of_org` (interactor) — non-member raises `Unauthorized`
- [x] `test_when_unauthorized_user_not_part_of_org` (GraphQL) — returns `UnauthorizedError`
- [x] All 8 existing tests still pass
- [x] Pre-commit clean on all files