### PR TITLE
feat: handle ready_for_review webhook action

### DIFF
--- a/apps/codecov-api/webhook_handlers/constants.py
+++ b/apps/codecov-api/webhook_handlers/constants.py
@@ -24,21 +24,22 @@ class GitHubWebhookEvents:
 
 
 class GitHubPullRequestActions:
-    OPENED = "opened"
     CLOSED = "closed"
+    LABELED = "labeled"
+    OPENED = "opened"
+    READY_FOR_REVIEW = "ready_for_review"
     REOPENED = "reopened"
     SYNCHRONIZE = "synchronize"
-    LABELED = "labeled"
+
     EDITED = "edited"
-    READY_FOR_REVIEW = "ready_for_review"
 
     PULLS_SYNC_ACTIONS = [
-        OPENED,
         CLOSED,
+        LABELED,
+        OPENED,
+        READY_FOR_REVIEW,
         REOPENED,
         SYNCHRONIZE,
-        LABELED,
-        READY_FOR_REVIEW,
     ]
 
 

--- a/apps/codecov-api/webhook_handlers/constants.py
+++ b/apps/codecov-api/webhook_handlers/constants.py
@@ -23,6 +23,25 @@ class GitHubWebhookEvents:
     repository_events = [PULL_REQUEST, DELETE, PUSH, PUBLIC, STATUS, REPOSITORY, MEMBER]
 
 
+class GitHubPullRequestActions:
+    OPENED = "opened"
+    CLOSED = "closed"
+    REOPENED = "reopened"
+    SYNCHRONIZE = "synchronize"
+    LABELED = "labeled"
+    EDITED = "edited"
+    READY_FOR_REVIEW = "ready_for_review"
+
+    PULLS_SYNC_ACTIONS = [
+        OPENED,
+        CLOSED,
+        REOPENED,
+        SYNCHRONIZE,
+        LABELED,
+        READY_FOR_REVIEW,
+    ]
+
+
 class BitbucketHTTPHeaders:
     EVENT = "HTTP_X_EVENT_KEY"
     UUID = "HTTP_X_HOOK_UUID"

--- a/apps/codecov-api/webhook_handlers/tests/test_github.py
+++ b/apps/codecov-api/webhook_handlers/tests/test_github.py
@@ -509,6 +509,21 @@ class GithubWebhookHandlerTests(APITestCase):
             [call(repoid=self.repo.repoid, pullid=pull.pullid)] * len(valid_actions)
         )
 
+    @patch("services.task.TaskService.pulls_sync")
+    def test_pull_request_ready_for_review_triggers_pulls_sync(self, pulls_sync_mock):
+        pull = PullFactory(repository=self.repo)
+        self._post_event_data(
+            event=GitHubWebhookEvents.PULL_REQUEST,
+            data={
+                "repository": {"id": self.repo.service_id},
+                "action": "ready_for_review",
+                "number": pull.pullid,
+            },
+        )
+        pulls_sync_mock.assert_called_once_with(
+            repoid=self.repo.repoid, pullid=pull.pullid
+        )
+
     def test_pull_request_updates_title_if_edited(self):
         pull = PullFactory(repository=self.repo)
         new_title = "brand new dang title"

--- a/apps/codecov-api/webhook_handlers/views/github.py
+++ b/apps/codecov-api/webhook_handlers/views/github.py
@@ -28,6 +28,7 @@ from shared.helpers.redis import get_redis_connection
 from utils.config import get_config
 from webhook_handlers.constants import (
     GitHubHTTPHeaders,
+    GitHubPullRequestActions,
     GitHubWebhookEvents,
     WebhookHandlerErrorMessages,
 )
@@ -316,15 +317,17 @@ class GithubWebhookHandler(APIView):
         if not repo.active:
             return Response(data=WebhookHandlerErrorMessages.SKIP_NOT_ACTIVE)
 
-        action, pullid = request.data.get("action"), request.data.get("number")
+        action = request.data.get("action")
+        pullid = request.data.get("number")
 
-        if action in ["opened", "closed", "reopened", "synchronize", "labeled"]:
-            TaskService().pulls_sync(repoid=repo.repoid, pullid=pullid)
-
-        elif action == "edited":
+        if action == GitHubPullRequestActions.EDITED:
             Pull.objects.filter(repository=repo, pullid=pullid).update(
                 title=request.data.get("pull_request", {}).get("title")
             )
+            return Response()
+
+        if action in GitHubPullRequestActions.PULLS_SYNC_ACTIONS:
+            TaskService().pulls_sync(repoid=repo.repoid, pullid=pullid)
 
         return Response()
 


### PR DESCRIPTION
## Summary

- Adds `GitHubPullRequestActions` constants class to `webhook_handlers/constants.py`
- Adds `ready_for_review` to the list of actions that trigger `PullsSync`
- Refactors `pull_request()` handler to use the new constants instead of bare strings

## Test plan

- [x] New test: `test_pull_request_ready_for_review_triggers_pulls_sync` — verifies `pulls_sync` is called when action is `ready_for_review`
- [x] Existing tests pass: `test_pull_request_triggers_pulls_sync_task_for_valid_actions`, `test_pull_request_updates_title_if_edited`, `test_pull_request_exits_early_if_repo_not_active`

Closes https://github.com/codecov/core-engineering/issues/64

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to GitHub webhook routing that only expands the set of PR actions that enqueue `pulls_sync`, with a focused unit test added.
> 
> **Overview**
> The GitHub `pull_request` webhook now triggers `TaskService().pulls_sync` when the action is `ready_for_review`, aligning behavior with other PR lifecycle actions.
> 
> PR action handling is refactored to use a new `GitHubPullRequestActions` constants class (including a shared `PULLS_SYNC_ACTIONS` list), and a test is added to assert the new `ready_for_review` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae9a8282f43d2a84ceaaf95e2e251c287d2a9b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->