### PR TITLE
feat(graphql): add hasLinkedSentryLogin to Me type

### DIFF
--- a/apps/codecov-api/graphql_api/types/me/me.graphql
+++ b/apps/codecov-api/graphql_api/types/me/me.graphql
@@ -34,12 +34,12 @@ type Me {
     before: String
   ): MyOrganizationConnection!
     @cost(complexity: 15, multipliers: ["first", "last"])
-  isSyncingWithGitProvider: Boolean!
-  trackingMetadata: trackingMetadata! # temporary solution to expose the user metadata
-  privateAccess: Boolean
-  termsAgreement: Boolean
-  supportPin: String
   hasLinkedSentryLogin: Boolean!
+  isSyncingWithGitProvider: Boolean!
+  privateAccess: Boolean
+  supportPin: String
+  termsAgreement: Boolean
+  trackingMetadata: trackingMetadata! # temporary solution to expose the user metadata
 }
 
 # Temporary type to gather the different attributes for tracking until we have

--- a/apps/codecov-api/graphql_api/types/me/me.graphql
+++ b/apps/codecov-api/graphql_api/types/me/me.graphql
@@ -39,6 +39,7 @@ type Me {
   privateAccess: Boolean
   termsAgreement: Boolean
   supportPin: String
+  hasLinkedSentryLogin: Boolean!
 }
 
 # Temporary type to gather the different attributes for tracking until we have

--- a/apps/codecov-api/graphql_api/types/me/me.py
+++ b/apps/codecov-api/graphql_api/types/me/me.py
@@ -4,6 +4,7 @@ from asgiref.sync import sync_to_async
 from graphql import GraphQLResolveInfo
 
 from codecov_auth.models import Owner, OwnerProfile
+from services.sentry import is_sentry_user
 from codecov_auth.views.okta_cloud import OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY
 from graphql_api.actions.owner import (
     get_owner_login_sessions,
@@ -128,6 +129,11 @@ def resolve_business_email(current_owner: Owner, _, **kwargs) -> str | None:
 @me_bindable.field("supportPin")
 def resolve_support_pin(current_owner: Owner, _, **kwargs) -> str | None:
     return current_owner.support_pin
+
+
+@me_bindable.field("hasLinkedSentryLogin")
+def resolve_has_linked_sentry_login(owner: Owner, _, **kwargs) -> bool:
+    return is_sentry_user(owner)
 
 
 @me_bindable.field("privateAccess")

--- a/apps/codecov-api/graphql_api/types/me/me.py
+++ b/apps/codecov-api/graphql_api/types/me/me.py
@@ -4,7 +4,6 @@ from asgiref.sync import sync_to_async
 from graphql import GraphQLResolveInfo
 
 from codecov_auth.models import Owner, OwnerProfile
-from services.sentry import is_sentry_user
 from codecov_auth.views.okta_cloud import OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY
 from graphql_api.actions.owner import (
     get_owner_login_sessions,
@@ -132,8 +131,11 @@ def resolve_support_pin(current_owner: Owner, _, **kwargs) -> str | None:
 
 
 @me_bindable.field("hasLinkedSentryLogin")
+@sync_to_async
 def resolve_has_linked_sentry_login(owner: Owner, _, **kwargs) -> bool:
-    return is_sentry_user(owner)
+    if owner.user_id is None:
+        return False
+    return owner.user.sentry_user.exists()
 
 
 @me_bindable.field("privateAccess")


### PR DESCRIPTION
## Summary

- Adds `hasLinkedSentryLogin: Boolean!` to the `Me` GraphQL type
- Resolver checks `owner.user.sentry_user.exists()` — confirms the `SentryUser` row actually exists rather than trusting the denormalized `sentry_user_id` text field on `Owner`
- Needed so Gazebo can show a deprecation notice to users who log in via Sentry (deprecation date: July 8, 2026)

## For Calvin

This is the backend half. Gazebo needs to query `me { hasLinkedSentryLogin }` and show a deprecation banner when it's `true` — pointing users to reconnect via GitHub/GitLab/Bitbucket before July 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)