### PR TITLE
fix(sentry): path rules beat parent_sampled in traces_sampler

### DIFF
--- a/apps/codecov-api/codecov/sentry_sampling.py
+++ b/apps/codecov-api/codecov/sentry_sampling.py
@@ -15,21 +15,10 @@ of requests but carry low per-request debugging signal:
 
 Everything else falls back to the default sample rate from ``settings``.
 
-Precedence
-----------
-Path-based drops and down-samples take precedence over ``parent_sampled``.
-This is deliberate: the shelter ingress sits in front of ``codecov-api`` and
-initializes its own Sentry SDK with ``traces_sample_rate=1.0``, which means
-every request shelter forwards arrives at api with ``parent_sampled=True``.
-If we honored that first we would re-sample every webhook, badge and health
-probe at 100%, which is the opposite of the goal of this sampler. So we
-apply path rules first, then honor ``parent_sampled`` for everything else
-so distributed traces from internal callers (worker → api, etc.) stay
-coherent on routes we *do* care about.
-
-The factory pattern (:func:`make_traces_sampler`) lets the settings module
-inject the configurable defaults while keeping the matching logic pure and
-unit-testable.
+Path rules take precedence over ``parent_sampled`` — shelter sits in front
+of api with ``traces_sample_rate=1.0`` and would otherwise re-sample every
+webhook/badge/health probe at 100%. ``parent_sampled`` still governs routes
+without a path rule so internal traces (worker → api, etc.) stay coherent.
 """
 
 from __future__ import annotations
@@ -107,9 +96,6 @@ def make_traces_sampler(
     """
 
     def traces_sampler(sampling_context: SamplingContext) -> float:
-        # Path-based rules first: a "drop this route" decision must beat
-        # parent_sampled, otherwise shelter's traces_sample_rate=1.0 in
-        # front of api would re-sample every webhook/badge/health probe.
         path = _extract_path(sampling_context)
         if path:
             if path in _HEALTH_PATHS:
