### PR TITLE
feat: add Sentry app deprecation notice to PR comments and GraphQL owner type

### DIFF
--- a/apps/codecov-api/graphql_api/tests/test_owner.py
+++ b/apps/codecov-api/graphql_api/tests/test_owner.py
@@ -305,6 +305,51 @@ class TestOwnerType(GraphQLTestHelper, TestCase):
         data = self.gql_request(query, owner=user)
         assert data["owner"]["isCurrentUserPartOfOrg"] is True
 
+    def test_is_only_using_sentry_app_true(self):
+        owner = OwnerFactory(username="sentry-only-user", service="github")
+        GithubAppInstallationFactory(owner=owner, app_id=12637)
+        query = """
+            query ($username: String!) {
+                owner(username: $username) {
+                    isOnlyUsingSentryApp
+                }
+            }
+        """
+        data = self.gql_request(
+            query, owner=owner, variables={"username": owner.username}
+        )
+        assert data["owner"]["isOnlyUsingSentryApp"] is True
+
+    def test_is_only_using_sentry_app_false_when_has_other_app(self):
+        owner = OwnerFactory(username="multi-app-user", service="github")
+        GithubAppInstallationFactory(owner=owner, app_id=12637)
+        GithubAppInstallationFactory(owner=owner, app_id=9999)
+        query = """
+            query ($username: String!) {
+                owner(username: $username) {
+                    isOnlyUsingSentryApp
+                }
+            }
+        """
+        data = self.gql_request(
+            query, owner=owner, variables={"username": owner.username}
+        )
+        assert data["owner"]["isOnlyUsingSentryApp"] is False
+
+    def test_is_only_using_sentry_app_false_when_no_installations(self):
+        owner = OwnerFactory(username="no-app-user", service="github")
+        query = """
+            query ($username: String!) {
+                owner(username: $username) {
+                    isOnlyUsingSentryApp
+                }
+            }
+        """
+        data = self.gql_request(
+            query, owner=owner, variables={"username": owner.username}
+        )
+        assert data["owner"]["isOnlyUsingSentryApp"] is False
+
     def test_yaml_when_owner_not_have_yaml(self):
         org = OwnerFactory(username="no_yaml", yaml=None, service="github")
         self.owner.organizations = [org.ownerid]

