### PR TITLE
fix(notify): send checks on GitHub merge queue branches with only_pulls

### DIFF
--- a/apps/worker/services/notification/notifiers/status/base.py
+++ b/apps/worker/services/notification/notifiers/status/base.py
@@ -20,13 +20,7 @@ from shared.torngit.exceptions import TorngitClientError, TorngitError
 log = logging.getLogger(__name__)
 
 # Matches GitHub merge queue branch names: gh-readonly-queue/<base-branch>/pr-<number>-<sha>
-_MERGE_QUEUE_RE = re.compile(r"^gh-readonly-queue/(.+)/pr-\d+-[0-9a-f]+$")
-
-
-def _merge_queue_base_branch(branch: str) -> str | None:
-    """Return the target base branch for a GitHub merge queue branch, or None."""
-    m = _MERGE_QUEUE_RE.match(branch)
-    return m.group(1) if m else None
+_MERGE_QUEUE_RE = re.compile(r"^gh-readonly-queue/.+/pr-\d+-[0-9a-f]+$")
 
 
 class StatusNotifier(AbstractBaseNotifier):
@@ -57,14 +51,13 @@ class StatusNotifier(AbstractBaseNotifier):
     def can_we_set_this_status(self, comparison: ComparisonProxy) -> bool:
         head = comparison.head.commit
         pull = comparison.pull
-        merge_queue_base = _merge_queue_base_branch(head.branch or "")
         if (
             (
                 self.notifier_yaml_settings.get("only_pulls")
                 or self.notifier_yaml_settings.get("base") == "pr"
             )
             and not pull
-            and not merge_queue_base
+            and not _MERGE_QUEUE_RE.match(head.branch or "")
         ):
             return False
         if not match(self.notifier_yaml_settings.get("branches"), head.branch):

--- a/apps/worker/services/notification/notifiers/status/base.py
+++ b/apps/worker/services/notification/notifiers/status/base.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import sentry_sdk
 from asgiref.sync import async_to_sync
@@ -17,6 +18,15 @@ from shared.helpers.cache import NO_VALUE, cache, make_hash_sha256
 from shared.torngit.exceptions import TorngitClientError, TorngitError
 
 log = logging.getLogger(__name__)
+
+# Matches GitHub merge queue branch names: gh-readonly-queue/<base-branch>/pr-<number>-<sha>
+_MERGE_QUEUE_RE = re.compile(r"^gh-readonly-queue/(.+)/pr-\d+-[0-9a-f]+$")
+
+
+def _merge_queue_base_branch(branch: str) -> str | None:
+    """Return the target base branch for a GitHub merge queue branch, or None."""
+    m = _MERGE_QUEUE_RE.match(branch)
+    return m.group(1) if m else None
 
 
 class StatusNotifier(AbstractBaseNotifier):
@@ -47,10 +57,15 @@ class StatusNotifier(AbstractBaseNotifier):
     def can_we_set_this_status(self, comparison: ComparisonProxy) -> bool:
         head = comparison.head.commit
         pull = comparison.pull
+        merge_queue_base = _merge_queue_base_branch(head.branch or "")
         if (
-            self.notifier_yaml_settings.get("only_pulls")
-            or self.notifier_yaml_settings.get("base") == "pr"
-        ) and not pull:
+            (
+                self.notifier_yaml_settings.get("only_pulls")
+                or self.notifier_yaml_settings.get("base") == "pr"
+            )
+            and not pull
+            and not merge_queue_base
+        ):
             return False
         if not match(self.notifier_yaml_settings.get("branches"), head.branch):
             return False

--- a/apps/worker/services/notification/notifiers/tests/unit/test_status.py
+++ b/apps/worker/services/notification/notifiers/tests/unit/test_status.py
@@ -379,6 +379,62 @@ class TestBaseStatusNotifier:
         )
         assert not exclude_branch_notifier.can_we_set_this_status(comparison)
 
