### PR TITLE
fix(migrations): work around GinIndex+OpClass codegen regression in Django 5.x

### DIFF
--- a/libs/shared/shared/django_apps/core/migrations/0056_branch_name_trgm_idx.py
+++ b/libs/shared/shared/django_apps/core/migrations/0056_branch_name_trgm_idx.py
@@ -4,7 +4,7 @@ import django.contrib.postgres.indexes
 import django.db.models.functions.text
 from django.db import migrations
 
-from shared.django_apps.migration_utils import RiskyAddIndex
+from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
@@ -22,13 +22,28 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        RiskyAddIndex(
-            model_name="branch",
-            index=django.contrib.postgres.indexes.GinIndex(
-                django.contrib.postgres.indexes.OpClass(
-                    django.db.models.functions.text.Upper("name"), name="gin_trgm_ops"
+        # SeparateDatabaseAndState is used here because GinIndex(OpClass(...)) codegen
+        # broke in Django 5.x: it places the operator class inside the expression parens
+        # instead of after them, producing invalid SQL. The correct SQL is hardcoded in
+        # the database_operations; state_operations keep Django's model state in sync.
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                RiskyRunSQL(
+                    sql='CREATE INDEX IF NOT EXISTS "name_trgm_idx" ON "branches" USING gin ((UPPER("name")) gin_trgm_ops)',
+                    reverse_sql='DROP INDEX IF EXISTS "name_trgm_idx"',
                 ),
-                name="name_trgm_idx",
-            ),
+            ],
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="branch",
+                    index=django.contrib.postgres.indexes.GinIndex(
+                        django.contrib.postgres.indexes.OpClass(
+                            django.db.models.functions.text.Upper("name"),
+                            name="gin_trgm_ops",
+                        ),
+                        name="name_trgm_idx",
+                    ),
+                ),
+            ],
         ),
     ]

--- a/libs/shared/shared/django_apps/core/migrations/0056_branch_name_trgm_idx.py
+++ b/libs/shared/shared/django_apps/core/migrations/0056_branch_name_trgm_idx.py
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 RiskyRunSQL(
-                    sql='CREATE INDEX IF NOT EXISTS "name_trgm_idx" ON "branches" USING gin ((UPPER("name")) gin_trgm_ops)',
+                    sql='CREATE INDEX IF NOT EXISTS "name_trgm_idx" ON "branches" USING gin ((UPPER("branch")) gin_trgm_ops)',
                     reverse_sql='DROP INDEX IF EXISTS "name_trgm_idx"',
                 ),
             ],

--- a/libs/shared/shared/django_apps/core/migrations/0080_repository_repos_name_trgm_idx.py
+++ b/libs/shared/shared/django_apps/core/migrations/0080_repository_repos_name_trgm_idx.py
@@ -4,7 +4,7 @@ import django.contrib.postgres.indexes
 import django.db.models.functions.text
 from django.db import migrations
 
-from shared.django_apps.migration_utils import RiskyAddIndex
+from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
@@ -22,13 +22,28 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        RiskyAddIndex(
-            model_name="repository",
-            index=django.contrib.postgres.indexes.GinIndex(
-                django.contrib.postgres.indexes.OpClass(
-                    django.db.models.functions.text.Upper("name"), name="gin_trgm_ops"
+        # SeparateDatabaseAndState is used here because GinIndex(OpClass(...)) codegen
+        # broke in Django 5.x: it places the operator class inside the expression parens
+        # instead of after them, producing invalid SQL. The correct SQL is hardcoded in
+        # the database_operations; state_operations keep Django's model state in sync.
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                RiskyRunSQL(
+                    sql='CREATE INDEX IF NOT EXISTS "repos_name_trgm_idx" ON "repos" USING gin ((UPPER("name")) gin_trgm_ops)',
+                    reverse_sql='DROP INDEX IF EXISTS "repos_name_trgm_idx"',
                 ),
-                name="repos_name_trgm_idx",
-            ),
+            ],
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="repository",
+                    index=django.contrib.postgres.indexes.GinIndex(
+                        django.contrib.postgres.indexes.OpClass(
+                            django.db.models.functions.text.Upper("name"),
+                            name="gin_trgm_ops",
+                        ),
+                        name="repos_name_trgm_idx",
+                    ),
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
## Problem

`GinIndex(OpClass(Upper(field), name="gin_trgm_ops"))` generates invalid SQL under Django 5.x. The operator class ends up **inside** the expression parens instead of after them:

```sql
-- Generated (broken):
CREATE INDEX ... USING gin ((UPPER("name") gin_trgm_ops))

-- Correct:
CREATE INDEX ... USING gin ((UPPER("name")) gin_trgm_ops)
```

PostgreSQL rejects this with `syntax error at or near "gin_trgm_ops"`, causing the worker to crash-loop on startup when it tries to run migrations.

Two migrations are affected:
- `core/0056_branch_name_trgm_idx`
- `core/0080_repository_repos_name_trgm_idx`

Both were generated against Django 4.2 and worked fine then, but fail on Django 5.x.

## Fix

Replace `RiskyAddIndex` with `SeparateDatabaseAndState`:

- `database_operations`: `RiskyRunSQL` with the correct hardcoded SQL (preserves the risky-skip behaviour via `SKIP_RISKY_MIGRATION_STEPS`)
- `state_operations`: plain `AddIndex` to keep Django's model state in sync

The SQL used is exactly what the migration docstrings already document as the intended DDL. `IF NOT EXISTS` makes it safe to re-run.

## Testing

Verified against PostgreSQL 14 with Django 5.x — migrations apply cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production database migrations by replacing ORM-generated index DDL with raw `RunSQL`, so mistakes could break migration application or leave schema/state mismatched, though the change is limited to two index creations and uses `IF NOT EXISTS`/reversible SQL.
> 
> **Overview**
> Works around a Django 5.x SQL generation regression for `GinIndex(OpClass(...))` by changing two trigram index migrations to use `SeparateDatabaseAndState`.
> 
> The DB step now runs explicit `CREATE INDEX IF NOT EXISTS ... gin_trgm_ops` via `RiskyRunSQL` (preserving `SKIP_RISKY_MIGRATION_STEPS` behavior), while the migration state still records the corresponding `AddIndex` so Django’s model state remains consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7d9f133a644bdf38a13e66be9212abf9d4859e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->