### PR TITLE
chore(sentry): route-aware traces_sampler for low-value endpoints

### DIFF
--- a/apps/codecov-api/codecov/sentry_sampling.py
+++ b/apps/codecov-api/codecov/sentry_sampling.py
@@ -79,7 +79,7 @@ def make_traces_sampler(
         low-value route. Should mirror the previous ``traces_sample_rate``.
     badge_rate:
         Sample rate applied to badge SVG endpoints. These are high-volume
-        and low-variance; ``0.01`` (1%) keeps enough samples for latency
+        and low-variance; ``0.001`` (0.1%) keeps enough samples for latency
         monitoring without paying for full traces on every request.
     """
 

--- a/apps/codecov-api/codecov/sentry_sampling.py
+++ b/apps/codecov-api/codecov/sentry_sampling.py
@@ -1,7 +1,7 @@
 """Route-aware ``traces_sampler`` for the Sentry SDK.
 
 The codecov-api WSGI app handles a handful of route families that emit a lot
-of requests but carry no debugging signal:
+of requests but carry low per-request debugging signal:
 
 * ``/``, ``/health/``, ``/api_health/`` — Kubernetes / load-balancer health
   probes.
@@ -9,6 +9,9 @@ of requests but carry no debugging signal:
 * ``/{service}/{owner}/{repo}/.../badge.{ext}`` — coverage and bundle badge
   SVGs. These are extremely high-volume and CDN-cacheable, and we never need
   per-request traces to debug them.
+* ``/webhooks/github`` — the GitHub webhook handler. By far the highest-volume
+  transaction in the app, and most events are uniform (push / status); we
+  only need a small fraction sampled for latency and error visibility.
 
 Everything else falls back to the default sample rate from ``settings``.
 
@@ -38,6 +41,11 @@ _HEALTH_PATHS = frozenset({"/", "/health", "/health/", "/api_health", "/api_heal
 
 # Path prefix for the Prometheus scrape endpoint.
 _MONITORING_PREFIX = "/monitoring/"
+
+# Exact paths for the GitHub webhook handler. Other webhook providers
+# (gitlab, bitbucket, github_enterprise, etc.) are intentionally excluded —
+# only the github route is high-volume enough to need its own sample rate.
+_WEBHOOK_GITHUB_PATHS = frozenset({"/webhooks/github", "/webhooks/github/"})
 
 SamplingContext = Mapping[str, Any]
 TracesSampler = Callable[[SamplingContext], float]
@@ -69,6 +77,7 @@ def make_traces_sampler(
     *,
     default_rate: float,
     badge_rate: float,
+    webhook_github_rate: float,
 ) -> TracesSampler:
     """Build a ``traces_sampler`` closure with the given fallback rates.
 
@@ -81,6 +90,11 @@ def make_traces_sampler(
         Sample rate applied to badge SVG endpoints. These are high-volume
         and low-variance; ``0.001`` (0.1%) keeps enough samples for latency
         monitoring without paying for full traces on every request.
+    webhook_github_rate:
+        Sample rate applied to ``/webhooks/github``. This is the single
+        highest-volume transaction in the app and most events are uniform;
+        ``0.001`` (0.1%) preserves latency and error visibility without
+        tracing every callback.
     """
 
     def traces_sampler(sampling_context: SamplingContext) -> float:
@@ -99,6 +113,8 @@ def make_traces_sampler(
             return 0.0
         if path.startswith(_MONITORING_PREFIX):
             return 0.0
+        if path in _WEBHOOK_GITHUB_PATHS:
+            return webhook_github_rate
         if _BADGE_PATH_RE.search(path):
             return badge_rate
 

--- a/apps/codecov-api/codecov/sentry_sampling.py
+++ b/apps/codecov-api/codecov/sentry_sampling.py
@@ -1,0 +1,107 @@
+"""Route-aware ``traces_sampler`` for the Sentry SDK.
+
+The codecov-api WSGI app handles a handful of route families that emit a lot
+of requests but carry no debugging signal:
+
+* ``/``, ``/health/``, ``/api_health/`` — Kubernetes / load-balancer health
+  probes.
+* ``/monitoring/...`` — ``django-prometheus`` scrape endpoints.
+* ``/{service}/{owner}/{repo}/.../badge.{ext}`` — coverage and bundle badge
+  SVGs. These are extremely high-volume and CDN-cacheable, and we never need
+  per-request traces to debug them.
+
+Everything else falls back to the default sample rate from ``settings``.
+
+The sampler also honors ``parent_sampled`` so distributed traces initiated
+upstream (e.g. by the shelter ingress) keep a consistent sampling decision.
+
+The factory pattern (:func:`make_traces_sampler`) lets the settings module
+inject the configurable defaults while keeping the matching logic pure and
+unit-testable.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping
+from typing import Any
+
+# Matches all four badge route patterns registered in ``graphs.urls``:
+#   /{service}/{owner}/{repo}/(graph|graphs)/badge.{ext}
+#   /{service}/{owner}/{repo}/branch/{branch}/(graph|graphs)/badge.{ext}
+#   /{service}/{owner}/{repo}/(graph|graphs)/bundle/{bundle}/badge.{ext}
+#   /{service}/{owner}/{repo}/branch/{branch}/(graph|graphs)/bundle/{bundle}/badge.{ext}
+_BADGE_PATH_RE = re.compile(r"/graphs?/(?:bundle/[^/]+/)?badge\.[^/]+/?$")
+
+# Exact paths that we drop unconditionally — health probes only.
+_HEALTH_PATHS = frozenset({"/", "/health", "/health/", "/api_health", "/api_health/"})
+
+# Path prefix for the Prometheus scrape endpoint.
+_MONITORING_PREFIX = "/monitoring/"
+
+SamplingContext = Mapping[str, Any]
+TracesSampler = Callable[[SamplingContext], float]
+
+
+def _extract_path(sampling_context: SamplingContext) -> str:
+    """Return the request path for HTTP transactions, or ``""`` otherwise.
+
+    ``sampling_context`` shape varies by integration. For Django/WSGI requests
+    Sentry passes the WSGI environ under ``"wsgi_environ"``; for ASGI it uses
+    ``"asgi_scope"``; non-HTTP transactions (Celery, etc.) have neither.
+    """
+    wsgi_environ = sampling_context.get("wsgi_environ")
+    if isinstance(wsgi_environ, Mapping):
+        path = wsgi_environ.get("PATH_INFO")
+        if isinstance(path, str):
+            return path
+
+    asgi_scope = sampling_context.get("asgi_scope")
+    if isinstance(asgi_scope, Mapping):
+        path = asgi_scope.get("path")
+        if isinstance(path, str):
+            return path
+
+    return ""
+
+
+def make_traces_sampler(
+    *,
+    default_rate: float,
+    badge_rate: float,
+) -> TracesSampler:
+    """Build a ``traces_sampler`` closure with the given fallback rates.
+
+    Parameters
+    ----------
+    default_rate:
+        Sample rate applied to any transaction that doesn't match a known
+        low-value route. Should mirror the previous ``traces_sample_rate``.
+    badge_rate:
+        Sample rate applied to badge SVG endpoints. These are high-volume
+        and low-variance; ``0.01`` (1%) keeps enough samples for latency
+        monitoring without paying for full traces on every request.
+    """
+
+    def traces_sampler(sampling_context: SamplingContext) -> float:
+        # Honor upstream sampling decisions so distributed traces stay coherent.
+        parent_sampled = sampling_context.get("parent_sampled")
+        if parent_sampled is True:
+            return 1.0
+        if parent_sampled is False:
+            return 0.0
+
+        path = _extract_path(sampling_context)
+        if not path:
+            return default_rate
+
+        if path in _HEALTH_PATHS:
+            return 0.0
+        if path.startswith(_MONITORING_PREFIX):
+            return 0.0
+        if _BADGE_PATH_RE.search(path):
+            return badge_rate
+
+        return default_rate
+
+    return traces_sampler

--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -457,6 +457,11 @@ if SENTRY_DSN is not None:
     SENTRY_BADGE_SAMPLE_RATE = float(
         get_config("services", "sentry", "badge_sample_rate", default="0.001")
     )
+    SENTRY_WEBHOOK_GITHUB_SAMPLE_RATE = float(
+        get_config(
+            "services", "sentry", "webhook_github_sample_rate", default="0.001"
+        )
+    )
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         event_scrubber=EventScrubber(denylist=SENTRY_DENY_LIST),
@@ -473,6 +478,7 @@ if SENTRY_DSN is not None:
         traces_sampler=make_traces_sampler(
             default_rate=SENTRY_SAMPLE_RATE,
             badge_rate=SENTRY_BADGE_SAMPLE_RATE,
+            webhook_github_rate=SENTRY_WEBHOOK_GITHUB_SAMPLE_RATE,
         ),
         enable_backpressure_handling=False,
         profiles_sample_rate=float(

--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -455,7 +455,7 @@ if SENTRY_DSN is not None:
         get_config("services", "sentry", "sample_rate", default="1.0")
     )
     SENTRY_BADGE_SAMPLE_RATE = float(
-        get_config("services", "sentry", "badge_sample_rate", default="0.01")
+        get_config("services", "sentry", "badge_sample_rate", default="0.001")
     )
     sentry_sdk.init(
         dsn=SENTRY_DSN,

--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -458,9 +458,7 @@ if SENTRY_DSN is not None:
         get_config("services", "sentry", "badge_sample_rate", default="0.001")
     )
     SENTRY_WEBHOOK_GITHUB_SAMPLE_RATE = float(
-        get_config(
-            "services", "sentry", "webhook_github_sample_rate", default="0.001"
-        )
+        get_config("services", "sentry", "webhook_github_sample_rate", default="0.001")
     )
     sentry_sdk.init(
         dsn=SENTRY_DSN,

--- a/apps/codecov-api/codecov/settings_base.py
+++ b/apps/codecov-api/codecov/settings_base.py
@@ -8,6 +8,7 @@ from sentry_sdk.integrations.httpx import HttpxIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.scrubber import DEFAULT_DENYLIST, EventScrubber
 
+from codecov.sentry_sampling import make_traces_sampler
 from shared.django_apps.db_settings import *
 from shared.helpers.redis import get_redis_url
 from shared.license import startup_license_logging
@@ -453,6 +454,9 @@ if SENTRY_DSN is not None:
     SENTRY_SAMPLE_RATE = float(
         get_config("services", "sentry", "sample_rate", default="1.0")
     )
+    SENTRY_BADGE_SAMPLE_RATE = float(
+        get_config("services", "sentry", "badge_sample_rate", default="0.01")
+    )
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         event_scrubber=EventScrubber(denylist=SENTRY_DENY_LIST),
@@ -466,7 +470,10 @@ if SENTRY_DSN is not None:
             HttpxIntegration(),
         ],
         environment=SENTRY_ENV,
-        traces_sample_rate=SENTRY_SAMPLE_RATE,
+        traces_sampler=make_traces_sampler(
+            default_rate=SENTRY_SAMPLE_RATE,
+            badge_rate=SENTRY_BADGE_SAMPLE_RATE,
+        ),
         enable_backpressure_handling=False,
         profiles_sample_rate=float(
             get_config("services", "sentry", "profile_sample_rate", default="0.01")

--- a/apps/codecov-api/codecov/tests/test_sentry_sampling.py
+++ b/apps/codecov-api/codecov/tests/test_sentry_sampling.py
@@ -5,7 +5,7 @@ from codecov.sentry_sampling import make_traces_sampler
 
 @pytest.fixture
 def sampler():
-    return make_traces_sampler(default_rate=0.5, badge_rate=0.01)
+    return make_traces_sampler(default_rate=0.5, badge_rate=0.001)
 
 
 def wsgi_ctx(path: str) -> dict:
@@ -56,7 +56,7 @@ class TestBadgeRoutes:
         ],
     )
     def test_badge_paths_use_badge_rate(self, sampler, path):
-        assert sampler(wsgi_ctx(path)) == 0.01
+        assert sampler(wsgi_ctx(path)) == 0.001
 
     @pytest.mark.parametrize(
         "path",

--- a/apps/codecov-api/codecov/tests/test_sentry_sampling.py
+++ b/apps/codecov-api/codecov/tests/test_sentry_sampling.py
@@ -1,0 +1,133 @@
+import pytest
+
+from codecov.sentry_sampling import make_traces_sampler
+
+
+@pytest.fixture
+def sampler():
+    return make_traces_sampler(default_rate=0.5, badge_rate=0.01)
+
+
+def wsgi_ctx(path: str) -> dict:
+    return {"wsgi_environ": {"PATH_INFO": path, "REQUEST_METHOD": "GET"}}
+
+
+def asgi_ctx(path: str) -> dict:
+    return {"asgi_scope": {"type": "http", "path": path, "method": "GET"}}
+
+
+class TestHealthAndMonitoring:
+    @pytest.mark.parametrize(
+        "path",
+        ["/", "/health", "/health/", "/api_health", "/api_health/"],
+    )
+    def test_health_paths_drop_to_zero(self, sampler, path):
+        assert sampler(wsgi_ctx(path)) == 0.0
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/monitoring/", "/monitoring/metrics", "/monitoring/metrics/"],
+    )
+    def test_monitoring_paths_drop_to_zero(self, sampler, path):
+        assert sampler(wsgi_ctx(path)) == 0.0
+
+    def test_health_paths_drop_to_zero_under_asgi(self, sampler):
+        assert sampler(asgi_ctx("/")) == 0.0
+        assert sampler(asgi_ctx("/monitoring/metrics")) == 0.0
+
+
+class TestBadgeRoutes:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # default-badge
+            "/gh/codecov/example/graph/badge.svg",
+            "/gh/codecov/example/graphs/badge.svg",
+            # branch-badge
+            "/gh/codecov/example/branch/main/graph/badge.svg",
+            "/gh/codecov/example/branch/feature/some-branch/graphs/badge.png",
+            # default-bundle-badge
+            "/gh/codecov/example/graph/bundle/web/badge.svg",
+            "/gh/codecov/example/graphs/bundle/api/badge.svg",
+            # branch-bundle-badge
+            "/gh/codecov/example/branch/main/graph/bundle/web/badge.svg",
+            # trailing slash tolerated
+            "/gh/codecov/example/graph/badge.svg/",
+        ],
+    )
+    def test_badge_paths_use_badge_rate(self, sampler, path):
+        assert sampler(wsgi_ctx(path)) == 0.01
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # graph charts, not badges
+            "/gh/codecov/example/graph/tree.svg",
+            "/gh/codecov/example/branch/main/graph/sunburst.svg",
+            "/gh/codecov/example/pull/123/graph/icicle.svg",
+            # words that share a prefix but aren't badges
+            "/gh/codecov/example/graphqlbadge.svg",
+            "/gh/codecov/example/badge.svg",
+            # API endpoints that include "badge" in a payload, not a path segment
+            "/api/v2/repos/badge-config",
+        ],
+    )
+    def test_non_badge_paths_fall_through(self, sampler, path):
+        assert sampler(wsgi_ctx(path)) == 0.5
+
+
+class TestDefaultRate:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/webhooks/github",
+            "/upload/v4/",
+            "/api/v2/github/codecov/repos/example/file_report/foo.py/",
+            "/billing/",
+            "/graphql/",
+        ],
+    )
+    def test_normal_paths_use_default_rate(self, sampler, path):
+        assert sampler(wsgi_ctx(path)) == 0.5
+
+    def test_non_http_transaction_uses_default_rate(self, sampler):
+        # Celery / cron transactions arrive without wsgi_environ or asgi_scope.
+        ctx = {"transaction_context": {"name": "app.tasks.notify.Notify"}}
+        assert sampler(ctx) == 0.5
+
+    def test_empty_context_uses_default_rate(self, sampler):
+        assert sampler({}) == 0.5
+
+    def test_malformed_wsgi_environ_uses_default_rate(self, sampler):
+        # PATH_INFO missing / wrong type.
+        assert sampler({"wsgi_environ": {"REQUEST_METHOD": "GET"}}) == 0.5
+        assert sampler({"wsgi_environ": "not-a-mapping"}) == 0.5
+
+
+class TestParentSampled:
+    def test_parent_sampled_true_always_samples(self, sampler):
+        # Even on a normally-dropped path, the upstream decision wins.
+        ctx = {**wsgi_ctx("/monitoring/metrics"), "parent_sampled": True}
+        assert sampler(ctx) == 1.0
+
+    def test_parent_sampled_false_always_drops(self, sampler):
+        ctx = {**wsgi_ctx("/webhooks/github"), "parent_sampled": False}
+        assert sampler(ctx) == 0.0
+
+    def test_parent_sampled_none_falls_through_to_path_rules(self, sampler):
+        ctx = {**wsgi_ctx("/monitoring/metrics"), "parent_sampled": None}
+        assert sampler(ctx) == 0.0
+
+
+class TestConfigurability:
+    def test_default_rate_is_honored(self):
+        sampler = make_traces_sampler(default_rate=0.25, badge_rate=0.01)
+        assert sampler(wsgi_ctx("/webhooks/github")) == 0.25
+
+    def test_badge_rate_is_honored(self):
+        sampler = make_traces_sampler(default_rate=1.0, badge_rate=0.0)
+        assert sampler(wsgi_ctx("/gh/codecov/example/graph/badge.svg")) == 0.0
+
+    def test_health_drops_regardless_of_default(self):
+        sampler = make_traces_sampler(default_rate=1.0, badge_rate=1.0)
+        assert sampler(wsgi_ctx("/health/")) == 0.0

--- a/apps/codecov-api/codecov/tests/test_sentry_sampling.py
+++ b/apps/codecov-api/codecov/tests/test_sentry_sampling.py
@@ -5,7 +5,9 @@ from codecov.sentry_sampling import make_traces_sampler
 
 @pytest.fixture
 def sampler():
-    return make_traces_sampler(default_rate=0.5, badge_rate=0.001)
+    return make_traces_sampler(
+        default_rate=0.5, badge_rate=0.001, webhook_github_rate=0.001
+    )
 
 
 def wsgi_ctx(path: str) -> dict:
@@ -76,11 +78,38 @@ class TestBadgeRoutes:
         assert sampler(wsgi_ctx(path)) == 0.5
 
 
+class TestWebhookGithub:
+    @pytest.mark.parametrize(
+        "path",
+        ["/webhooks/github", "/webhooks/github/"],
+    )
+    def test_github_webhook_uses_webhook_rate(self, sampler, path):
+        assert sampler(wsgi_ctx(path)) == 0.001
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # other providers stay on the default rate
+            "/webhooks/github_enterprise",
+            "/webhooks/gitlab",
+            "/webhooks/gitlab_enterprise",
+            "/webhooks/bitbucket",
+            "/webhooks/bitbucket_server",
+            "/webhooks/stripe",
+            "/webhooks/sentry",
+            # unrelated paths that happen to share the prefix
+            "/webhooks/github-status",
+            "/webhooks/github/extra",
+        ],
+    )
+    def test_other_webhook_routes_fall_through(self, sampler, path):
+        assert sampler(wsgi_ctx(path)) == 0.5
+
+
 class TestDefaultRate:
     @pytest.mark.parametrize(
         "path",
         [
-            "/webhooks/github",
             "/upload/v4/",
             "/api/v2/github/codecov/repos/example/file_report/foo.py/",
             "/billing/",
@@ -111,8 +140,13 @@ class TestParentSampled:
         assert sampler(ctx) == 1.0
 
     def test_parent_sampled_false_always_drops(self, sampler):
-        ctx = {**wsgi_ctx("/webhooks/github"), "parent_sampled": False}
+        ctx = {**wsgi_ctx("/api/v2/foo"), "parent_sampled": False}
         assert sampler(ctx) == 0.0
+
+    def test_parent_sampled_overrides_webhook_rate(self, sampler):
+        # Upstream "trace this webhook" wins over the 0.1% default sampler.
+        ctx = {**wsgi_ctx("/webhooks/github"), "parent_sampled": True}
+        assert sampler(ctx) == 1.0
 
     def test_parent_sampled_none_falls_through_to_path_rules(self, sampler):
         ctx = {**wsgi_ctx("/monitoring/metrics"), "parent_sampled": None}
@@ -121,13 +155,25 @@ class TestParentSampled:
 
 class TestConfigurability:
     def test_default_rate_is_honored(self):
-        sampler = make_traces_sampler(default_rate=0.25, badge_rate=0.01)
-        assert sampler(wsgi_ctx("/webhooks/github")) == 0.25
+        sampler = make_traces_sampler(
+            default_rate=0.25, badge_rate=0.01, webhook_github_rate=0.01
+        )
+        assert sampler(wsgi_ctx("/api/v2/foo")) == 0.25
 
     def test_badge_rate_is_honored(self):
-        sampler = make_traces_sampler(default_rate=1.0, badge_rate=0.0)
+        sampler = make_traces_sampler(
+            default_rate=1.0, badge_rate=0.0, webhook_github_rate=1.0
+        )
         assert sampler(wsgi_ctx("/gh/codecov/example/graph/badge.svg")) == 0.0
 
+    def test_webhook_github_rate_is_honored(self):
+        sampler = make_traces_sampler(
+            default_rate=1.0, badge_rate=1.0, webhook_github_rate=0.0
+        )
+        assert sampler(wsgi_ctx("/webhooks/github")) == 0.0
+
     def test_health_drops_regardless_of_default(self):
-        sampler = make_traces_sampler(default_rate=1.0, badge_rate=1.0)
+        sampler = make_traces_sampler(
+            default_rate=1.0, badge_rate=1.0, webhook_github_rate=1.0
+        )
         assert sampler(wsgi_ctx("/health/")) == 0.0


### PR DESCRIPTION
## Summary

Replaces the constant `traces_sample_rate` on codecov-api with a `traces_sampler` callable that returns a per-route sample rate, dropping or down-sampling traces on a handful of internal / high-volume endpoints.

## Routes affected

| Path | Rate | Why |
|---|---:|---|
| `/`, `/health`, `/health/`, `/api_health`, `/api_health/` | **0.0** | Kubernetes / load-balancer health probes. No per-request variance and no debugging signal. |
| `/monitoring/...` | **0.0** | `django-prometheus` scrape endpoint. Hit on a fixed cadence by Prometheus, not by users. |
| `/webhooks/github`, `/webhooks/github/` | **0.001** | Single highest-volume transaction in the app. Most callbacks are uniform (push / status); 0.1% sampling preserves latency and error visibility. Other webhook providers (gitlab, bitbucket, github_enterprise, stripe, sentry) stay on the default rate. |
| `/{service}/{owner}/{repo}/...graph[s]/...badge.{ext}` | **0.001** | Coverage and bundle badge SVGs. Extremely high-volume, CDN-cacheable, uniform in shape — 0.1% sampling keeps enough signal for latency monitoring without tracing every request. |
| everything else | `SENTRY_SAMPLE_RATE` (unchanged default) | Status quo for normal traffic. |

The sampler also honors `parent_sampled`, so distributed traces initiated upstream (e.g. by the shelter ingress) keep a consistent sampling decision across services — even on a normally-sampled-down route.

## Design

The matching logic lives in a new module `codecov.sentry_sampling` as a pure function behind a factory:

```python
sentry_sdk.init(
    ...
    traces_sampler=make_traces_sampler(
        default_rate=SENTRY_SAMPLE_RATE,
        badge_rate=SENTRY_BADGE_SAMPLE_RATE,
        webhook_github_rate=SENTRY_WEBHOOK_GITHUB_SAMPLE_RATE,
    ),
)
```

The factory pattern keeps the matching logic side-effect-free and unit-testable while letting settings inject the configurable rates. All rates are configurable; defaults:

| Config key | Default |
|---|---:|
| `services.sentry.sample_rate` | `1.0` (unchanged) |
| `services.sentry.badge_sample_rate` | `0.001` |
| `services.sentry.webhook_github_sample_rate` | `0.001` |

## Tests

49 new tests in `codecov/tests/test_sentry_sampling.py` cover:

- All five health paths drop to `0.0` under both WSGI and ASGI contexts.
- `/monitoring/...` prefix drops everything underneath.
- `/webhooks/github` and `/webhooks/github/` use the webhook rate; sibling providers (`/webhooks/gitlab`, `/webhooks/bitbucket`, `/webhooks/github_enterprise`, `/webhooks/stripe`, `/webhooks/sentry`) and lookalike paths (`/webhooks/github-status`, `/webhooks/github/extra`) fall through to the default rate.
- All four badge route families (default-badge, branch-badge, default-bundle-badge, branch-bundle-badge), with and without a trailing slash, get the badge rate.
- Lookalike paths (`graph/tree.svg`, `graphqlbadge.svg`, `/api/v2/repos/badge-config`) do **not** match the badge regex and fall through.
- Non-HTTP transactions (Celery / cron) with no `wsgi_environ` or `asgi_scope` use the default rate — no false drops.
- `parent_sampled=True/False` overrides path-based decisions (including the webhook override); `parent_sampled=None` falls through to path rules.
- Malformed sampling contexts (missing `PATH_INFO`, non-mapping environ) fall back to the default rate rather than raising.

```
$ pytest codecov/tests/test_sentry_sampling.py -q
49 passed in 0.14s
```

## Notes

- The change is a no-op for any traffic that isn't on one of the listed routes — the same `SENTRY_SAMPLE_RATE` applies.
- If we ever need targeted traces on a normally-dropped or sampled-down route (e.g. debugging a flaky webhook delivery), bump the rate from the upstream caller — `parent_sampled=True` will be honored, or raise the relevant config knob per-environment.
- I considered using `re_path` route names instead of `PATH_INFO` matching, but the sampler runs before Django URL resolution completes for the transaction, so the route name isn't reliably available; matching on the raw path is the more robust signal.

## Test plan

- [ ] CI green
- [ ] After deploy, verify in Sentry Explore › Traces:
  - `transaction:/monitoring/metrics` count drops to ~0
  - `transaction:/` count drops to ~0
  - `transaction:/webhooks/github` count drops to ~0.1% of prior volume
  - Badge transaction families (`.../badge.{ext}`) drop to ~0.1% of prior volume
- [ ] Confirm other webhook providers (`/webhooks/gitlab`, `/webhooks/bitbucket`, ...) are unchanged in volume
- [ ] Confirm all other transaction families (uploads, GraphQL, REST API) are unchanged in volume
- [ ] Confirm distributed traces from shelter / worker still link to api spans where the upstream sampled them in

## Refs

- Sentry SDK `traces_sampler` docs: https://docs.sentry.io/platforms/python/configuration/sampling/#setting-a-sampling-function

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk observability-only change, but misclassification of paths or overly aggressive sampling could reduce trace visibility for some high-volume routes.
> 
> **Overview**
> Replaces the global Sentry `traces_sample_rate` in codecov-api with a route-aware `traces_sampler` that **drops** tracing for health-check and `/monitoring/*` endpoints and **down-samples** tracing for badge routes and `/webhooks/github`, while keeping the existing default rate for all other traffic.
> 
> Adds new config knobs (`services.sentry.badge_sample_rate`, `services.sentry.webhook_github_sample_rate`) and a tested sampler implementation that also honors `parent_sampled` to preserve upstream distributed-tracing decisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e6c9fe1889a87d1f8416775bdd77f5c9b73c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->