### PR TITLE
feat: allow staff users to delete owners in Django admin

### DIFF
--- a/apps/codecov-api/codecov_auth/admin.py
+++ b/apps/codecov-api/codecov_auth/admin.py
@@ -821,7 +821,7 @@ class OwnerAdmin(AdminMixin, admin.ModelAdmin):
         return False
 
     def has_delete_permission(self, request, obj=None):
-        return bool(request.user and request.user.is_superuser)
+        return bool(request.user and request.user.is_staff)
 
     def delete_queryset(self, request, queryset) -> None:
         for owner in queryset:


### PR DESCRIPTION
## What
Loosen `OwnerAdmin.has_delete_permission` from `is_superuser` to `is_staff`, so staff users (not just superusers) can delete owners from the Django admin.

## Why
Owner deletion was previously restricted to superusers. Staff need to perform this operation. This aligns with the existing `is_staff` convention already used elsewhere in `codecov_auth/admin.py` (e.g. `OrgUploadTokenInline.has_delete_permission` / `has_add_permission`).

## Notes
- Behavior is otherwise unchanged: deletions still route through the same `TaskService().delete_owner()` pipeline (mark for deletion → PII obfuscation → 48h grace period → cron-driven cascade cleanup).
- `is_staff` is already required to access the Django admin at all, so this effectively grants delete to admin users.