+    def test_can_we_set_this_status_merge_queue(self, sample_comparison_without_pull):
+        comparison = sample_comparison_without_pull
+        # Put the head commit on a GitHub merge queue branch targeting "new_branch"
+        comparison.head.commit.branch = "gh-readonly-queue/new_branch/pr-42-abc1234f"
+
+        # only_pulls: true should not block merge queue commits
+        only_pulls_notifier = StatusNotifier(
+            repository=comparison.head.commit.repository,
+            title="title",
+            notifier_yaml_settings={"only_pulls": True},
+            notifier_site_settings=True,
+            current_yaml=UserYaml({}),
+            repository_service={},
+        )
+        assert only_pulls_notifier.can_we_set_this_status(comparison)
+
+        # branches filter is matched against the raw branch name, not the extracted base;
+        # "new_branch" does not match "gh-readonly-queue/new_branch/pr-42-abc1234f"
+        raw_branch_filter_notifier = StatusNotifier(
+            repository=comparison.head.commit.repository,
+            title="title",
+            notifier_yaml_settings={"only_pulls": True, "branches": ["new_branch"]},
+            notifier_site_settings=True,
+            current_yaml=UserYaml({}),
+            repository_service={},
+        )
+        assert not raw_branch_filter_notifier.can_we_set_this_status(comparison)
+
+        # a branches filter that explicitly matches the full merge queue branch name passes
+        mq_branch_filter_notifier = StatusNotifier(
+            repository=comparison.head.commit.repository,
+            title="title",
+            notifier_yaml_settings={
+                "only_pulls": True,
+                "branches": ["gh-readonly-queue/new_branch.*"],
+            },
+            notifier_site_settings=True,
+            current_yaml=UserYaml({}),
+            repository_service={},
+        )
+        assert mq_branch_filter_notifier.can_we_set_this_status(comparison)
+
+        # negative pattern on the raw merge queue branch name is honored
+        exclude_mq_notifier = StatusNotifier(
+            repository=comparison.head.commit.repository,
+            title="title",
+            notifier_yaml_settings={
+                "only_pulls": True,
+                "branches": ["!gh-readonly-queue.*"],
+            },
+            notifier_site_settings=True,
+            current_yaml=UserYaml({}),
+            repository_service={},
+        )
+        assert not exclude_mq_notifier.can_we_set_this_status(comparison)
+
     def test_notify_after_n_builds_flags(self, sample_comparison, mocker):
         comparison = sample_comparison
         no_settings_notifier = StatusNotifier(


### PR DESCRIPTION
## Summary

GitHub merge queue commits run on `gh-readonly-queue/<base-branch>/pr-N-<sha>` branches and have no associated PR (GitHub's `/commits/{sha}/pulls` API returns nothing for these refs). When a repo configures `only_pulls: true` or `base: pr`, `can_we_set_this_status` blocked the commit with `not_fit_criteria` — silently skipping all notifications and leaving the merge queue unable to unblock.

**Fix:** detect merge queue branches in `can_we_set_this_status` and exempt them from the `only_pulls` / `base: pr` guard, treating them as PR-equivalent. The `branches` filter continues to match against the raw branch name unchanged — customers who want to explicitly include or exclude merge queue commits from their filter should use `gh-readonly-queue/<base>.*` patterns.

## Changes

- `apps/worker/services/notification/notifiers/status/base.py` — add `_merge_queue_base_branch()` helper + update `can_we_set_this_status`
- `apps/worker/services/notification/notifiers/tests/unit/test_status.py` — 4 new cases: `only_pulls` bypass, raw-branch filter blocks merge queue branch, explicit `gh-readonly-queue/…` filter passes, negative `!gh-readonly-queue.*` filter is honored

## Test plan

- [x] New test `test_can_we_set_this_status_merge_queue` covers all four cases — passes locally
- [x] Existing `test_can_we_set_this_status_no_pull` still passes (no regression to normal `only_pulls` behavior)
- [x] Full `TestBaseStatusNotifier` class: 22/22 green
- [ ] Verify by re-triggering a merge queue run after deploy

## Notes

- `only_pulls: true` with merge queues is not documented on docs.codecov.com — follow-up doc update warranted
- The `or ()` dead code on `checks/base.py:98` (`if comparison.pull is None or ():`) is unrelated; worth a separate cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)