### PR TITLE
feat: Add automatic tax enablement for stripe calls

### DIFF
--- a/apps/codecov-api/api/internal/tests/views/test_account_viewset.py
+++ b/apps/codecov-api/api/internal/tests/views/test_account_viewset.py
@@ -1312,6 +1312,7 @@ class AccountViewSetTests(APITestCase):
 
         modify_subscription_mock.assert_called_once_with(
             self.current_owner.stripe_subscription_id,
+            automatic_tax={"enabled": True},
             default_payment_method=payment_method_id,
         )
 

--- a/apps/codecov-api/billing/tests/test_views.py
+++ b/apps/codecov-api/billing/tests/test_views.py
@@ -1750,7 +1750,9 @@ class StripeWebhookHandlerTests(APITestCase):
         )
 
         subscription_modify_mock.assert_called_once_with(
-            "sub_123", default_payment_method=payment_method
+            "sub_123",
+            automatic_tax={"enabled": True},
+            default_payment_method=payment_method,
         )
 
     @patch("services.billing.stripe.PaymentIntent.retrieve")
@@ -1858,7 +1860,9 @@ class StripeWebhookHandlerTests(APITestCase):
             },
         )
         subscription_modify_mock.assert_called_once_with(
-            "sub_123", default_payment_method=payment_method_retrieve_mock.return_value
+            "sub_123",
+            automatic_tax={"enabled": True},
+            default_payment_method=payment_method_retrieve_mock.return_value,
         )
 
     @patch("logging.Logger.error")
@@ -1978,10 +1982,12 @@ class StripeWebhookHandlerTests(APITestCase):
             [
                 call(
                     "sub_123",
+                    automatic_tax={"enabled": True},
                     default_payment_method=payment_method_retrieve_mock.return_value,
                 ),
                 call(
                     "sub_124",
+                    automatic_tax={"enabled": True},
                     default_payment_method=payment_method_retrieve_mock.return_value,
                 ),
             ]