--- a/apps/codecov-api/graphql_api/types/owner/owner.graphql
+++ b/apps/codecov-api/graphql_api/types/owner/owner.graphql
@@ -14,6 +14,7 @@ type Owner {
   isAdmin: Boolean
   isCurrentUserActivated: Boolean
   isCurrentUserPartOfOrg: Boolean!
+  isOnlyUsingSentryApp: Boolean!
   isGithubRateLimited: Boolean
   isUserOktaAuthenticated: Boolean
   measurements(

--- a/apps/codecov-api/graphql_api/types/owner/owner.py
+++ b/apps/codecov-api/graphql_api/types/owner/owner.py
@@ -41,6 +41,9 @@ from graphql_api.types.enums import OrderingDirection, RepositoryOrdering
 from graphql_api.types.errors.errors import NotFoundError
 from graphql_api.types.repository.repository import TOKEN_UNAVAILABLE
 from services.billing import BillingService
+from shared.django_apps.codecov_auth.sentry_app_deprecation import (
+    is_owner_only_using_sentry_app,
+)
 from shared.helpers.redis import get_redis_connection
 from shared.plan.constants import DEFAULT_FREE_PLAN
 from shared.plan.service import PlanService
@@ -236,6 +239,13 @@ def resolve_is_current_user_an_admin(owner: Owner, info: GraphQLResolveInfo) -> 
     current_owner = info.context["request"].current_owner
     command = info.context["executor"].get_command("owner")
     return command.get_is_current_user_an_admin(owner, current_owner)
+
+
+@owner_bindable.field("isOnlyUsingSentryApp")
+async def resolve_is_only_using_sentry_app(
+    owner: Owner, info: GraphQLResolveInfo
+) -> bool:
+    return await sync_to_async(is_owner_only_using_sentry_app)(owner.ownerid)
 
 
 @owner_bindable.field("hashOwnerid")

--- a/apps/worker/services/notification/notifiers/comment/__init__.py
+++ b/apps/worker/services/notification/notifiers/comment/__init__.py
@@ -25,6 +25,10 @@ from services.notification.notifiers.comment.conditions import (
 )
 from services.notification.notifiers.mixins.message import MessageMixin
 from services.urls import append_tracking_params_to_urls, get_members_url, get_plan_url
+from shared.django_apps.codecov_auth.sentry_app_deprecation import (
+    SENTRY_APP_DEPRECATION_DATE,
+    is_owner_only_using_sentry_app,
+)
 from shared.metrics import Counter, inc_counter
 from shared.plan.constants import PlanName
 from shared.torngit.exceptions import (
@@ -315,9 +319,22 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
         }
 
     def is_enabled(self) -> bool:
+        if is_owner_only_using_sentry_app(self.repository.ownerid):
+            return True
         return bool(self.notifier_yaml_settings) and isinstance(
             self.notifier_yaml_settings, dict
         )
+
+    SENTRY_APP_DEPRECATION_NOTICE = (
+        "> [!CAUTION]\n"
+        "> This repository is currently using the Sentry GitHub App to receive Codecov PR comments. "
+        f"This integration will be deprecated on {SENTRY_APP_DEPRECATION_DATE}. "
+        "Please [install the Codecov GitHub App](https://github.com/apps/codecov/installations/select_target) "
+        "to continue receiving coverage reports on your pull requests."
+    )
+
+    def is_only_using_sentry_app(self, comparison: ComparisonProxy) -> bool:
+        return is_owner_only_using_sentry_app(self.repository.ownerid)
 
     def build_message(
         self,
@@ -335,12 +352,19 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
         if comparison.pull.is_first_coverage_pull:
             return self._create_welcome_message()
         pull_dict = comparison.enriched_pull.provider_pull
-        return self.create_message(
+        message = self.create_message(
             comparison,
             pull_dict,
             self.notifier_yaml_settings,
             status_or_checks_helper_text=status_or_checks_helper_text,
         )
+        if self.is_only_using_sentry_app(comparison):
+            for i, line in enumerate(message):
+                if line.startswith("## [Codecov]"):
+                    message.insert(i + 1, "")
+                    message.insert(i + 2, self.SENTRY_APP_DEPRECATION_NOTICE)
+                    break
+        return message
 
     def should_see_project_coverage_cta(self):
         """

--- a/apps/worker/services/notification/notifiers/tests/unit/test_comment.py
+++ b/apps/worker/services/notification/notifiers/tests/unit/test_comment.py
@@ -35,6 +35,12 @@ from services.notification.notifiers.mixins.message.sections import (
 from services.notification.notifiers.tests.conftest import generate_sample_comparison
 from services.repository import EnrichedPull
 from services.yaml.reader import get_components_from_yaml
+from shared.django_apps.codecov_auth.tests.factories import (
+    GithubAppInstallationFactory as DjangoGithubAppInstallationFactory,
+)
+from shared.django_apps.codecov_auth.tests.factories import (
+    OwnerFactory as DjangoOwnerFactory,
+)
 from shared.plan.constants import DEFAULT_FREE_PLAN, PlanName
 from shared.reports.readonly import ReadOnlyReport
 from shared.reports.resources import Report, ReportFile
@@ -420,6 +426,131 @@ class TestCommentNotifierHelpers:
         base_title, base_totals, head_title, head_totals, expected_result = case
         diff = diff_to_string({}, base_title, base_totals, head_title, head_totals)
         assert diff == expected_result
+
+
+class TestIsOnlyUsingSentryApp:
+    SENTRY_APP_ID = 12637
+
+    def _make_notifier(self, owner_id, mocker):
+        repository = mocker.MagicMock(ownerid=owner_id)
+        return CommentNotifier(
+            repository=repository,
+            title="some_title",
+            notifier_yaml_settings={"layout": "reach, diff, flags, files, footer"},
+            notifier_site_settings=None,
+            current_yaml={},
+            repository_service=None,
+        )
+
+    @pytest.mark.django_db
+    def test_only_sentry_app_returns_true(self, mocker):
+        owner = DjangoOwnerFactory.create()
+        DjangoGithubAppInstallationFactory(owner=owner, app_id=self.SENTRY_APP_ID)
+        notifier = self._make_notifier(owner.ownerid, mocker)
+        assert notifier.is_only_using_sentry_app(mocker.MagicMock()) is True
+
+    @pytest.mark.django_db
+    def test_sentry_app_plus_another_returns_false(self, mocker):
+        owner = DjangoOwnerFactory.create()
+        DjangoGithubAppInstallationFactory(owner=owner, app_id=self.SENTRY_APP_ID)
+        DjangoGithubAppInstallationFactory(owner=owner, app_id=9999)
+        notifier = self._make_notifier(owner.ownerid, mocker)
+        assert notifier.is_only_using_sentry_app(mocker.MagicMock()) is False
+
+    @pytest.mark.django_db
+    def test_no_installations_returns_false(self, mocker):
+        owner = DjangoOwnerFactory.create()
+        notifier = self._make_notifier(owner.ownerid, mocker)
+        assert notifier.is_only_using_sentry_app(mocker.MagicMock()) is False
+
+    @pytest.mark.django_db
+    def test_only_other_app_returns_false(self, mocker):
+        owner = DjangoOwnerFactory.create()
+        DjangoGithubAppInstallationFactory(owner=owner, app_id=9999)
+        notifier = self._make_notifier(owner.ownerid, mocker)
+        assert notifier.is_only_using_sentry_app(mocker.MagicMock()) is False
+
+
+class TestIsEnabledSentryOverride:
+    @pytest.mark.django_db
+    def test_is_enabled_true_when_sentry_only_even_if_yaml_disabled(self, mocker):
+        owner = DjangoOwnerFactory.create()
+        DjangoGithubAppInstallationFactory(owner=owner, app_id=12637)
+        repository = mocker.MagicMock(ownerid=owner.ownerid)
+        notifier = CommentNotifier(
+            repository=repository,
+            title="title",
+            notifier_yaml_settings=False,  # comments disabled in YAML
+            notifier_site_settings=None,
+            current_yaml={},
+            repository_service=None,
+        )
+        assert notifier.is_enabled() is True
+
+    @pytest.mark.django_db
+    def test_is_enabled_respects_yaml_when_not_sentry_only(self, mocker):
+        owner = DjangoOwnerFactory.create()
+        repository = mocker.MagicMock(ownerid=owner.ownerid)
+        notifier = CommentNotifier(
+            repository=repository,
+            title="title",
+            notifier_yaml_settings=False,
+            notifier_site_settings=None,
+            current_yaml={},
+            repository_service=None,
+        )
+        assert notifier.is_enabled() is False
+
+
+class TestBuildMessageSentryDeprecationNotice:
+    def _make_notifier(self, repository):
+        return CommentNotifier(
+            repository=repository,
+            title="title",
+            notifier_yaml_settings={"layout": "reach, diff, flags, files, footer"},
+            notifier_site_settings=True,
+            current_yaml={},
+            repository_service=None,
+        )
+
+    @pytest.mark.django_db
+    def test_notice_inserted_after_header_when_sentry_only(self, dbsession, mocker):
+        repository = RepositoryFactory.create()
+        dbsession.add(repository)
+        dbsession.flush()
+        notifier = self._make_notifier(repository)
+        fake_message = ["## [Codecov](http://example.com) Report", "", "some content"]
+        mocker.patch.object(notifier, "create_message", return_value=fake_message)
+        mocker.patch.object(notifier, "is_only_using_sentry_app", return_value=True)
+        comparison = mocker.MagicMock()
+        comparison.pull.is_first_coverage_pull = False
+        comparison.enriched_pull.provider_pull = {}
+
+        result = notifier.build_message(comparison)
+
+        header_idx = next(
+            i for i, line in enumerate(result) if line.startswith("## [Codecov]")
+        )
+        assert result[header_idx + 1] == ""
+        assert CommentNotifier.SENTRY_APP_DEPRECATION_NOTICE in result[header_idx + 2]
+
+    @pytest.mark.django_db
+    def test_notice_not_inserted_when_not_sentry_only(self, dbsession, mocker):
+        repository = RepositoryFactory.create()
+        dbsession.add(repository)
+        dbsession.flush()
+        notifier = self._make_notifier(repository)
+        fake_message = ["## [Codecov](http://example.com) Report", "", "some content"]
+        mocker.patch.object(notifier, "create_message", return_value=fake_message)
+        mocker.patch.object(notifier, "is_only_using_sentry_app", return_value=False)
+        comparison = mocker.MagicMock()
+        comparison.pull.is_first_coverage_pull = False
+        comparison.enriched_pull.provider_pull = {}
+
+        result = notifier.build_message(comparison)
+
+        assert result == fake_message
+        assert CommentNotifier.SENTRY_APP_DEPRECATION_NOTICE not in result
 
 
 @pytest.mark.usefixtures("is_not_first_pull")

--- a/libs/shared/shared/django_apps/codecov_auth/sentry_app_deprecation.py
+++ b/libs/shared/shared/django_apps/codecov_auth/sentry_app_deprecation.py
@@ -11,10 +11,7 @@ from shared.django_apps.codecov_auth.models import GithubAppInstallation
 # Sentry's GitHub app, which Codecov historically used for PR notifications
 SENTRY_APP_ID = 12637
 
-# TODO(before merge): 30 days after the ~June 12 trigger/announcement date.
-# Both the trigger date and this value are still moving ("currently" June 12),
-# so confirm the final date with the comms/timeline owner before merge.
-SENTRY_APP_DEPRECATION_DATE = "July 12, 2026"
+SENTRY_APP_DEPRECATION_DATE = "July 8, 2026"
 
 
 def is_owner_only_using_sentry_app(owner_id: int) -> bool:

--- a/libs/shared/shared/django_apps/codecov_auth/sentry_app_deprecation.py
+++ b/libs/shared/shared/django_apps/codecov_auth/sentry_app_deprecation.py
@@ -1,0 +1,25 @@
+"""Transitional helpers for the Sentry GitHub App deprecation.
+
+TEMPORARY — delete this entire module at the deprecation cleanup (~2026-07-20).
+It exists only to detect owners whose sole GitHub app installation is the legacy
+Sentry app, so we can show them a one-time migration notice. Once the deprecation
+window closes and the messaging is removed, nothing should import from here.
+"""
+
+from shared.django_apps.codecov_auth.models import GithubAppInstallation
+
+# Sentry's GitHub app, which Codecov historically used for PR notifications
+SENTRY_APP_ID = 12637
+
+# TODO(before merge): 30 days after the ~June 12 trigger/announcement date.
+# Both the trigger date and this value are still moving ("currently" June 12),
+# so confirm the final date with the comms/timeline owner before merge.
+SENTRY_APP_DEPRECATION_DATE = "July 12, 2026"
+
+
+def is_owner_only_using_sentry_app(owner_id: int) -> bool:
+    installations = GithubAppInstallation.objects.filter(owner_id=owner_id)
+    count = installations.count()
+    if count != 1:
+        return False
+    return installations.filter(app_id=SENTRY_APP_ID).exists()


### PR DESCRIPTION
## What this does
Adds a deprecation notice for owners who **only** use the legacy Sentry GitHub App:
- **PR comments** (worker): injects a one-time "switch to the Codecov GitHub App" notice into the comment for affected owners.
- **GraphQL** (api): adds `Owner.isOnlyUsingSentryApp` so the frontend can surface the same signal.

Detection lives in `is_owner_only_using_sentry_app(owner_id)` — true when the owner's only GitHub app installation is the Sentry app (`app_id 12637`).

## Transitional — built to be deleted
This is throwaway deprecation scaffolding, scheduled for removal at the ~2026-07-08 cleanup. To make that deletion trivial and safe, the logic + constants live in one dedicated module, `codecov_auth/sentry_app_deprecation.py` (top-level model import — no circular-import workaround, no `# noqa`). Cleanup = `git rm` that file, drop the GraphQL field, and remove the comment-notice call site.

## Notes
**`is_enabled()` behavior/perf.** Force-enables the comment notifier for Sentry-app-only owners (even if comments are disabled) and runs a DB query per comment notification for all owners. Intentional for reach.

## Tests
`test_owner.py` (74) and `test_comment.py` (126) pass locally; pre-commit clean.