### PR TITLE
feat: Change django admin sentry actions auth check to harness

### DIFF
--- a/libs/shared/shared/django_apps/codecov_auth/models.py
+++ b/libs/shared/shared/django_apps/codecov_auth/models.py
@@ -585,9 +585,9 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
     def clean(self):
         if self.staff:
             domain = self.email.split("@")[1] if self.email else ""
-            if domain not in ["codecov.io", "sentry.io"]:
+            if domain not in ["codecov.io", "harness.io"]:
                 raise ValidationError(
-                    "User not part of Codecov or Sentry cannot be a staff member"
+                    "User not part of Codecov or Harness cannot be a staff member"
                 )
         if not self.plan:
             self.plan = None


### PR DESCRIPTION
On stage django admin, allow accounts with harness.io as the primary address to make changes while removing access for sentry.io email accounts.