--- a/apps/codecov-api/billing/views.py
+++ b/apps/codecov-api/billing/views.py
@@ -516,7 +516,9 @@ class StripeWebhookHandler(APIView):
                 },
             )
             stripe.Subscription.modify(
-                subscription["id"], default_payment_method=new_default_payment_method
+                subscription["id"],
+                automatic_tax={"enabled": True},
+                default_payment_method=new_default_payment_method,
             )
 
     def checkout_session_completed(
@@ -572,6 +574,7 @@ class StripeWebhookHandler(APIView):
                 for owner in owners:
                     stripe.Subscription.modify(
                         owner.stripe_subscription_id,
+                        automatic_tax={"enabled": True},
                         default_payment_method=payment_method,
                     )
             else:

--- a/apps/codecov-api/services/billing.py
+++ b/apps/codecov-api/services/billing.py
@@ -284,6 +284,7 @@ class StripeService(AbstractPaymentService):
         # schedule a cancellation at the end of the paid period with no refund
         stripe.Subscription.modify(
             owner.stripe_subscription_id,
+            automatic_tax={"enabled": True},
             cancel_at_period_end=True,
             proration_behavior="none",
         )
@@ -363,6 +364,7 @@ class StripeService(AbstractPaymentService):
 
             subscription = stripe.Subscription.modify(
                 owner.stripe_subscription_id,
+                automatic_tax={"enabled": True},
                 cancel_at_period_end=False,
                 items=[
                     {
@@ -434,6 +436,7 @@ class StripeService(AbstractPaymentService):
 
         stripe.SubscriptionSchedule.modify(
             subscription_schedule_id,
+            default_settings={"automatic_tax": {"enabled": True}},
             end_behavior="release",
             phases=[
                 {
@@ -585,6 +588,7 @@ class StripeService(AbstractPaymentService):
                 if owner.stripe_customer_id
                 else None
             ),
+            automatic_tax={"enabled": True},
         )
         log.info(
             f"Stripe Checkout Session created successfully for owner {owner.ownerid} by user #{self.requesting_user.ownerid}"
@@ -654,7 +658,9 @@ class StripeService(AbstractPaymentService):
                 invoice_settings={"default_payment_method": payment_method},
             )
             stripe.Subscription.modify(
-                owner.stripe_subscription_id, default_payment_method=payment_method
+                owner.stripe_subscription_id,
+                automatic_tax={"enabled": True},
+                default_payment_method=payment_method,
             )
         log.info(
             f"Successfully updated payment method for owner {owner.ownerid} by user #{self.requesting_user.ownerid}",

--- a/apps/codecov-api/services/tests/test_billing.py
+++ b/apps/codecov-api/services/tests/test_billing.py
@@ -198,6 +198,7 @@ class StripeServiceTests(TestCase):
         plan = Plan.objects.get(name=desired_plan["value"])
         subscription_modify_mock.assert_called_once_with(
             owner.stripe_subscription_id,
+            automatic_tax={"enabled": True},
             cancel_at_period_end=False,
             items=[
                 {
@@ -229,6 +230,7 @@ class StripeServiceTests(TestCase):
         plan = Plan.objects.get(name=desired_plan["value"])
         schedule_modify_mock.assert_called_once_with(
             schedule_id,
+            default_settings={"automatic_tax": {"enabled": True}},
             end_behavior="release",
             phases=[
                 {
@@ -333,6 +335,7 @@ class StripeServiceTests(TestCase):
         self.stripe.delete_subscription(owner)
         modify_mock.assert_called_once_with(
             stripe_subscription_id,
+            automatic_tax={"enabled": True},
             cancel_at_period_end=True,
             proration_behavior="none",
         )
@@ -387,6 +390,7 @@ class StripeServiceTests(TestCase):
         schedule_release_mock.assert_called_once_with(stripe_schedule_id)
         modify_mock.assert_called_once_with(
             stripe_subscription_id,
+            automatic_tax={"enabled": True},
             cancel_at_period_end=True,
             proration_behavior="none",
         )
@@ -684,6 +688,7 @@ class StripeServiceTests(TestCase):
         modify_customer_mock.assert_not_called()
         modify_sub_mock.assert_called_once_with(
             stripe_subscription_id,
+            automatic_tax={"enabled": True},
             cancel_at_period_end=True,
             proration_behavior="none",
         )
@@ -1648,6 +1653,7 @@ class StripeServiceTests(TestCase):
             },
             tax_id_collection={"enabled": True},
             customer_update=None,
+            automatic_tax={"enabled": True},
         )
 
     @patch("services.billing.stripe.checkout.Session.create")
@@ -1698,6 +1704,7 @@ class StripeServiceTests(TestCase):
             },
             tax_id_collection={"enabled": True},
             customer_update={"name": "auto", "address": "auto"},
+            automatic_tax={"enabled": True},
         )
 
     @patch("logging.Logger.error")
@@ -1778,7 +1785,9 @@ class StripeServiceTests(TestCase):
         )
 
         modify_sub_mock.assert_called_once_with(
-            subscription_id, default_payment_method=payment_method_id
+            subscription_id,
+            automatic_tax={"enabled": True},
+            default_payment_method=payment_method_id,
         )
 
     @patch("services.billing.stripe.PaymentMethod.attach")


### PR DESCRIPTION
Add tax enablement true for step 6 of preparing for anrok https://help-center.anrok.com/hc/en-us/articles/17604840278675-Integrate-Anrok-Stripe.

Changes are made to creation or updates of Stripe Checkout Sessions, Invoices, Subscriptions via the Stripe API. We don't have Quotes or Payment Links currently in our code to modify.

<img width="797" height="34" alt="Screenshot 2026-06-04 at 8 52 44 AM" src="https://github.com/user-attachments/assets/78f038d3-07cb-42f9-8a0b-37052e809b70" />
<img width="418" height="433" alt="Screenshot 2026-06-04 at 8 52 59 AM" src="https://github.com/user-attachments/assets/26f5e142-1384-42f3-9058-43c663ec9df9" />
