### PR TITLE
feat: improve django admin owner and repository pages

### DIFF
--- a/apps/codecov-api/codecov_auth/admin.py
+++ b/apps/codecov-api/codecov_auth/admin.py
@@ -6,7 +6,7 @@ import django.forms as forms
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.models import LogEntry
-from django.db.models import OuterRef, Subquery
+from django.db.models import Count, OuterRef, Subquery
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms import CheckboxInput, Select, Textarea
 from django.http import HttpRequest
@@ -674,7 +674,7 @@ class AccountAdmin(AdminMixin, admin.ModelAdmin):
 @admin.register(Owner)
 class OwnerAdmin(AdminMixin, admin.ModelAdmin):
     exclude = ("oauth_token",)
-    list_display = ("name", "username", "email", "service")
+    list_display = ("username", "name", "repository_count", "email", "service")
     readonly_fields = []
     search_fields = ("name__iregex", "username__iregex", "email__iregex", "ownerid")
     actions = [impersonate_owner, extend_trial, refresh_owner, export_owner_data]
@@ -784,6 +784,17 @@ class OwnerAdmin(AdminMixin, admin.ModelAdmin):
             },
         ),
     ]
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .annotate(repository_count=Count("repository", distinct=True))
+        )
+
+    @admin.display(description="repositories", ordering="repository_count")
+    def repository_count(self, obj):
+        return obj.repository_count
 
     def get_form(self, request, obj=None, change=False, **kwargs):
         form = super().get_form(request, obj, change, **kwargs)

--- a/apps/codecov-api/core/admin.py
+++ b/apps/codecov-api/core/admin.py
@@ -175,7 +175,9 @@ class RepositoryAdmin(AdminMixin, admin.ModelAdmin):
         if author is None:
             return "-"
         url = reverse("admin:codecov_auth_owner_change", args=[author.ownerid])
-        return format_html('<a href="{}">{}</a>', url, str(author))
+        return format_html(
+            '<a href="{}">{}/{}</a>', url, author.service, author.username
+        )
 
     def get_search_results(
         self,

--- a/apps/codecov-api/core/admin.py
+++ b/apps/codecov-api/core/admin.py
@@ -134,7 +134,7 @@ class RepositoryAdminForm(forms.ModelForm):
 @admin.register(Repository)
 class RepositoryAdmin(AdminMixin, admin.ModelAdmin):
     inlines = [RepositoryTokenInline]
-    list_display = ("name", "service_id", "author")
+    list_display = ("name", "service_id", "author_link")
     search_fields = (
         "name",
         "author__username__exact",
@@ -168,6 +168,14 @@ class RepositoryAdmin(AdminMixin, admin.ModelAdmin):
         "private",
         "webhook_secret",
     )
+
+    @admin.display(description="author", ordering="author")
+    def author_link(self, obj):
+        author = obj.author
+        if author is None:
+            return "-"
+        url = reverse("admin:codecov_auth_owner_change", args=[author.ownerid])
+        return format_html('<a href="{}">{}</a>', url, str(author))
 
     def get_search_results(
         self,

--- a/libs/shared/shared/django_apps/codecov_auth/models.py
+++ b/libs/shared/shared/django_apps/codecov_auth/models.py
@@ -409,7 +409,7 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
     repository_set = RepositoryManager()
 
     def __str__(self):
-        return f"Owner<{self.service}/{self.username}>"
+        return f"{self.service}/{self.username}"
 
     def save(self, *args, **kwargs):
         self.updatestamp = timezone.now()


### PR DESCRIPTION
Link the repository's author to the owner change page, show the repository count on the owner list view, and reorder the owner list to lead with username before name.

<img width="1310" height="293" alt="image" src="https://github.com/user-attachments/assets/8f06330c-7d8b-48cc-8871-917ba4d35c6c" />
<img width="1043" height="355" alt="image" src="https://github.com/user-attachments/assets/b676f4fd-cf14-4e3a-807d-6fb56ffb7f6a" />


<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