@@ -121,8 +107,6 @@ def make_traces_sampler(
             if _BADGE_PATH_RE.search(path):
                 return badge_rate
 
-        # Otherwise honor upstream sampling decisions so distributed traces
-        # from internal callers (worker → api, etc.) stay coherent.
         parent_sampled = sampling_context.get("parent_sampled")
         if parent_sampled is True:
             return 1.0

--- a/apps/codecov-api/codecov/sentry_sampling.py
+++ b/apps/codecov-api/codecov/sentry_sampling.py
@@ -15,8 +15,17 @@ of requests but carry low per-request debugging signal:
 
 Everything else falls back to the default sample rate from ``settings``.
 
-The sampler also honors ``parent_sampled`` so distributed traces initiated
-upstream (e.g. by the shelter ingress) keep a consistent sampling decision.
+Precedence
+----------
+Path-based drops and down-samples take precedence over ``parent_sampled``.
+This is deliberate: the shelter ingress sits in front of ``codecov-api`` and
+initializes its own Sentry SDK with ``traces_sample_rate=1.0``, which means
+every request shelter forwards arrives at api with ``parent_sampled=True``.
+If we honored that first we would re-sample every webhook, badge and health
+probe at 100%, which is the opposite of the goal of this sampler. So we
+apply path rules first, then honor ``parent_sampled`` for everything else
+so distributed traces from internal callers (worker → api, etc.) stay
+coherent on routes we *do* care about.
 
 The factory pattern (:func:`make_traces_sampler`) lets the settings module
 inject the configurable defaults while keeping the matching logic pure and
@@ -98,25 +107,27 @@ def make_traces_sampler(
     """
 
     def traces_sampler(sampling_context: SamplingContext) -> float:
-        # Honor upstream sampling decisions so distributed traces stay coherent.
+        # Path-based rules first: a "drop this route" decision must beat
+        # parent_sampled, otherwise shelter's traces_sample_rate=1.0 in
+        # front of api would re-sample every webhook/badge/health probe.
+        path = _extract_path(sampling_context)
+        if path:
+            if path in _HEALTH_PATHS:
+                return 0.0
+            if path.startswith(_MONITORING_PREFIX):
+                return 0.0
+            if path in _WEBHOOK_GITHUB_PATHS:
+                return webhook_github_rate
+            if _BADGE_PATH_RE.search(path):
+                return badge_rate
+
+        # Otherwise honor upstream sampling decisions so distributed traces
+        # from internal callers (worker → api, etc.) stay coherent.
         parent_sampled = sampling_context.get("parent_sampled")
         if parent_sampled is True:
             return 1.0
         if parent_sampled is False:
             return 0.0
-
-        path = _extract_path(sampling_context)
-        if not path:
-            return default_rate
-
-        if path in _HEALTH_PATHS:
-            return 0.0
-        if path.startswith(_MONITORING_PREFIX):
-            return 0.0
-        if path in _WEBHOOK_GITHUB_PATHS:
-            return webhook_github_rate
-        if _BADGE_PATH_RE.search(path):
-            return badge_rate
 
         return default_rate
 

--- a/apps/codecov-api/codecov/tests/test_sentry_sampling.py
+++ b/apps/codecov-api/codecov/tests/test_sentry_sampling.py
@@ -134,10 +134,6 @@ class TestDefaultRate:
 
 
 class TestParentSampled:
-    # Path-based rules take precedence over parent_sampled so the shelter
-    # ingress (traces_sample_rate=1.0) cannot re-sample low-value routes at
-    # 100% via trace propagation. See module docstring for rationale.
-
     @pytest.mark.parametrize(
         "path,expected",
         [
@@ -173,8 +169,6 @@ class TestParentSampled:
         assert sampler(ctx) == expected
 
     def test_parent_sampled_true_wins_on_non_rule_paths(self, sampler):
-        # For routes without a path rule, distributed-trace coherence still
-        # matters — honor what the upstream service decided.
         ctx = {**wsgi_ctx("/api/v2/foo"), "parent_sampled": True}
         assert sampler(ctx) == 1.0
 
@@ -191,8 +185,6 @@ class TestParentSampled:
         assert sampler(ctx) == 0.0
 
     def test_parent_sampled_true_on_non_http_uses_default(self, sampler):
-        # No path to match — only parent decision applies (Celery/cron with
-        # an inbound sentry-trace, etc.).
         ctx = {"parent_sampled": True}
         assert sampler(ctx) == 1.0
 

--- a/apps/codecov-api/codecov/tests/test_sentry_sampling.py
+++ b/apps/codecov-api/codecov/tests/test_sentry_sampling.py
@@ -134,23 +134,67 @@ class TestDefaultRate:
 
 
 class TestParentSampled:
-    def test_parent_sampled_true_always_samples(self, sampler):
-        # Even on a normally-dropped path, the upstream decision wins.
-        ctx = {**wsgi_ctx("/monitoring/metrics"), "parent_sampled": True}
+    # Path-based rules take precedence over parent_sampled so the shelter
+    # ingress (traces_sample_rate=1.0) cannot re-sample low-value routes at
+    # 100% via trace propagation. See module docstring for rationale.
+
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("/", 0.0),
+            ("/health/", 0.0),
+            ("/api_health/", 0.0),
+            ("/monitoring/metrics", 0.0),
+            ("/webhooks/github", 0.001),
+            ("/webhooks/github/", 0.001),
+            ("/gh/codecov/example/graph/badge.svg", 0.001),
+            ("/gh/codecov/example/branch/main/graph/bundle/web/badge.svg", 0.001),
+        ],
+    )
+    def test_parent_sampled_true_does_not_override_path_rules(
+        self, sampler, path, expected
+    ):
+        ctx = {**wsgi_ctx(path), "parent_sampled": True}
+        assert sampler(ctx) == expected
+
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("/", 0.0),
+            ("/monitoring/metrics", 0.0),
+            ("/webhooks/github", 0.001),
+            ("/gh/codecov/example/graph/badge.svg", 0.001),
+        ],
+    )
+    def test_parent_sampled_false_does_not_override_path_rules(
+        self, sampler, path, expected
+    ):
+        ctx = {**wsgi_ctx(path), "parent_sampled": False}
+        assert sampler(ctx) == expected
+
+    def test_parent_sampled_true_wins_on_non_rule_paths(self, sampler):
+        # For routes without a path rule, distributed-trace coherence still
+        # matters — honor what the upstream service decided.
+        ctx = {**wsgi_ctx("/api/v2/foo"), "parent_sampled": True}
         assert sampler(ctx) == 1.0
 
-    def test_parent_sampled_false_always_drops(self, sampler):
+    def test_parent_sampled_false_drops_on_non_rule_paths(self, sampler):
         ctx = {**wsgi_ctx("/api/v2/foo"), "parent_sampled": False}
         assert sampler(ctx) == 0.0
 
-    def test_parent_sampled_overrides_webhook_rate(self, sampler):
-        # Upstream "trace this webhook" wins over the 0.1% default sampler.
-        ctx = {**wsgi_ctx("/webhooks/github"), "parent_sampled": True}
-        assert sampler(ctx) == 1.0
+    def test_parent_sampled_none_falls_through_to_default(self, sampler):
+        ctx = {**wsgi_ctx("/api/v2/foo"), "parent_sampled": None}
+        assert sampler(ctx) == 0.5
 
-    def test_parent_sampled_none_falls_through_to_path_rules(self, sampler):
+    def test_parent_sampled_none_still_uses_path_rules(self, sampler):
         ctx = {**wsgi_ctx("/monitoring/metrics"), "parent_sampled": None}
         assert sampler(ctx) == 0.0
+
+    def test_parent_sampled_true_on_non_http_uses_default(self, sampler):
+        # No path to match — only parent decision applies (Celery/cron with
+        # an inbound sentry-trace, etc.).
+        ctx = {"parent_sampled": True}
+        assert sampler(ctx) == 1.0
 
 
 class TestConfigurability:


### PR DESCRIPTION
## Summary

Path-based drop and down-sample rules in the api `traces_sampler` (introduced in #924) are currently being defeated by trace propagation from the shelter ingress. Reorder the sampler so path rules win over `parent_sampled`, restoring the intended sampling rates on `/webhooks/github`, `/health/`, `/monitoring/...`, and badge URLs.

## The problem

`shelter/libs/helpers.py` initializes the Sentry SDK with `traces_sample_rate=1.0`:

\`\`\`python
sentry_sdk.init(
    dsn=sentry_dsn,
    environment=f\"{app_name}-{APP_ENV}\",
    traces_sample_rate=1.0,
    ...
)
\`\`\`

shelter samples every inbound webhook at 100% and forwards the request to codecov-api with `sentry-trace` headers. On the api side, the current sampler does this first:

\`\`\`python
parent_sampled = sampling_context.get(\"parent_sampled\")
if parent_sampled is True:
    return 1.0  # ← shelter wins; path rules never run
\`\`\`

So every webhook coming through shelter gets sampled at 100% on api regardless of the route. The 0.1% `webhook_github_rate` from #924 only applies to requests that hit api *without* going through shelter (internal callers, k8s probes).

## Verification in production

After #924 rolled out to `production-release-894811b`, I checked the data:

- `/webhooks/github` on the new api release: **~50,000 transactions / 15 min** (expected ~50 at a 0.1% rate)
- Every single sampled transaction had a non-empty `parent_span`:

\`\`\`
parent_span: be1c69666492f039
parent_span: a036d3cc41de412e
parent_span: ba42426f4dba6c06
parent_span: 97ac1285a0638d39
parent_span: ab8bb9b2833eb42b
\`\`\`

That's the shelter→api hop overriding the api-side sampler.

Health checks (`/`, `/health/`, `/monitoring/metrics`) and badge URLs are *not* affected in practice because they don't typically come through shelter — those rules are working correctly today. But the precedence is wrong in principle, and `/webhooks/github` is the single largest cost center on the org-wide spans bill.

## The fix

One-block reorder in `codecov.sentry_sampling.make_traces_sampler`:

\`\`\`python
def traces_sampler(sampling_context):
    # Path-based rules first: a \"drop this route\" decision must beat
    # parent_sampled, otherwise shelter's traces_sample_rate=1.0 in
    # front of api would re-sample every webhook/badge/health probe.
    path = _extract_path(sampling_context)
    if path:
        if path in _HEALTH_PATHS:
            return 0.0
        if path.startswith(_MONITORING_PREFIX):
            return 0.0
        if path in _WEBHOOK_GITHUB_PATHS:
            return webhook_github_rate
        if _BADGE_PATH_RE.search(path):
            return badge_rate

    # Otherwise honor upstream sampling decisions so distributed traces
    # from internal callers (worker → api, etc.) stay coherent.
    parent_sampled = sampling_context.get(\"parent_sampled\")
    if parent_sampled is True:
        return 1.0
    if parent_sampled is False:
        return 0.0

    return default_rate
\`\`\`

The semantic change is precise: a path rule *always* applies on a route it matches, regardless of what upstream decided. For everything else, `parent_sampled` continues to govern, so worker→api Celery beats / cron-initiated traces stay coherent.

## What about distributed traces?

For routes covered by a path rule we accept a *partial* distributed trace as a tradeoff: shelter's webhook-ingress span is kept at 100% (under its own SDK init), and the api-side downstream is sampled per the rule. That's the right tradeoff for high-volume, low-variance routes like `/webhooks/github` — we keep enough samples to debug latency and errors, and we drop the 99.9% noise.

The cleaner long-term fix is to give shelter its own `traces_sampler` that down-samples `/webhooks/github` at the trace origin. I'll file a follow-up for that — it touches the shelter repo and is a larger change. This PR is the immediate cost cut.

## Tests

`TestParentSampled` in `test_sentry_sampling.py` is expanded to cover both directions:

- `parent_sampled=True` *no longer* overrides the rates on `/`, `/health/`, `/api_health/`, `/monitoring/metrics`, `/webhooks/github`, `/webhooks/github/`, default-badge and bundle-badge URLs.
- `parent_sampled=False` similarly doesn't override path rules (a slightly stricter interpretation than the alternative — keeps the semantics symmetric and simple).
- `parent_sampled=True` *still* wins on routes without a path rule (e.g. `/api/v2/foo`) so distributed-trace coherence is preserved where it matters.
- `parent_sampled=False` still drops to 0 on non-rule routes.
- Non-HTTP transactions (Celery/cron) with `parent_sampled=True` and no path → 1.0 (unchanged).

\`\`\`
$ pytest apps/codecov-api/codecov/tests/test_sentry_sampling.py -q
62 passed in 0.19s
\`\`\`

## Expected impact after rollout

Re-querying `/webhooks/github` 30 min after deploy should show:

- transactions / 15 min on api dropping from ~50,000 to **~50** (1000× reduction)
- span count proportionally
- distributed traces remain visible at the shelter level for incident triage; the api-side detail is sampled

That eliminates the last major chunk of the org-wide span bill on api. Combined with #923 (middleware spans off) and #924 (other routes), this should be effectively the end-state for the api project. ecdn-api and slack-app still need their respective deploys to fully roll over.

## Refs

- Builds on #923 (middleware spans disabled) and #924 (route-aware sampler).
- Sentry SDK docs on `traces_sampler` precedence: https://docs.sentry.io/platforms/python/configuration/sampling/

## Test plan

- [ ] CI green
- [ ] After deploy, verify in Sentry Explore:
  - `transaction:/webhooks/github project:api release:production-release-<new>` count drops by ~1000× vs the current rate
  - Other webhook providers (`/webhooks/gitlab`, `/webhooks/bitbucket`, ...) remain unchanged in volume
  - Default-rate routes (uploads, REST API, GraphQL) remain unchanged
  - Distributed traces that *do* start in api (no parent) and propagate to worker still link correctly

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Sentry tracing sampling precedence for high-volume routes, which can significantly alter production trace volume and distributed-trace continuity. Risk is mitigated by expanded unit coverage across parent-sampled and path-rule combinations.
> 
> **Overview**
> Updates `codecov.sentry_sampling.make_traces_sampler` to evaluate **path-based drop/downsample rules before** honoring `parent_sampled`, ensuring `/health*`, `/monitoring/*`, badge URLs, and `/webhooks/github` keep their intended sampling rates even when upstream services propagate a sampled trace.
> 
> Expands `TestParentSampled` to assert that both `parent_sampled=True` and `parent_sampled=False` no longer override these path rules, while `parent_sampled` still controls sampling for non-matching routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c346f2e6a1af1c7e8a276a50bfa8187eafd4cc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->