### PR TITLE
chore(sentry): disable Django middleware span auto-instrumentation

### DIFF
--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -460,7 +460,7 @@ if SENTRY_DSN is not None:
             "enable_logs": True,
         },
         integrations=[
-            DjangoIntegration(signals_spans=False),
+            DjangoIntegration(signals_spans=False, middleware_spans=False),
             CeleryIntegration(),
             RedisIntegration(cache_prefixes=["cache:"]),
             HttpxIntegration(),

--- a/apps/worker/helpers/sentry.py
+++ b/apps/worker/helpers/sentry.py
@@ -44,7 +44,7 @@ def initialize_sentry() -> None:
         enable_backpressure_handling=False,
         integrations=[
             CeleryIntegration(monitor_beat_tasks=True),
-            DjangoIntegration(signals_spans=False),
+            DjangoIntegration(signals_spans=False, middleware_spans=False),
             SqlalchemyIntegration(),
             RedisIntegration(cache_prefixes=["cache:"]),
             HttpxIntegration(),


### PR DESCRIPTION
## Summary

Adds `middleware_spans=False` to `DjangoIntegration` in both the codecov-api and worker Sentry SDK init paths.

## Why

Auto-instrumented `middleware.django` spans don't carry useful debugging information. A `middleware.django` span only contains:

- `span.description` — the FQN of the middleware method (e.g. `django.middleware.csrf.CsrfViewMiddleware.__call__`)
- `span.duration`
- standard envelope fields (trace_id, parent_span_id, transaction, timestamp, project, environment, release)

There are **no middleware-specific attributes** — no headers, no auth context, no body, no user info on the span. Because Django middleware wraps `get_response`, the `__call__` duration is bounded by everything below it in the chain rather than the middleware's own cost, so the p95s cluster at the request-envelope value and individual middleware spans rarely identify a real bottleneck. Each of the ~19 middleware in the api project fires on every request with nearly identical timings.

Everything debuggable (the request envelope, ORM queries, Redis commands, outbound HTTP, view rendering) is on its own span and is **not affected** by this change.

If a specific custom middleware ever needs targeted timing, we can manually wrap it with `sentry_sdk.start_span(op="middleware.codecov", description="…")` instead of relying on the auto-instrumentation.

## Notes

- This is the same flavor of "drop low-signal auto-spans" as the existing `signals_spans=False` on this integration.
- The worker change is a no-op today — worker doesn't serve Django requests — but I'm keeping the two `DjangoIntegration(...)` call sites identical so the kwarg doesn't drift.

## Test plan

- [ ] CI green (existing tests use `mocker.ANY` for the integrations list, no test churn expected)
- [ ] After deploy, confirm in Sentry Explore › Traces that `span.op:middleware.django` count drops to ~0 for the api / ecdn-api projects
- [ ] Confirm `/api/v2/...` transaction throughput and p95 latency are unchanged on the parent (http.server) span
- [ ] Confirm `db`, `db.redis`, `http.client`, `view.render` child spans are still emitted for the same transactions

## Refs

- Sentry SDK docs: https://docs.sentry.io/platforms/python/integrations/django/#options